### PR TITLE
Add nwb file context to `write_segmentation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
-# v0.1.1
+# Upcoming
 
+### Fixes
+
+### Improvements
+* Unified the `run_conversion` method of `BaseSegmentationExtractorInterface` with that of all the other base interfaces. The method `write_segmentation` now uses the common `make_or_load_nwbfile` context manager [PR #29](https://github.com/catalystneuro/neuroconv/pull/29)
+
+### Features
+
+### Testing
+
+# v0.1.1
 ### Fixes
 * Fixed the behavior of the `file_paths` usage in the MovieInterface when run via the YAML conversion specification. [PR #33](https://github.com/catalystneuro/neuroconv/pull/33)
 

--- a/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
@@ -1,5 +1,6 @@
-"""Authors: Cody Baker and Ben Dichter."""
+"""Authors: Heberto Mayorquin, Cody Baker and Ben Dichter."""
 from abc import ABC
+from typing import Optional
 
 from pynwb import NWBFile
 from pynwb.device import Device
@@ -10,6 +11,7 @@ from ...tools.roiextractors import write_segmentation, get_nwb_segmentation_meta
 from ...utils import (
     get_schema_from_hdmf_class,
     fill_defaults,
+    OptionalFilePathType,
     get_base_schema,
 )
 
@@ -57,5 +59,21 @@ class BaseSegmentationExtractorInterface(BaseDataInterface, ABC):
         _ = metadata.pop("NWBFile")
         return metadata
 
-    def run_conversion(self, nwbfile: NWBFile, metadata: dict, overwrite: bool = False):
-        write_segmentation(self.segmentation_extractor, nwbfile=nwbfile, metadata=metadata, overwrite=overwrite)
+    def run_conversion(
+        self,
+        nwbfile_path: OptionalFilePathType = None,
+        nwbfile: Optional[NWBFile] = None,
+        metadata: Optional[dict] = None,
+        overwrite: bool = False,
+        save_path: OptionalFilePathType = None,
+    ):
+
+        write_segmentation(
+            self.segmentation_extractor,
+            nwbfile_path=nwbfile_path,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            overwrite=overwrite,
+            verbose=self.verbose,
+            save_path=save_path,
+        )

--- a/src/neuroconv/datainterfaces/ophys/caiman/caimandatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/caiman/caimandatainterface.py
@@ -9,5 +9,6 @@ class CaimanSegmentationInterface(BaseSegmentationExtractorInterface):
 
     SegX = CaimanSegmentationExtractor
 
-    def __init__(self, file_path: FilePathType):
+    def __init__(self, file_path: FilePathType, verbose: bool = True):
         super().__init__(file_path=file_path)
+        self.verbose = verbose

--- a/src/neuroconv/datainterfaces/ophys/cnmfe/cnmfedatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/cnmfe/cnmfedatainterface.py
@@ -9,5 +9,7 @@ class CnmfeSegmentationInterface(BaseSegmentationExtractorInterface):
 
     SegX = CnmfeSegmentationExtractor
 
-    def __init__(self, file_path: FilePathType):
+    def __init__(self, file_path: FilePathType, verbose: bool = True):
+
         super().__init__(file_path=file_path)
+        self.verbose = verbose

--- a/src/neuroconv/datainterfaces/ophys/extract/extractdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/extract/extractdatainterface.py
@@ -9,5 +9,6 @@ class ExtractSegmentationInterface(BaseSegmentationExtractorInterface):
 
     SegX = ExtractSegmentationExtractor
 
-    def __init__(self, file_path: FilePathType):
+    def __init__(self, file_path: FilePathType, verbose: bool = True):
+        self.verbose = verbose
         super().__init__(file_path=file_path)

--- a/src/neuroconv/datainterfaces/ophys/suite2p/suite2pdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/suite2p/suite2pdatainterface.py
@@ -10,5 +10,8 @@ class Suite2pSegmentationInterface(BaseSegmentationExtractorInterface):
 
     SegX = Suite2pSegmentationExtractor
 
-    def __init__(self, folder_path: FolderPathType, combined: bool = False, plane_no: IntType = 0):
+    def __init__(
+        self, folder_path: FolderPathType, combined: bool = False, plane_no: IntType = 0, verbose: bool = True
+    ):
         super().__init__(folder_path=folder_path, combined=combined, plane_no=plane_no)
+        self.verbose = verbose

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -520,7 +520,7 @@ def write_segmentation(
             nwbfile_path = save_path
 
     with make_or_load_nwbfile(
-        nwbfile_path=nwbfile_path, nwbfile=nwbfile, metadata=metadata, overwrite=overwrite, verbose=verbose
+        nwbfile_path=nwbfile_path, nwbfile=nwbfile, metadata=metadata_base_common, overwrite=overwrite, verbose=verbose
     ) as nwbfile_out:
         # Processing Module:
         if "ophys" not in nwbfile_out.processing:
@@ -531,7 +531,7 @@ def write_segmentation(
         for plane_no_loop, (segext_obj, metadata) in enumerate(zip(segext_objs, metadata_base_list)):
 
             # Add device:
-            add_devices(nwbfile=nwbfile, metadata=metadata)
+            add_devices(nwbfile=nwbfile_out, metadata=metadata)
 
             # ImageSegmentation:
             image_segmentation_name = (
@@ -545,8 +545,8 @@ def write_segmentation(
 
             # Add imaging plane
             imaging_plane_name = "ImagingPlane" if plane_no_loop == 0 else f"ImagePlane_{plane_no_loop}"
-            add_imaging_plane(nwbfile=nwbfile, metadata=metadata)
-            imaging_plane = nwbfile.imaging_planes[imaging_plane_name]
+            add_imaging_plane(nwbfile=nwbfile_out, metadata=metadata)
+            imaging_plane = nwbfile_out.imaging_planes[imaging_plane_name]
 
             # PlaneSegmentation:
             input_kwargs = dict(


### PR DESCRIPTION
We changed most of the `run_conversion` methods of the base interfaces to have a common signature:
https://github.com/catalystneuro/nwb-conversion-tools/issues/511

Hoever, we left `BaseSegmentationExtractorInterface` and its main method `write_segmentation` without this change. This PR addresses that point. 

This PR is necessary to complete the conversion gallery for the segmentation interfaces with a common interface. 