### PR TITLE
Dynamic module loading as interface attributes

### DIFF
--- a/docs/conversion_examples_gallery/behavior/deeplabcut.rst
+++ b/docs/conversion_examples_gallery/behavior/deeplabcut.rst
@@ -9,12 +9,12 @@ Convert DeepLabCut imaging data to NWB using :py:class:`~neuroconv.datainterface
     >>> from dateutil import tz
     >>> from pathlib import Path
     >>> from neuroconv import DeepLabCutInterface
-    ...
     >>>
     >>> file_path = BEHAVIOR_DATA_PATH / "DLC" / "m3v1mp4DLC_resnet50_openfieldAug20shuffle1_30000.h5"
     >>> config_file_path = BEHAVIOR_DATA_PATH / "DLC" / "config.yaml"
     >>>
     >>> interface = DeepLabCutInterface(file_path=file_path, config_file_path=config_file_path, subject_name="ind1", verbose=False)
+    ...
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=tz.gettz("US/Pacific"))

--- a/docs/conversion_examples_gallery/behavior/deeplabcut.rst
+++ b/docs/conversion_examples_gallery/behavior/deeplabcut.rst
@@ -9,6 +9,7 @@ Convert DeepLabCut imaging data to NWB using :py:class:`~neuroconv.datainterface
     >>> from dateutil import tz
     >>> from pathlib import Path
     >>> from neuroconv import DeepLabCutInterface
+    ...
     >>>
     >>> file_path = BEHAVIOR_DATA_PATH / "DLC" / "m3v1mp4DLC_resnet50_openfieldAug20shuffle1_30000.h5"
     >>> config_file_path = BEHAVIOR_DATA_PATH / "DLC" / "config.yaml"

--- a/src/neuroconv/basedatainterface.py
+++ b/src/neuroconv/basedatainterface.py
@@ -13,7 +13,7 @@ class BaseDataInterface(ABC):
     """Abstract class defining the structure of all DataInterfaces."""
 
     modules_to_import: Optional[List[str]] = None
-    loaded_modules: Optional[Dict[importlib.types.ModuleType]] = None
+    loaded_modules: Optional[Dict[str, importlib.types.ModuleType]] = None
 
     @classmethod
     def get_source_schema(cls):

--- a/src/neuroconv/basedatainterface.py
+++ b/src/neuroconv/basedatainterface.py
@@ -1,15 +1,19 @@
 """Authors: Cody Baker and Ben Dichter."""
-from abc import abstractmethod, ABC
 import uuid
-from typing import Optional
+import importlib
+from abc import abstractmethod, ABC
+from typing import Optional, List, Dict
 
 from pynwb import NWBFile
 
-from .utils import get_base_schema, get_schema_from_method_signature
+from .utils import get_base_schema, get_schema_from_method_signature, safe_import
 
 
 class BaseDataInterface(ABC):
     """Abstract class defining the structure of all DataInterfaces."""
+
+    modules_to_import: Optional[List[str]] = None
+    loaded_modules: Optional[Dict[importlib.types.ModuleType]] = None
 
     @classmethod
     def get_source_schema(cls):
@@ -23,6 +27,10 @@ class BaseDataInterface(ABC):
 
     def __init__(self, **source_data):
         self.source_data = source_data
+        if self.modules_to_import:
+            self.loaded_modules = {
+                module_name: safe_import(module_name=module_name) for module_name in self.modules_to_import
+            }
 
     def get_metadata_schema(self):
         """Retrieve JSON schema for metadata."""

--- a/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
@@ -8,16 +8,11 @@ from ....basedatainterface import BaseDataInterface
 from ....utils import dict_deep_update, FilePathType, OptionalFilePathType
 from ....tools.nwb_helpers import make_or_load_nwbfile
 
-try:
-    from dlc2nwb.utils import auxiliaryfunctions, write_subject_to_nwb
-
-    HAVE_DLC2NWB = True
-except ImportError:
-    HAVE_DLC2NWB = False
-
 
 class DeepLabCutInterface(BaseDataInterface):
