### PR TITLE
[Bug]: Fix file_paths wrapping for YAML specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Upcoming
 
+### Fixes
+* Fixed the behavior of the `file_paths` usage in the MovieInterface when run via the YAML conversion specification. [PR #33](https://github.com/catalystneuro/neuroconv/pull/33)
+
 ### Improvements
 * Added function to add ImagingPlane objects to an nwbfile in `roiextractors` and corresponding unit tests. [PR #19](https://github.com/catalystneuro/neuroconv/pull/19)
 

--- a/src/neuroconv/tools/yaml_conversion_specification/yaml_conversion_specification.py
+++ b/src/neuroconv/tools/yaml_conversion_specification/yaml_conversion_specification.py
@@ -138,7 +138,10 @@ def run_conversion_from_yaml(
             source_data = session["source_data"]
             for interface_name, interface_source_data in session["source_data"].items():
                 for key, value in interface_source_data.items():
-                    source_data[interface_name].update({key: str(Path(data_folder_path) / value)})
+                    if key == "file_paths":
+                        source_data[interface_name].update({key: [str(Path(data_folder_path) / x) for x in value]})
+                    else:
+                        source_data[interface_name].update({key: str(Path(data_folder_path) / value)})
             converter = CustomNWBConverter(source_data=source_data)
             metadata = converter.get_metadata()
             for metadata_source in [global_metadata, experiment_metadata, session.get("metadata", dict())]:

--- a/tests/test_on_data/conversion_specifications/GIN_conversion_specification_movies.yml
+++ b/tests/test_on_data/conversion_specifications/GIN_conversion_specification_movies.yml
@@ -1,0 +1,24 @@
+metadata:
+  NWBFile:
+    lab: My Lab
+    institution: My Institution
+data_interfaces:
+  - MovieInterface
+
+experiments:
+  ymaze:
+    metadata:
+      NWBFile:
+        session_description: Subject navigating a Y-shaped maze.
+
+    sessions:
+      - nwbfile_name: example_converter_spec_1
+        source_data:
+          MovieInterface:
+            file_paths:
+              - videos/CFR/video_mp4.mp4
+        metadata:
+          NWBFile:
+            session_start_time: "2020-10-09T21:19:09+00:00"
+          Subject:
+            subject_id: "1"

--- a/tests/test_on_data/test_yaml_conversion_specification.py
+++ b/tests/test_on_data/test_yaml_conversion_specification.py
@@ -131,7 +131,7 @@ class TestYAMLConversionSpecification(TestCase):
             output_folder_path=self.test_folder,
             overwrite=True,
         )
-            
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_on_data/test_yaml_conversion_specification.py
+++ b/tests/test_on_data/test_yaml_conversion_specification.py
@@ -11,7 +11,7 @@ from neuroconv import run_conversion_from_yaml
 from neuroconv.utils import load_dict_from_file
 
 from .setup_paths import ECEPHY_DATA_PATH as DATA_PATH
-from .setup_paths import OUTPUT_PATH
+from .setup_paths import OUTPUT_PATH, BEHAVIOR_DATA_PATH
 
 
 class TestYAMLConversionSpecification(TestCase):
@@ -122,6 +122,16 @@ class TestYAMLConversionSpecification(TestCase):
                 overwrite=True,
             )
 
+    def test_run_conversion_from_yaml(self):
+        path_to_test_yml_files = Path(__file__).parent / "conversion_specifications"
+        yaml_file_path = path_to_test_yml_files / "GIN_conversion_specification_movies.yml"
+        run_conversion_from_yaml(
+            specification_file_path=yaml_file_path,
+            data_folder_path=BEHAVIOR_DATA_PATH,
+            output_folder_path=self.test_folder,
+            overwrite=True,
+        )
+            
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

When putting together the tutorial for https://github.com/NeurodataWithoutBorders/nwb_hackathons/pull/197, discovered a slight problem specific to the MovieInterface when run through the YAML conversion specification feature.

## How to test the behavior?

Tests added.

## Checklist

- [x] Have you thoroughly read our [Developer Guide](https://neuroconv.readthedocs.io/en/main/developer_guide.html)?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/neuroconv/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
- [x] Did you update the [CHANGLOG.md](https://github.com/catalystneuro/neuroconv/blob/main/CHANGELOG.md) file on your branch to describe your changes?
- [x] Did you bump the appropriate version number in [setup.py](https://github.com/catalystneuro/neuroconv/blob/main/setup.py#L30) on your branch?
