### PR TITLE
Add data interface for Neuralynx Sorting 

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -47,7 +47,7 @@ jobs:
         id: cache-ecephys-datasets
         with:
           path: ./ephy_testing_data
-          key: ecephys-datasets-22-07-29-${{ matrix.os }}-${{ steps.ecephys.outputs.HASH_EPHY_DATASET }}
+          key: ecephys-datasets-2022-08-03-${{ matrix.os }}-${{ steps.ecephys.outputs.HASH_EPHY_DATASET }}
       - name: Get ophys_testing_data current head hash
         id: ophys
         run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"
@@ -56,7 +56,7 @@ jobs:
         id: cache-ophys-datasets
         with:
           path: ./ophys_testing_data
-          key: ophys-datasets-22-07-29-${{ matrix.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
+          key: ophys-datasets-2022-08-03-${{ matrix.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
       - name: Get behavior_testing_data current head hash
         id: behavior
         run: echo "::set-output name=HASH_BEHAVIOR_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/behavior_testing_data.git HEAD | cut -f1)"
@@ -83,9 +83,10 @@ jobs:
         run: |
           datalad install https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
           cd ephy_testing_data
-          datalad get -r ./neuralynx/Cheetah_v5.7.4/original_data/
-          datalad get -r ./neuralynx/Cheetah_v5.6.3/original_data/
           datalad get -r ./neuralynx/Cheetah_v5.4.0/original_data/
+          datalad get -r ./neuralynx/Cheetah_v5.5.1/original_data/
+          datalad get -r ./neuralynx/Cheetah_v5.6.3/original_data/
+          datalad get -r ./neuralynx/Cheetah_v5.7.4/original_data/
           datalad get -r ./neuroscope/
           datalad get -r ./openephysbinary/v0.4.4.1_with_video_tracking/
           datalad get -r ./blackrock/

--- a/docs/api/interfaces.ecephys.rst
+++ b/docs/api/interfaces.ecephys.rst
@@ -21,8 +21,8 @@ Blackrock Recording
 -------------------
 .. automodule:: neuroconv.datainterfaces.ecephys.blackrock.blackrockdatainterface
 
-CED Recording
--------------
+Cambridge Electronic Design (CED) Recording
+-------------------------------------------
 .. automodule:: neuroconv.datainterfaces.ecephys.ced.ceddatainterface
 
 CellExplorer Sorting
@@ -37,8 +37,8 @@ Kilosort Sorting
 ----------------
 .. automodule:: neuroconv.datainterfaces.ecephys.kilosort.kilosortdatainterface
 
-Neuralynx Recording
--------------------
+Neuralynx Recording & Sorting
+-----------------------------
 .. automodule:: neuroconv.datainterfaces.ecephys.neuralynx.neuralynxdatainterface
 
 Neuroscope Recording & Sorting
@@ -61,6 +61,6 @@ SpikeGLX Recording
 ------------------
 .. automodule:: neuroconv.datainterfaces.ecephys.spikeglx.spikeglxdatainterface
 
-EDF Recording
+European Data Format (EDF) Recording
 ------------------
 .. automodule:: neuroconv.datainterfaces.ecephys.edf.edfdatainterface

--- a/docs/conversion_example_gallery.rst
+++ b/docs/conversion_example_gallery.rst
@@ -32,6 +32,7 @@ Sorting
     Kilosort <conversion_examples_gallery/sorting/kilosort>
     Neuroscope <conversion_examples_gallery/sorting/neuroscope>
     Phy <conversion_examples_gallery/sorting/phy>
+    Neuralynx <conversion_examples_gallery/sorting/neuralynx>
 
 
 Imaging

--- a/docs/conversion_examples_gallery/sorting/neuralynx.rst
+++ b/docs/conversion_examples_gallery/sorting/neuralynx.rst
@@ -1,7 +1,7 @@
-Kilosort data conversion
-^^^^^^^^^^^^^^^^^^^^^^^^
+Neuralynx data conversion
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Convert Kilosort data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.kilosort.kilosortdatainterface.KilosortSortingInterface`.
+Convert Neuralynx data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.neuralynx.neuralynxdatainterface.NeuralynxSortingInterface`.
 
 .. code-block:: python
 
@@ -9,16 +9,16 @@ Convert Kilosort data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.
     >>> from dateutil import tz
     >>> from pathlib import Path
     >>>
-    >>> from neuroconv import KilosortSortingInterface
+    >>> from neuroconv import NeuralynxSortingInterface
     >>>
-    >>> folder_path = f"{ECEPHY_DATA_PATH}/phy/phy_example_0"
+    >>> folder_path = f"{ECEPHY_DATA_PATH}/neuralynx/Cheetah_v5.5.1/original_data"
     >>> # Change the folder_path to the location of the data in your system
-    >>> interface = KilosortSortingInterface(folder_path=folder_path, verbose=False)
+    >>> interface = NeuralynxSortingInterface(folder_path=folder_path, verbose=False)
     >>>
     >>> metadata = interface.get_metadata()
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=tz.gettz("US/Pacific")).isoformat()
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
-    >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./saved_file.nwb"
+    >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./neuralynx_conversion.nwb"
     >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)
     >>>
     >>> # If the conversion was successful this should evaluate to ``True`` as the file was created.

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -15,7 +15,7 @@ psutil==5.8.0
 lxml==4.9.1
 opencv-python==4.5.1.48
 spikeextractors==0.9.10
-spikeinterface @ git+https://github.com/catalystneuro/spikeinterface.git@shift_spike_times_with_t_start
+spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@4346eff5706408435e8aa8345be22fdd452afa27
 neo @ git+https://github.com/NeuralEnsemble/python-neo@master
 roiextractors==0.4.18
 pyintan==0.3.0

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -15,8 +15,7 @@ psutil==5.8.0
 lxml==4.9.1
 opencv-python==4.5.1.48
 spikeextractors==0.9.10
-spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@47bdee521f962f5aa50bccce992f232c7f41b161
-
+spikeinterface @ git+https://github.com/catalystneuro/spikeinterface.git@shift_spike_times_with_t_start
 neo @ git+https://github.com/NeuralEnsemble/python-neo@master
 roiextractors==0.4.18
 pyintan==0.3.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -10,7 +10,7 @@ jsonschema>=3.2.0
 psutil>=5.8.0
 dandi==0.39.6
 spikeextractors>=0.9.10
-spikeinterface @ git+https://github.com/catalystneuro/spikeinterface.git@shift_spike_times_with_t_start
+spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@4346eff5706408435e8aa8345be22fdd452afa27
 neo>=0.9.0
 roiextractors==0.4.18
 lxml>=4.6.5

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -10,7 +10,7 @@ jsonschema>=3.2.0
 psutil>=5.8.0
 dandi==0.39.6
 spikeextractors>=0.9.10
-spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@47bdee521f962f5aa50bccce992f232c7f41b161
+spikeinterface @ git+https://github.com/catalystneuro/spikeinterface.git@shift_spike_times_with_t_start
 neo>=0.9.0
 roiextractors==0.4.18
 lxml>=4.6.5

--- a/src/neuroconv/datainterfaces/__init__.py
+++ b/src/neuroconv/datainterfaces/__init__.py
@@ -29,7 +29,7 @@ from .ecephys.axona.axonadatainterface import (
     AxonaLFPDataInterface,
     AxonaUnitRecordingExtractorInterface,
 )
-from .ecephys.neuralynx.neuralynxdatainterface import NeuralynxRecordingInterface
+from .ecephys.neuralynx.neuralynxdatainterface import NeuralynxRecordingInterface, NeuralynxSortingInterface
 from .ecephys.phy.phydatainterface import PhySortingInterface
 from .ecephys.kilosort.kilosortdatainterface import KilosortSortingInterface
 from .ecephys.edf.edfdatainterface import EDFRecordingInterface
@@ -55,6 +55,7 @@ interface_list = [
     RecordingTutorialInterface,
     SortingTutorialInterface,
     NeuralynxRecordingInterface,
+    NeuralynxSortingInterface,
     NeuroscopeRecordingInterface,
     NeuroscopeMultiRecordingTimeInterface,
     NeuroscopeSortingInterface,

--- a/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -5,13 +5,13 @@ from natsort import natsorted
 from dateutil import parser
 import json
 
-from spikeinterface.extractors import NeuralynxRecordingExtractor
+from spikeinterface.extractors import NeuralynxRecordingExtractor, NeuralynxSortingExtractor
 from spikeinterface.core.old_api_utils import OldToNewRecording
-from spikeinterface import BaseRecording
 
 import spikeextractors as se
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
+from ..basesortingextractorinterface import BaseSortingExtractorInterface
 from ....utils import FolderPathType
 from ....utils.json_schema import dict_deep_update
 
@@ -120,3 +120,11 @@ class NeuralynxRecordingInterface(BaseRecordingExtractorInterface):
     def get_metadata(self):
         new_metadata = dict(NWBFile=get_metadata(self.source_data["folder_path"]))
         return dict_deep_update(super().get_metadata(), new_metadata)
+
+
+class NeuralynxSortingInterface(BaseSortingExtractorInterface):
+    SX = NeuralynxSortingExtractor
+
+    def __init__(self, folder_path: FolderPathType, sampling_frequency: float = None, verbose: bool = True):
+
+        super().__init__(folder_path=folder_path, sampling_frequency=sampling_frequency, verbose=verbose)

--- a/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -126,5 +126,16 @@ class NeuralynxSortingInterface(BaseSortingExtractorInterface):
     SX = NeuralynxSortingExtractor
 
     def __init__(self, folder_path: FolderPathType, sampling_frequency: float = None, verbose: bool = True):
+        """_summary_
+
+        Parameters
+        ----------
+        folder_path : str, Path
+            The path to the folder/directory containing the data files for the session (nse, ntt, nse, nev)
+        sampling_frequency : float, optional
+            If a specific sampling_frequency is desired it can be set with this argument.
+        verbose : bool, optional
+            Enables verbosity
+        """
 
         super().__init__(folder_path=folder_path, sampling_frequency=sampling_frequency, verbose=verbose)

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -1199,7 +1199,15 @@ def add_units_table(
         unit_kwargs = dict(property_to_default_values)
         for property in properties_with_data:
             unit_kwargs[property] = data_to_add[property]["data"][row]
-        spike_times = checked_sorting.get_unit_spike_train(unit_id=units_ids[row], return_times=True)
+        spike_times = []
+
+        # Extract and cocatenate the spike times from multiple segments
+        for segment_index in range(checked_sorting.get_num_segments()):
+            segment_spike_times = checked_sorting.get_unit_spike_train(
+                unit_id=0, segment_index=segment_index, return_times=True
+            )
+            spike_times.append(segment_spike_times)
+        spike_times = np.concatenate(spike_times)
         units_table.add_unit(spike_times=spike_times, **unit_kwargs, enforce_unique_id=True)
 
     # Add unit_name as a column and fill previously existing rows with unit_name equal to str(ids)

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -1204,7 +1204,7 @@ def add_units_table(
         # Extract and cocatenate the spike times from multiple segments
         for segment_index in range(checked_sorting.get_num_segments()):
             segment_spike_times = checked_sorting.get_unit_spike_train(
-                unit_id=0, segment_index=segment_index, return_times=True
+                unit_id=units_ids[row], segment_index=segment_index, return_times=True
             )
             spike_times.append(segment_spike_times)
         spike_times = np.concatenate(spike_times)

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -26,6 +26,7 @@ from neuroconv import (
     CEDRecordingInterface,
     IntanRecordingInterface,
     NeuralynxRecordingInterface,
+    NeuralynxSortingInterface,
     NeuroscopeRecordingInterface,
     NeuroscopeSortingInterface,
     OpenEphysRecordingExtractorInterface,
@@ -40,6 +41,7 @@ from neuroconv import (
     AxonaLFPDataInterface,
     EDFRecordingInterface,
 )
+
 
 from .setup_paths import ECEPHY_DATA_PATH as DATA_PATH
 from .setup_paths import OUTPUT_PATH
@@ -297,6 +299,16 @@ class TestEcephysNwbConversions(unittest.TestCase):
                 )
             ),
         ),
+        param(
+            data_interface=NeuralynxSortingInterface,
+            interface_kwargs=dict(folder_path=str(DATA_PATH / "neuralynx" / "Cheetah_v5.5.1" / "original_data")),
+            case_name="mono_electrodes",
+        ),
+        param(
+            data_interface=NeuralynxSortingInterface,
+            interface_kwargs=dict(folder_path=str(DATA_PATH / "neuralynx" / "Cheetah_v5.6.3" / "original_data")),
+            case_name="tetrodes",
+        ),
     ]
 
     for spikeextractors_backend in [False, True]:
@@ -349,8 +361,10 @@ class TestEcephysNwbConversions(unittest.TestCase):
             nwb_sorting = NwbSortingExtractor(file_path=nwbfile_path, sampling_frequency=sf)
             check_sortings_equal(SX1=sorting, SX2=nwb_sorting)
         else:
-            nwb_sorting = NwbSortingExtractorSI(file_path=nwbfile_path, sampling_frequency=sf)
-            check_sorting_equal_si(SX1=sorting, SX2=nwb_sorting)
+            # NWBSortingExtractor on spikeinterface does not yet support loading data written from multiple segment.
+            if sorting.get_num_segments() == 1:
+                nwb_sorting = NwbSortingExtractorSI(file_path=nwbfile_path, sampling_frequency=sf)
+                check_sorting_equal_si(SX1=sorting, SX2=nwb_sorting)
 
     @parameterized.expand(
         input=[


### PR DESCRIPTION
This should close #16 

Important point. Neuralynx is multi segment. The strategy that I am following for the units table is to concatenate spikes coming from a single unit across multiple segments (appropriately time shifted, https://github.com/SpikeInterface/spikeinterface/pull/865#event-7117106059) and hence pinning to a development branch in spike-interface and the modifications in our own `spikeinterface` module. 
