### PR TITLE
Fix overflow memory tests for recorders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ### Improvements
 * Added function to add ImagingPlane objects to an nwbfile in `roiextractors` and corresponding unit tests. [PR #19](https://github.com/catalystneuro/neuroconv/pull/19)
-* Added unittests for the `write_as` functionality in the `add_electrical_series` of the spikeinterface module [PR #32](https://github.com/catalystneuro/neuroconv/pull/32)
 
 ### Features
-Add non-iterative writing capabilities to `add_electrical_series` [PR #32](https://github.com/catalystneuro/neuroconv/pull/32)
+* Add non-iterative writing capabilities to `add_electrical_series`. [PR #32](https://github.com/catalystneuro/neuroconv/pull/32)
+
+### Testing
+* Added unittests for the `write_as` functionality in the `add_electrical_series` of the spikeinterface module. [PR #32](https://github.com/catalystneuro/neuroconv/pull/32)
+
 
 # v0.1.0
 
-The first release of NeuroConv.
+* The first release of NeuroConv.

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -700,14 +700,11 @@ class TestAddElectricalSeries(TestCase):
         dtype = self.test_recording_extractor.get_dtype()
         element_size_in_bytes = dtype.itemsize
         num_channels = self.test_recording_extractor.get_num_channels()
-        num_frames = self.test_recording_extractor.get_num_frames()
 
         available_memory_in_bytes = psutil.virtual_memory().available
-        frame_size_in_bytes = element_size_in_bytes * num_channels
 
-        excess_in_bytes = frame_size_in_bytes * int(num_frames) * 2  # 2 times excess in frames
-
-        num_frames_to_overflow = (available_memory_in_bytes + excess_in_bytes) / (element_size_in_bytes * num_channels)
+        excess = 1.5  # Of what is available in memory
+        num_frames_to_overflow = (available_memory_in_bytes * excess) / (element_size_in_bytes * num_channels)
 
         # Mock recording extractor with as much frames as necessary to overflow memory
 

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -705,7 +705,7 @@ class TestAddElectricalSeries(TestCase):
         available_memory_in_bytes = psutil.virtual_memory().available
         frame_size_in_bytes = element_size_in_bytes * num_channels
 
-        excess_in_bytes = frame_size_in_bytes * int(num_frames / 2)  # 50 excess frames
+        excess_in_bytes = frame_size_in_bytes * int(num_frames / 2)  # 50 % excess frames
 
         num_frames_to_overflow = (available_memory_in_bytes + excess_in_bytes) / (element_size_in_bytes * num_channels)
 

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -705,7 +705,7 @@ class TestAddElectricalSeries(TestCase):
         available_memory_in_bytes = psutil.virtual_memory().available
         frame_size_in_bytes = element_size_in_bytes * num_channels
 
-        excess_in_bytes = frame_size_in_bytes * int(num_frames / 2)  # 50 % excess frames
+        excess_in_bytes = frame_size_in_bytes * int(num_frames) * 2  # 200 % excess frames
 
         num_frames_to_overflow = (available_memory_in_bytes + excess_in_bytes) / (element_size_in_bytes * num_channels)
 

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -705,7 +705,7 @@ class TestAddElectricalSeries(TestCase):
         available_memory_in_bytes = psutil.virtual_memory().available
         frame_size_in_bytes = element_size_in_bytes * num_channels
 
-        excess_in_bytes = frame_size_in_bytes * int(num_frames) * 2  # 200 % excess frames
+        excess_in_bytes = frame_size_in_bytes * int(num_frames) * 2  # 2 times excess in frames
 
         num_frames_to_overflow = (available_memory_in_bytes + excess_in_bytes) / (element_size_in_bytes * num_channels)
 

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -700,12 +700,14 @@ class TestAddElectricalSeries(TestCase):
         dtype = self.test_recording_extractor.get_dtype()
         element_size_in_bytes = dtype.itemsize
         num_channels = self.test_recording_extractor.get_num_channels()
+        num_frames = self.test_recording_extractor.get_num_frames()
 
         available_memory_in_bytes = psutil.virtual_memory().available
         frame_size_in_bytes = element_size_in_bytes * num_channels
-        available_memory_in_bytes_plus_one_frame = available_memory_in_bytes + frame_size_in_bytes
 
-        num_frames_to_overflow = available_memory_in_bytes_plus_one_frame / (element_size_in_bytes * num_channels)
+        excess_in_bytes = frame_size_in_bytes * int(num_frames / 2)  # 50 excess frames
+
+        num_frames_to_overflow = (available_memory_in_bytes + excess_in_bytes) / (element_size_in_bytes * num_channels)
 
         # Mock recording extractor with as much frames as necessary to overflow memory
 


### PR DESCRIPTION
The other margin was too small as indicated by an error during https://github.com/catalystneuro/neuroconv/pull/33

This PR should fix it.