### PR TITLE
Make the links in the conversion gallery work again

### DIFF
--- a/docs/conversion_examples_gallery/imaging/hdf5imaging.rst
+++ b/docs/conversion_examples_gallery/imaging/hdf5imaging.rst
@@ -1,7 +1,7 @@
 HDF5 data conversion
 ^^^^^^^^^^^^^^^^^^^
 
-Convert HDF5 imaging data to NWB using :py:class:`~nwb_conversion_tools.datainterfaces.ophys.hdf5.hdf5datainterface.Hdf5ImagingInterface`.
+Convert HDF5 imaging data to NWB using :py:class:`~neuroconv.datainterfaces.ophys.hdf5.hdf5datainterface.Hdf5ImagingInterface`.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/imaging/scanbox.rst
+++ b/docs/conversion_examples_gallery/imaging/scanbox.rst
@@ -1,7 +1,7 @@
 Scanbox data conversion
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Convert Scanbox imaging data to NWB using :py:class:`~nwb_conversion_tools.datainterfaces.ophys.sbx.sbxdatainterface.SbxImagingInterface`.
+Convert Scanbox imaging data to NWB using :py:class:`~neuroconv.datainterfaces.ophys.sbx.sbxdatainterface.SbxImagingInterface`.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/imaging/scanimage.rst
+++ b/docs/conversion_examples_gallery/imaging/scanimage.rst
@@ -1,7 +1,7 @@
 ScanImage data conversion
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Convert ScanImage imaging data to NWB using :py:class:`~nwb_conversion_tools.datainterfaces.ophys.scanimage.scanimageimaginginterface.ScanImageImagingInterface`.
+Convert ScanImage imaging data to NWB using :py:class:`~neuroconv.datainterfaces.ophys.scanimage.scanimageimaginginterface.ScanImageImagingInterface`.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/imaging/tiff.rst
+++ b/docs/conversion_examples_gallery/imaging/tiff.rst
@@ -1,7 +1,7 @@
 Tif data conversion
 ^^^^^^^^^^^^^^^^^^^
 
-Convert Tiff imaging data to NWB using :py:class:`~nwb_conversion_tools.datainterfaces.ophys.tiff.tiffdatainterface.TiffImagingInterface`.
+Convert Tiff imaging data to NWB using :py:class:`~neuroconv.datainterfaces.ophys.tiff.tiffdatainterface.TiffImagingInterface`.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/recording/axona.rst
+++ b/docs/conversion_examples_gallery/recording/axona.rst
@@ -1,7 +1,7 @@
 Axona data converison
 ^^^^^^^^^^^^^^^^^^^^^
 
-Convert axona data to NWB using :py:class:`~nwb_conversion_tools.datainterfaces.ecephys.axona.axonadatainterface.AxonaRecordingExtractorInterface`.
+Convert axona data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.axona.axonadatainterface.AxonaRecordingExtractorInterface`.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/recording/blackrock.rst
+++ b/docs/conversion_examples_gallery/recording/blackrock.rst
@@ -1,7 +1,7 @@
 Blackrock data conversion
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Convert Blackrock data to NWB using :py:class:`~nwb_conversion_tools.datainterfaces.ecephys.blackrock.blackrockdatainterface.BlackrockRecordingExtractorInterface`.
+Convert Blackrock data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.blackrock.blackrockdatainterface.BlackrockRecordingExtractorInterface`.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/recording/intan.rst
+++ b/docs/conversion_examples_gallery/recording/intan.rst
@@ -1,6 +1,6 @@
 Intan data conversion
 ^^^^^^^^^^^^^^^^^^^^^
