### PR TITLE
Propagate default iterator in ecephys to data interfaces

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/baselfpextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baselfpextractorinterface.py
@@ -39,7 +39,7 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
         use_times: bool = False,
         compression: Optional[str] = None,
         compression_opts: Optional[int] = None,
-        iterator_type: Optional[str] = None,
+        iterator_type: Optional[str] = "v2",
         iterator_opts: Optional[dict] = None,
         save_path: OptionalFilePathType = None,  # TODO: to be removed, depreceation applied at tools level
     ):

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -107,7 +107,7 @@ class BaseRecordingExtractorInterface(BaseDataInterface, ABC):
         es_key: str = None,
         compression: Optional[str] = None,
         compression_opts: Optional[int] = None,
-        iterator_type: Optional[str] = None,
+        iterator_type: Optional[str] = "v2",
         iterator_opts: Optional[dict] = None,
         save_path: OptionalFilePathType = None,  # TODO: to be removed, depreceation applied at tools level
     ):

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -605,7 +605,7 @@ class TestWriteElectrodes(unittest.TestCase):
                     assert nwb.electrodes["group"][i].description == "M1 description"
 
 
-class TestAddElectricalSeries(TestCase):
+class TestAddElectricalSeries(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Use common recording objects and values."""


### PR DESCRIPTION
In #32 non-iterative writing capabilities were added to the electrical series writing pipeline. To keep backwards compatibility the defaults of the function were changed to "v2" which is the "in-house" iterator (coincidentally now the docstrings are right, yei!). However, this change of default parameters was not propagated all the way up to the data interfaces so, in the current state, the would be running non-iterative write by default. This PR addresses this and some other minor refactoring of the `add_electrical_series` that I encountered while re-writing this.  