### PR TITLE
Unittest for `add_electrical_series` I

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ### Improvements
 * Added function to add ImagingPlane objects to an nwbfile in `roiextractors` and corresponding unit tests. [PR #19](https://github.com/catalystneuro/neuroconv/pull/19)
+* Added unittests for the `write_as` functionality in the `add_electrical_series` of the spikeinterface module [PR #32](https://github.com/catalystneuro/neuroconv/pull/32)
 
+### Features
+Add non-iterative writing capabilities to `add_electrical_series` [PR #32](https://github.com/catalystneuro/neuroconv/pull/32)
 
 # v0.1.0
 

--- a/src/neuroconv/tools/spikeinterface/__init__.py
+++ b/src/neuroconv/tools/spikeinterface/__init__.py
@@ -3,6 +3,7 @@ from .spikeinterface import (
     add_devices,
     add_electrode_groups,
     add_electrodes,
+    check_if_recording_traces_fit_into_memory,
     add_electrical_series,
     add_epochs,
     write_recording,

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -877,7 +877,7 @@ def write_recording(
     write_scaled: bool = False,
     compression: Optional[str] = None,
     compression_opts: Optional[int] = None,
-    iterator_type: Optional[str] = None,
+    iterator_type: Optional[str] = "v2",
     iterator_opts: Optional[dict] = None,
     save_path: OptionalFilePathType = None,  # TODO: to be removed
 ):


### PR DESCRIPTION
As discussed, I am adding multi segment support to the `write_recording` function. To pin current behavior and increase unittest coverage I am adding the first batch of tests to `add_electrical_series` in `test_si`. The test here are concerned with default arguments and writing the recording to the correct place (e.g. acquisition vs processing). To test the data I also added the option of  writing the data with no iterator but keep the default behavior identical for backward compatibility (it uses "V2").