-Convert Intan data to NWB using :py:class:`~nwb_conversion_tools.datainterfaces.ecephys.intan.intandatainterface.IntanRecordingInterface`.
+Convert Intan data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.intan.intandatainterface.IntanRecordingInterface`.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/recording/neuralynx.rst
+++ b/docs/conversion_examples_gallery/recording/neuralynx.rst
@@ -1,7 +1,7 @@
 Neuralynx data conversion
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Convert Neuralynx data to NWB using :py:class:`~.nwb_conversion_tools.datainterfaces.ecephys.neuralynx.neuralynxdatainterface.NeuralynxRecordingInterface`.
+Convert Neuralynx data to NWB using :py:class:`~.neuroconv.datainterfaces.ecephys.neuralynx.neuralynxdatainterface.NeuralynxRecordingInterface`.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/recording/neuroscope.rst
+++ b/docs/conversion_examples_gallery/recording/neuroscope.rst
@@ -1,7 +1,7 @@
 Neuroscope data conversion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Convert Neuroscope data to NWB using :py:class:`~nwb_conversion_tools.datainterfaces.ecephys.neuroscope.neuroscopedatainterface.NeuroscopeRecordingInterface`.
+Convert Neuroscope data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.neuroscope.neuroscopedatainterface.NeuroscopeRecordingInterface`.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/recording/openephys.rst
+++ b/docs/conversion_examples_gallery/recording/openephys.rst
@@ -1,7 +1,7 @@
 Open Ephys data conversion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Convert OpenEphys data to NWB using :py:class:`~nwb_conversion_tools.datainterfaces.ecephys.openephys.openephysdatainterface.OpenEphysRecordingExtractorInterface`.
+Convert OpenEphys data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.openephys.openephysdatainterface.OpenEphysRecordingExtractorInterface`.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/recording/spikegadgets.rst
+++ b/docs/conversion_examples_gallery/recording/spikegadgets.rst
@@ -1,7 +1,7 @@
 Spikegadgets data conversion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Convert spikegadgets data to NWB using :py:class:`~nwb_conversion_tools.datainterfaces.ecephys.spikegadgets.spikegadgetsdatainterface.SpikeGadgetsRecordingInterface`.
+Convert spikegadgets data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.spikegadgets.spikegadgetsdatainterface.SpikeGadgetsRecordingInterface`.
 
 .. code-block:: python
     # TODO - re-enable '' lines when SI >0.94 is released

--- a/docs/conversion_examples_gallery/recording/spikeglx.rst
+++ b/docs/conversion_examples_gallery/recording/spikeglx.rst
@@ -1,7 +1,7 @@
 Spikeglx data converison
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Convert spikeglx data to NWB using :py:class:`~nwb_conversion_tools.datainterfaces.ecephys.spikeglx.spikeglxdatainterface.SpikeGLXRecordingInterface`.
+Convert spikeglx data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.spikeglx.spikeglxdatainterface.SpikeGLXRecordingInterface`.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/sorting/cellexplorer.rst
+++ b/docs/conversion_examples_gallery/sorting/cellexplorer.rst
@@ -1,7 +1,7 @@
 Cell Explorer data conversion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Convert cell explorer sorting data to NWB using :py:class:`~nwb_conversion_tools.datainterfaces.ecephys.cellexplorer.cellexplorerdatainterface.CellExplorerSortingInterface`.
+Convert cell explorer sorting data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.cellexplorer.cellexplorerdatainterface.CellExplorerSortingInterface`.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/sorting/kilosort.rst
+++ b/docs/conversion_examples_gallery/sorting/kilosort.rst
@@ -1,7 +1,7 @@
 Kilosort data conversion
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Convert Kilosort data to NWB using :py:class:`~nwb_conversion_tools.datainterfaces.ecephys.kilosort.kilosortdatainterface`.
+Convert Kilosort data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.kilosort.kilosortdatainterface`.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/sorting/neuroscope.rst
+++ b/docs/conversion_examples_gallery/sorting/neuroscope.rst
@@ -1,7 +1,7 @@
 Neuroscope sorting data conversion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Convert Neuroscope sorting data to NWB using :py:class:`~nwb_conversion_tools.datainterfaces.ecephys.neuroscope.neuroscopedatainterface.NeuroscopeSortingInterface`.
+Convert Neuroscope sorting data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.neuroscope.neuroscopedatainterface.NeuroscopeSortingInterface`.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/sorting/phy.rst
+++ b/docs/conversion_examples_gallery/sorting/phy.rst
@@ -1,7 +1,7 @@
 Phy sorting data conversion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Convert Phy data to NWB using :py:class:`~.nwb_conversion_tools.datainterfaces.ecephys.phy.phydatainterface.PhySortingInterface`.
+Convert Phy data to NWB using :py:class:`~.neuroconv.datainterfaces.ecephys.phy.phydatainterface.PhySortingInterface`.
 
 .. code-block:: python
 


### PR DESCRIPTION
The links stopped working after the most recent porting. This PR restores them.