### PR TITLE
Old to new recorders refactoring, spikeinterface objects in all recording interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 * Unified the `run_conversion` method of `BaseSegmentationExtractorInterface` with that of all the other base interfaces. The method `write_segmentation` now uses the common `make_or_load_nwbfile` context manager [PR #29](https://github.com/catalystneuro/neuroconv/pull/29)
+* Coerced the recording extractors with `spikeextractors_backend=True` to BaseRecording objects for Axona, Blackrock, Openephys, and SpikeGadgets. [PR #38](https://github.com/catalystneuro/neuroconv/pull/38)
 
 ### Features
 

--- a/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Union
 
 import spikeextractors as se
+from spikeinterface.core.old_api_utils import OldToNewRecording
+
 from pynwb import NWBFile
 from pynwb.behavior import Position, SpatialSeries
 
@@ -71,6 +73,7 @@ class AxonaRecordingExtractorInterface(BaseRecordingExtractorInterface):
     def __init__(self, file_path: FilePathType, verbose: bool = True):
         super().__init__(filename=file_path, verbose=verbose)
         self.source_data = dict(file_path=file_path, verbose=verbose)
+        self.recording_extractor = OldToNewRecording(oldapi_recording_extractor=self.recording_extractor)
 
     def get_metadata(self):
 

--- a/src/neuroconv/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -3,6 +3,8 @@ from typing import Optional
 from pathlib import Path
 
 from spikeinterface.extractors import BlackrockRecordingExtractor
+from spikeinterface.core.old_api_utils import OldToNewRecording
+
 import spikeextractors as se
 from pynwb.ecephys import ElectricalSeries
 
@@ -66,6 +68,8 @@ class BlackrockRecordingExtractorInterface(BaseRecordingExtractorInterface):
             self.source_data = dict(
                 file_path=file_path, nsx_override=nsx_override, nsx_to_load=nsx_to_load, verbose=verbose
             )
+            self.recording_extractor = OldToNewRecording(oldapi_recording_extractor=self.recording_extractor)
+
         else:
             super().__init__(file_path=file_path, verbose=verbose)
 

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysdatainterface.py
@@ -4,6 +4,7 @@ from typing import Optional
 import pyopenephys
 import spikeextractors as se
 from spikeinterface.extractors import OpenEphysBinaryRecordingExtractor
+from spikeinterface.core.old_api_utils import OldToNewRecording
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
@@ -40,6 +41,7 @@ class OpenEphysRecordingExtractorInterface(BaseRecordingExtractorInterface):
             super().__init__(
                 folder_path=folder_path, experiment_id=experiment_id, recording_id=recording_id, verbose=verbose
             )
+            self.recording_extractor = OldToNewRecording(oldapi_recording_extractor=self.recording_extractor)
 
         else:
             super().__init__(folder_path=folder_path, verbose=verbose)
@@ -51,12 +53,9 @@ class OpenEphysRecordingExtractorInterface(BaseRecordingExtractorInterface):
         """Auto-fill as much of the metadata as possible. Must comply with metadata schema."""
         metadata = super().get_metadata()
 
-        if self.spikeextractors_backend:
-            session_start_time = self.recording_extractor._fileobj.experiments[0].datetime
-        else:
-            folder_path = self.source_data["folder_path"]
-            fileobj = pyopenephys.File(folder_path)
-            session_start_time = fileobj.experiments[0].datetime
+        folder_path = self.source_data["folder_path"]
+        fileobj = pyopenephys.File(folder_path)
+        session_start_time = fileobj.experiments[0].datetime
 
         metadata["NWBFile"] = dict(session_start_time=session_start_time)
         return metadata

--- a/src/neuroconv/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
@@ -2,6 +2,7 @@
 
 import spikeextractors as se
 from spikeinterface.extractors import SpikeGadgetsRecordingExtractor
+from spikeinterface.core.old_api_utils import OldToNewRecording
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ....utils import FilePathType, OptionalFilePathType, OptionalArrayType
@@ -56,6 +57,7 @@ class SpikeGadgetsRecordingInterface(BaseRecordingExtractorInterface):
                 )
 
             super().__init__(filename=file_path, verbose=verbose)
+            self.recording_extractor = OldToNewRecording(oldapi_recording_extractor=self.recording_extractor)
         else:
             super().__init__(file_path=file_path, stream_id="trodes", verbose=verbose)
 


### PR DESCRIPTION
This PR is to make our tests more centered into spikeinterface. Now all the interfaces have recorders which are spikeinterface BaseRecording objects. This will clean a little bit our `gin_test_ecephys` which before had to take into account for this possibility and should make it easier to pin bugs in the future while also moving forward with the full transition to spikeinterface.