-    """Data interface for DeepLabCut datasets"""
+    """Data interface for DeepLabCut datasets."""
+
+    modules_to_import = ["dlc2nwb.utils"]
 
     def __init__(
         self,
@@ -43,14 +38,13 @@ class DeepLabCutInterface(BaseDataInterface):
         file_path = Path(file_path)
         if "DLC" not in file_path.stem or ".h5" not in file_path.suffixes:
             raise IOError("The file passed in is not a DeepLabCut h5 data file.")
-        assert HAVE_DLC2NWB, "to use this datainterface: 'pip install dlc2nwb'"
-
-        self._config_file = auxiliaryfunctions.read_config(config_file_path)
-        self.subject_name = subject_name
-        self.verbose = verbose
         super().__init__(file_path=file_path, config_file_path=config_file_path)
 
-    def get_metadata(self):
+        self._config_file = self.loaded_modules["dlc2nwb.utils"].auxiliaryfunctions.read_config(config_file_path)
+        self.subject_name = subject_name
+        self.verbose = verbose
+
+    def get_metadata(self):  # noqa: D102
         metadata = dict(
             NWBFile=dict(session_description=self._config_file["Task"], experimenter=[self._config_file["scorer"]]),
         )
@@ -65,6 +59,7 @@ class DeepLabCutInterface(BaseDataInterface):
     ):
         """
         Conversion from DLC output files to nwb. Derived from dlc2nwb library.
+
         Parameters
         ----------
         nwbfile_path: FilePathType
@@ -77,14 +72,13 @@ class DeepLabCutInterface(BaseDataInterface):
         overwrite: bool, optional
             Whether or not to overwrite the NWBFile if one exists at the nwbfile_path.
         """
-
         base_metadata = self.get_metadata()
         metadata = dict_deep_update(base_metadata, metadata)
 
         with make_or_load_nwbfile(
             nwbfile_path=nwbfile_path, nwbfile=nwbfile, metadata=metadata, overwrite=overwrite, verbose=self.verbose
         ) as nwbfile_out:
-            write_subject_to_nwb(
+            self.loaded_modules["dlc2nwb.utils"].write_subject_to_nwb(
                 nwbfile=nwbfile_out,
                 h5file=str(self.source_data["file_path"]),
                 individual_name=self.subject_name,

--- a/src/neuroconv/utils/__init__.py
+++ b/src/neuroconv/utils/__init__.py
@@ -19,5 +19,5 @@ from .json_schema import (
     get_metadata_schema_for_icephys,
 )
 from .globbing import decompose_f_string, parse_f_string
-
 from .checks import calculate_regular_series_rate
+from .imports import safe_import

--- a/src/neuroconv/utils/imports.py
+++ b/src/neuroconv/utils/imports.py
@@ -1,0 +1,15 @@
+"""Helper functions for performing more complicated import operations."""
+import importlib
+from typing import Optional
+
+
+def safe_import(module_name: str, pypi_package_name: Optional[str] = None):
+    """Import a module if it is installed or raise a more informative installation error if not."""
+    try:
+        return importlib.import_module(name=module_name)
+    except ModuleNotFoundError:
+        pypi_package_display_name = pypi_package_name or module_name
+        raise ModuleNotFoundError(
+            f"\nThe attempt to import '{module_name}' failed!\n"
+            f"To install this package, please run\n\n\tpip install {pypi_package_display_name}\n"
+        )


### PR DESCRIPTION
Another alternative to #71 that is a bit more sophisticated than #74.

A couple ideas going on here

i. Define a general utility method for safely importing a module if it is installed and giving a more informative error message to perform the installation if not. This method could be used to reduce code around the repo any time we use that type of lazy import logic.

ii. Define two new attributes internal to any `DataInterface` - the user would not even need to know they are there. The first is the `modules_to_import`, which is just a list of all the names of modules that one would need to load for the interface. The second is `loaded_modules` (should maybe be renamed to 'imported_modules'?) which is a dictionary mapping from all those strings in `modules_to_import` to the actual modules themselves. The loading of the modules is performed as a generic step in the `__init__` common to all data interfaces, though this part may need small adjustments for appropriate behavior depending on how customized the most downstream initialization is for any particular interface. This workflow adjustment could also be done a bit more effectively by making the `__init__` of any interface focus on module loading and setting up other class attributes, with a `__post_init__` steep for the recording/sorting/imaging/segmentation interfaces where we actually initialize the extractor after successfully loading the required modules.

### Benefits

1. No break to back compatibility. All previous code imports will work in the same manner, and will also be faster due to less global overhead.

2. Acts at the same level as our lazy installation assertions (during interface `__init__`), so any problems with either will be caught after importing the NeuroConv library but before running the conversion. (errors should trigger during initialization of interface)

3. References to imported modules are readily available to a downstream user. Even using the current `main` branch, when I import a `DataInterface` I do not automatically import any associated modules, just the classes/objects of that module that have been attached to the interface. To use any of those modules I would have to re-import them in the script I'm using the data interface in to establish a reference. But this approach allows immediate use without re-establishing the reference since the reference is attached to the interface itself. Granted, there aren't too many situations you'd actually want to use this in.

### Drawbacks

a. Goes against a spirit of [PEP8 import styling](https://pep8.org/#imports)

> Imports are always put at the top of the file, just after any module comments and docstrings, and before module globals and constants.

which is in place to detect any import errors prior to attempting to run any code. Though another common exception to this PEP standard is to do what is suggested here as a measure to avoid circular dependencies (not our issue, but tangentially related).

b. Unsure as of yet, but could be a bit 'touchy' as a generic property of every data interface. Also a more sophisticated thing to have to teach in the tutorials of creating custom data interfaces.