### PR TITLE
Add unit tests for add  electrical series II (scaling to volts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Upcoming
 
 ### Fixes
+* Prevented the CEDRecordingInterface from writing non-ecephys channel data. [PR #37](https://github.com/catalystneuro/neuroconv/pull/37)
 
 ### Improvements
 * Unified the `run_conversion` method of `BaseSegmentationExtractorInterface` with that of all the other base interfaces. The method `write_segmentation` now uses the common `make_or_load_nwbfile` context manager [PR #29](https://github.com/catalystneuro/neuroconv/pull/29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Features
 
 ### Testing
+* Added unittests for correctly writing the scaling factors to the nwbfile in the `add_electrical_series` function of the spikeinterface module. [PR #37](https://github.com/catalystneuro/neuroconv/pull/37)
 
 # v0.1.1
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Coerced the recording extractors with `spikeextractors_backend=True` to BaseRecording objects for Axona, Blackrock, Openephys, and SpikeGadgets. [PR #38](https://github.com/catalystneuro/neuroconv/pull/38)
 
 ### Features
+* Allow writing of offsets to ElectricalSeries obects from SpikeInterface (requires PyNWB>=2.1.0). [PR #37](https://github.com/catalystneuro/neuroconv/pull/37)
 
 ### Testing
 * Added unittests for correctly writing the scaling factors to the nwbfile in the `add_electrical_series` function of the spikeinterface module. [PR #37](https://github.com/catalystneuro/neuroconv/pull/37)

--- a/src/neuroconv/datainterfaces/ecephys/ced/ceddatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/ced/ceddatainterface.py
@@ -45,3 +45,8 @@ class CEDRecordingInterface(BaseRecordingExtractorInterface):
         if Path(file_path).suffix == ".smr":
             stream_id = "1"
         super().__init__(file_path=file_path, stream_id=stream_id, verbose=verbose)
+
+        # Subset raw channel properties
+        signal_channels = self.recording_extractor.neo_reader.header["signal_channels"]
+        channel_ids_of_raw_data = [channel_info[1] for channel_info in signal_channels if channel_info[4] == "mV"]
+        self.recording_extractor = self.recording_extractor.channel_slice(channel_ids=channel_ids_of_raw_data)

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -661,12 +661,14 @@ def add_electrical_series(
     unique_offset = np.unique(channel_offset)
     if unique_offset.size > 1:
         raise ValueError("Recording extractors with heterogeneous offsets are not supported")
+    unique_offset = unique_offset[0] if unique_offset[0] is not None else 0
 
     micro_to_volts_conversion_factor = 1e6
     eseries_kwargs.update(conversion=micro_to_volts_conversion_factor)
+
     if not write_scaled:
         eseries_kwargs.update(channel_conversion=channel_conversion)
-        eseries_kwargs.update(offset=unique_offset[0] * micro_to_volts_conversion_factor)
+        eseries_kwargs.update(offset=unique_offset * micro_to_volts_conversion_factor)
 
     if iterator_type is None:
         check_if_recording_traces_fit_into_memory(recording=checked_recording, segment_index=segment_index)

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -663,7 +663,7 @@ def add_electrical_series(
         raise ValueError("Recording extractors with heterogeneous offsets are not supported")
     unique_offset = unique_offset[0] if unique_offset[0] is not None else 0
 
-    micro_to_volts_conversion_factor = 1e6
+    micro_to_volts_conversion_factor = 1e-6
     eseries_kwargs.update(conversion=micro_to_volts_conversion_factor)
 
     if not write_scaled:

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -666,6 +666,9 @@ def add_electrical_series(
         eseries_kwargs.update(channel_conversion=channel_conversion)
         eseries_kwargs.update(offset=unique_offset * micro_to_volts_conversion_factor)
 
+    # Iterator
+    iterator_opts = dict() if iterator_opts is None else iterator_opts
+
     if iterator_type is None:
         check_if_recording_traces_fit_into_memory(recording=checked_recording, segment_index=segment_index)
         ephys_data = checked_recording.get_traces(return_scaled=write_scaled, segment_index=segment_index)

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -605,7 +605,7 @@ class TestWriteElectrodes(unittest.TestCase):
                     assert nwb.electrodes["group"][i].description == "M1 description"
 
 
-class TestAddElectricalSeries(TestCase):
+class TestAddElectricalSeries(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Use common recording objects and values."""
@@ -635,7 +635,7 @@ class TestAddElectricalSeries(TestCase):
 
         extracted_data = electrical_series.data[:]
         expected_data = self.test_recording_extractor.get_traces(segment_index=0)
-        np.testing.assert_array_equal(expected_data, extracted_data)
+        np.testing.assert_array_almost_equal(expected_data, extracted_data)
 
     def test_write_as_lfp(self):
         write_as = "lfp"
@@ -656,7 +656,7 @@ class TestAddElectricalSeries(TestCase):
         electrical_series = lfp_container.electrical_series["ElectricalSeries_lfp"]
         extracted_data = electrical_series.data[:]
         expected_data = self.test_recording_extractor.get_traces(segment_index=0)
-        np.testing.assert_array_equal(expected_data, extracted_data)
+        np.testing.assert_array_almost_equal(expected_data, extracted_data)
 
     def test_write_as_processing(self):
         write_as = "processed"
@@ -677,7 +677,7 @@ class TestAddElectricalSeries(TestCase):
         electrical_series = filtered_ephys_container.electrical_series["ElectricalSeries_processed"]
         extracted_data = electrical_series.data[:]
         expected_data = self.test_recording_extractor.get_traces(segment_index=0)
-        np.testing.assert_array_equal(expected_data, extracted_data)
+        np.testing.assert_array_almost_equal(expected_data, extracted_data)
 
     def test_write_as_assertion(self):
 
@@ -689,10 +689,6 @@ class TestAddElectricalSeries(TestCase):
             add_electrical_series(
                 recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None, write_as=write_as
             )
-
-    def test_write_scaled(self):
-        # TO-DO
-        pass
 
     def test_non_iterative_write(self):
 
@@ -708,7 +704,6 @@ class TestAddElectricalSeries(TestCase):
         num_frames_to_overflow = available_memory_in_bytes_plus_one_frame / (element_size_in_bytes * num_channels)
 
         # Mock recording extractor with as much frames as necessary to overflow memory
-
         mock_recorder = Mock()
         mock_recorder.get_dtype.return_value = dtype
         mock_recorder.get_num_channels.return_value = num_channels
@@ -718,6 +713,135 @@ class TestAddElectricalSeries(TestCase):
 
         with self.assertRaisesRegex(MemoryError, reg_expression):
             check_if_recording_traces_fit_into_memory(recording=mock_recorder)
+
+
+from spikeinterface.extractors import NumpyRecording
+
+
+class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Use common recording objects and values."""
+        cls.sampling_frequency = 1.0
+        cls.num_channels = 3
+        cls.num_frames = 5
+        cls.traces_list = [np.ones(shape=(cls.num_frames, cls.num_channels))]
+
+        # Combinations of gains and default
+        cls.gains_default = [1, 1, 1]
+        cls.offset_defaults = [0, 0, 0]
+        cls.gains_uniform = [2, 2, 2]
+        cls.offsets_uniform = [3, 3, 3]
+        cls.gains_variable = [1, 2, 3]
+        cls.offsets_variable = [1, 2, 3]
+
+    def setUp(self):
+        """Start with a fresh NWBFile, ElectrodeTable, and remapped BaseRecordings each time."""
+        self.nwbfile = NWBFile(
+            session_description="session_description1", identifier="file_id1", session_start_time=testing_session_time
+        )
+
+        # self.test_recording_extractor = NumpyRecording(self.traces_list, self.sampling_frequency)  # Flat traces [1, 1, 1] per channel
+
+        self.test_recording_extractor = generate_recording(
+            num_channels=self.num_channels, sampling_frequency=self.sampling_frequency, durations=[5]
+        )
+
+    def test_uniform_values(self):
+
+        gains = self.gains_default
+        offsets = self.offset_defaults
+        self.test_recording_extractor.set_channel_gains(gains=gains)
+        self.test_recording_extractor.set_channel_offsets(offsets=offsets)
+
+        add_electrical_series(
+            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None, write_scaled=True
+        )
+
+        acquisition_module = self.nwbfile.acquisition
+        electrical_series = acquisition_module["ElectricalSeries_raw"]
+
+        # Test conversion factor
+        extracted_data = electrical_series.data[:]
+        conversion_factor_scalar = electrical_series.conversion
+        assert conversion_factor_scalar == 10e6
+
+        # Test offset scalar
+        offset_scalar = electrical_series.offset
+        assert conversion_factor_scalar == offsets[0] * offset_scalar
+
+        # Test channel conversion vector
+        channel_conversion_vector = electrical_series.channel_conversion
+        np.testing.assert_array_almost_equal(channel_conversion_vector, gains)
+
+        # Test equality of data in Volts. Data in spikeextractors is in microvolts when scaled
+        data_in_volts = extracted_data @ channel_conversion_vector * conversion_factor_scalar + offset_scalar
+        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 10e6
+        np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
+
+    def test_uniform_non_default(self):
+
+        gains = self.gains_uniformm
+        offsets = self.offsets_uniform
+        self.test_recording_extractor.set_channel_gains(gains=gains)
+        self.test_recording_extractor.set_channel_offsets(offsets=offsets)
+
+        add_electrical_series(
+            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None, write_scaled=True
+        )
+
+        acquisition_module = self.nwbfile.acquisition
+        electrical_series = acquisition_module["ElectricalSeries_raw"]
+
+        # Test conversion factor
+        extracted_data = electrical_series.data[:]
+        conversion_factor_scalar = electrical_series.conversion
+        assert conversion_factor_scalar == 10e6
+
+        # Test offset scalar
+        offset_scalar = electrical_series.offset
+        assert conversion_factor_scalar == offsets[0] * offset_scalar
+
+        # Test channel conversion vector
+        channel_conversion_vector = electrical_series.channel_conversion
+        np.testing.assert_array_almost_equal(channel_conversion_vector, gains)
+
+        # Test equality of data in Volts. Data in spikeextractors is in microvolts when scaled
+        data_in_volts = extracted_data @ channel_conversion_vector * conversion_factor_scalar + offset_scalar
+        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 10e6
+        np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
+
+    def test_variable_gains(self):
+
+        gains = self.gains_variable
+        offsets = self.offsets_uniform
+        self.test_recording_extractor.set_channel_gains(gains=gains)
+        self.test_recording_extractor.set_channel_offsets(offsets=offsets)
+
+        add_electrical_series(
+            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None, write_scaled=True
+        )
+
+        acquisition_module = self.nwbfile.acquisition
+        electrical_series = acquisition_module["ElectricalSeries_raw"]
+
+        # Test conversion factor
+        extracted_data = electrical_series.data[:]
+        conversion_factor_scalar = electrical_series.conversion
+        assert conversion_factor_scalar == 10e6
+
+        # Test offset scalar
+        offset_scalar = electrical_series.offset
+        assert conversion_factor_scalar == offsets[0] * offset_scalar
+
+        # Test channel conversion vector
+        channel_conversion_vector = electrical_series.channel_conversion
+        np.testing.assert_array_almost_equal(channel_conversion_vector, gains)
+
+        # Test equality of data in Volts. Data in spikeextractors is in microvolts when scaled
+        data_in_volts = extracted_data @ channel_conversion_vector * conversion_factor_scalar + offset_scalar
+        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 10e6
+        np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
 
 
 class TestAddElectrodes(TestCase):

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -725,6 +725,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         cls.sampling_frequency = 1.0
         cls.num_channels = 3
         cls.num_frames = 5
+        cls.channel_ids = ["a", "b", "c"]
         cls.traces_list = [np.ones(shape=(cls.num_frames, cls.num_channels))]
 
         # Combinations of gains and default
@@ -741,10 +742,9 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
             session_description="session_description1", identifier="file_id1", session_start_time=testing_session_time
         )
 
-        # self.test_recording_extractor = NumpyRecording(self.traces_list, self.sampling_frequency)  # Flat traces [1, 1, 1] per channel
-
-        self.test_recording_extractor = generate_recording(
-            num_channels=self.num_channels, sampling_frequency=self.sampling_frequency, durations=[5]
+        # Flat traces [1, 1, 1] per channel
+        self.test_recording_extractor = NumpyRecording(
+            self.traces_list, self.sampling_frequency, channel_ids=self.channel_ids
         )
 
     def test_uniform_values(self):
@@ -754,61 +754,57 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         self.test_recording_extractor.set_channel_gains(gains=gains)
         self.test_recording_extractor.set_channel_offsets(offsets=offsets)
 
-        add_electrical_series(
-            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None, write_scaled=True
-        )
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeries_raw"]
 
         # Test conversion factor
-        extracted_data = electrical_series.data[:]
         conversion_factor_scalar = electrical_series.conversion
-        assert conversion_factor_scalar == 10e6
+        assert conversion_factor_scalar == 1e6
 
         # Test offset scalar
         offset_scalar = electrical_series.offset
-        assert conversion_factor_scalar == offsets[0] * offset_scalar
+        assert offset_scalar == offsets[0] * 1e6
 
         # Test channel conversion vector
         channel_conversion_vector = electrical_series.channel_conversion
         np.testing.assert_array_almost_equal(channel_conversion_vector, gains)
 
         # Test equality of data in Volts. Data in spikeextractors is in microvolts when scaled
-        data_in_volts = extracted_data @ channel_conversion_vector * conversion_factor_scalar + offset_scalar
-        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 10e6
+        extracted_data = electrical_series.data[:]
+        data_in_volts = extracted_data * channel_conversion_vector * conversion_factor_scalar + offset_scalar
+        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 1e6
         np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
 
     def test_uniform_non_default(self):
 
-        gains = self.gains_uniformm
+        gains = self.gains_uniform
         offsets = self.offsets_uniform
         self.test_recording_extractor.set_channel_gains(gains=gains)
         self.test_recording_extractor.set_channel_offsets(offsets=offsets)
 
-        add_electrical_series(
-            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None, write_scaled=True
-        )
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeries_raw"]
 
         # Test conversion factor
-        extracted_data = electrical_series.data[:]
         conversion_factor_scalar = electrical_series.conversion
-        assert conversion_factor_scalar == 10e6
+        assert conversion_factor_scalar == 1e6
 
         # Test offset scalar
         offset_scalar = electrical_series.offset
-        assert conversion_factor_scalar == offsets[0] * offset_scalar
+        assert offset_scalar == offsets[0] * 1e6
 
         # Test channel conversion vector
         channel_conversion_vector = electrical_series.channel_conversion
         np.testing.assert_array_almost_equal(channel_conversion_vector, gains)
 
         # Test equality of data in Volts. Data in spikeextractors is in microvolts when scaled
-        data_in_volts = extracted_data @ channel_conversion_vector * conversion_factor_scalar + offset_scalar
-        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 10e6
+        extracted_data = electrical_series.data[:]
+        data_in_volts = extracted_data * channel_conversion_vector * conversion_factor_scalar + offset_scalar
+        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 1e6
         np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
 
     def test_variable_gains(self):
@@ -818,29 +814,27 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         self.test_recording_extractor.set_channel_gains(gains=gains)
         self.test_recording_extractor.set_channel_offsets(offsets=offsets)
 
-        add_electrical_series(
-            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None, write_scaled=True
-        )
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeries_raw"]
 
         # Test conversion factor
-        extracted_data = electrical_series.data[:]
         conversion_factor_scalar = electrical_series.conversion
-        assert conversion_factor_scalar == 10e6
+        assert conversion_factor_scalar == 1e6
 
         # Test offset scalar
         offset_scalar = electrical_series.offset
-        assert conversion_factor_scalar == offsets[0] * offset_scalar
+        assert offset_scalar == offsets[0] * 1e6
 
         # Test channel conversion vector
         channel_conversion_vector = electrical_series.channel_conversion
         np.testing.assert_array_almost_equal(channel_conversion_vector, gains)
 
         # Test equality of data in Volts. Data in spikeextractors is in microvolts when scaled
-        data_in_volts = extracted_data @ channel_conversion_vector * conversion_factor_scalar + offset_scalar
-        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 10e6
+        extracted_data = electrical_series.data[:]
+        data_in_volts = extracted_data * channel_conversion_vector * conversion_factor_scalar + offset_scalar
+        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 1e6
         np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
 
 

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -760,11 +760,11 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
 
         # Test conversion factor
         conversion_factor_scalar = electrical_series.conversion
-        assert conversion_factor_scalar == 1e6
+        assert conversion_factor_scalar == 1e-6
 
         # Test offset scalar
         offset_scalar = electrical_series.offset
-        assert offset_scalar == offsets[0] * 1e6
+        assert offset_scalar == offsets[0] * 1e-6
 
         # Test channel conversion vector
         channel_conversion_vector = electrical_series.channel_conversion
@@ -773,7 +773,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         # Test equality of data in Volts. Data in spikeextractors is in microvolts when scaled
         extracted_data = electrical_series.data[:]
         data_in_volts = extracted_data * channel_conversion_vector * conversion_factor_scalar + offset_scalar
-        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 1e6
+        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 1e-6
         np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
 
     def test_uniform_non_default(self):
@@ -790,11 +790,11 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
 
         # Test conversion factor
         conversion_factor_scalar = electrical_series.conversion
-        assert conversion_factor_scalar == 1e6
+        assert conversion_factor_scalar == 1e-6
 
         # Test offset scalar
         offset_scalar = electrical_series.offset
-        assert offset_scalar == offsets[0] * 1e6
+        assert offset_scalar == offsets[0] * 1e-6
 
         # Test channel conversion vector
         channel_conversion_vector = electrical_series.channel_conversion
@@ -803,7 +803,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         # Test equality of data in Volts. Data in spikeextractors is in microvolts when scaled
         extracted_data = electrical_series.data[:]
         data_in_volts = extracted_data * channel_conversion_vector * conversion_factor_scalar + offset_scalar
-        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 1e6
+        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 1e-6
         np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
 
     def test_variable_gains(self):
@@ -820,11 +820,11 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
 
         # Test conversion factor
         conversion_factor_scalar = electrical_series.conversion
-        assert conversion_factor_scalar == 1e6
+        assert conversion_factor_scalar == 1e-6
 
         # Test offset scalar
         offset_scalar = electrical_series.offset
-        assert offset_scalar == offsets[0] * 1e6
+        assert offset_scalar == offsets[0] * 1e-6
 
         # Test channel conversion vector
         channel_conversion_vector = electrical_series.channel_conversion
@@ -833,7 +833,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         # Test equality of data in Volts. Data in spikeextractors is in microvolts when scaled
         extracted_data = electrical_series.data[:]
         data_in_volts = extracted_data * channel_conversion_vector * conversion_factor_scalar + offset_scalar
-        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 1e6
+        traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 1e-6
         np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
 
     def test_null_offsets_in_recording_extractor(self):
@@ -848,7 +848,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
 
         # Test conversion factor
         conversion_factor_scalar = electrical_series.conversion
-        assert conversion_factor_scalar == 1e6
+        assert conversion_factor_scalar == 1e-6
 
         # Test offset scalar
         offset_scalar = electrical_series.offset
@@ -864,7 +864,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         traces_data = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=False)
         gains = self.test_recording_extractor.get_channel_gains()
         traces_data_in_micro_volts = traces_data * gains
-        traces_data_in_volts = traces_data_in_micro_volts * 1e6
+        traces_data_in_volts = traces_data_in_micro_volts * 1e-6
         np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
 
     def test_variable_offsets_assertion(self):

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -837,6 +837,18 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 1e6
         np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
 
+    def test_variable_offsets_assertion(self):
+
+        gains = self.gains_default
+        offsets = self.offsets_variable
+        self.test_recording_extractor.set_channel_gains(gains=gains)
+        self.test_recording_extractor.set_channel_offsets(offsets=offsets)
+
+        reg_expression = f"Recording extractors with heterogeneous offsets are not supported"
+
+        with self.assertRaisesRegex(ValueError, reg_expression):
+            add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
+
 
 class TestAddElectrodes(TestCase):
     @classmethod

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -377,7 +377,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
             input_gain_array = np.ones_like(output_channel_conversion) * input_gain
             np.testing.assert_array_almost_equal(input_gain_array, output_channel_conversion)
 
-            nwb_recording = NwbRecordingExtractorSI(file_path=nwbfile_path)
+            nwb_recording = NwbRecordingExtractor(file_path=nwbfile_path)
             nwb_recording_gains = nwb_recording.get_channel_gains()
             npt.assert_almost_equal(input_gain * np.ones_like(nwb_recording_gains), nwb_recording_gains)
 

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -388,11 +388,11 @@ class TestEcephysNwbConversions(unittest.TestCase):
 
         with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
             nwbfile = io.read()
-            output_conversion = nwbfile.acquisition["ElectricalSeries_raw"].conversion
-            output_gain = output_conversion * 1e6
-            self.assertEqual(first=input_gain, second=output_gain)
+            output_channel_conversion = nwbfile.acquisition["ElectricalSeries_raw"].channel_conversion[:]
+            input_gain_array = np.ones_like(output_channel_conversion) * input_gain
+            np.testing.assert_array_almost_equal(input_gain_array, output_channel_conversion)
 
-            nwb_recording = NwbRecordingExtractor(file_path=nwbfile_path)
+            nwb_recording = NwbRecordingExtractorSI(file_path=nwbfile_path)
             nwb_recording_gains = nwb_recording.get_channel_gains()
             npt.assert_almost_equal(input_gain * np.ones_like(nwb_recording_gains), nwb_recording_gains)
 


### PR DESCRIPTION
I added tests for the `add_electrical_series` function in the spikeinterface module. Also, some change in the code of the module itself. Relevant to the discussion here is the discussion in https://github.com/catalystneuro/neuroconv/issues/34. 