### PR TITLE
Demonstrate __getattr__ overload for lazy imports

### DIFF
--- a/docs/conversion_examples_gallery/behavior/deeplabcut.rst
+++ b/docs/conversion_examples_gallery/behavior/deeplabcut.rst
@@ -9,8 +9,7 @@ Convert DeepLabCut imaging data to NWB using :py:class:`~neuroconv.datainterface
     >>> from dateutil import tz
     >>> from pathlib import Path
     >>> from neuroconv import DeepLabCutInterface
-    Loading DLC 2.2.1.1...
-    DLC loaded in light mode; you cannot use any GUI (labeling, relabeling and standalone GUI)
+    ...
     >>>
     >>> file_path = BEHAVIOR_DATA_PATH / "DLC" / "m3v1mp4DLC_resnet50_openfieldAug20shuffle1_30000.h5"
     >>> config_file_path = BEHAVIOR_DATA_PATH / "DLC" / "config.yaml"

--- a/docs/conversion_examples_gallery/behavior/deeplabcut.rst
+++ b/docs/conversion_examples_gallery/behavior/deeplabcut.rst
@@ -3,24 +3,24 @@ DeepLabCut data conversion
 
 Convert DeepLabCut imaging data to NWB using :py:class:`~neuroconv.datainterfaces.behavior.deeplabcut.deeplabcutdatainterface.DeepLabCutInterface`.
 
-#.. code-block:: python
+.. code-block:: python
 
-#    >>> from datetime import datetime
-#    >>> from dateutil import tz
-#    >>> from pathlib import Path
-#    >>> from neuroconv import DeepLabCutInterface
-#    >>>
-#    >>> file_path = BEHAVIOR_DATA_PATH / "DLC" / "m3v1mp4DLC_resnet50_openfieldAug20shuffle1_30000.h5"
-#    >>> config_file_path = BEHAVIOR_DATA_PATH / "DLC" / "config.yaml"
-#    >>>
-#    >>> interface = DeepLabCutInterface(file_path=file_path, config_file_path=config_file_path, subject_name="ind1",
-#verbose=False)
-#    >>> metadata = interface.get_metadata()
-##    >>> # For data provenance we add the time zone information to the conversion
-#    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=tz.gettz("US/Pacific"))
-#    >>> metadata["NWBFile"].update(session_start_time=session_start_time)
-#    >>> # Choose a path for saving the nwb file and run the conversion
-#    >>> interface.run_conversion(nwbfile_path=path_to_save_nwbfile, metadata=metadata)
-#    >>> # If the conversion was successful this should evaluate to ``True`` as the file was created.
-#    >>> Path(path_to_save_nwbfile).is_file()
-#    True
+    >>> from datetime import datetime
+    >>> from dateutil import tz
+    >>> from pathlib import Path
+    >>> from neuroconv import DeepLabCutInterface
+    >>>
+    >>> file_path = BEHAVIOR_DATA_PATH / "DLC" / "m3v1mp4DLC_resnet50_openfieldAug20shuffle1_30000.h5"
+    >>> config_file_path = BEHAVIOR_DATA_PATH / "DLC" / "config.yaml"
+    >>>
+    >>> interface = DeepLabCutInterface(file_path=file_path, config_file_path=config_file_path, subject_name="ind1",
+verbose=False)
+    >>> metadata = interface.get_metadata()
+    >>> # For data provenance we add the time zone information to the conversion
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=tz.gettz("US/Pacific"))
+    >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Choose a path for saving the nwb file and run the conversion
+    >>> interface.run_conversion(nwbfile_path=path_to_save_nwbfile, metadata=metadata)
+    >>> # If the conversion was successful this should evaluate to ``True`` as the file was created.
+    >>> Path(path_to_save_nwbfile).is_file()
+    True

--- a/docs/conversion_examples_gallery/behavior/deeplabcut.rst
+++ b/docs/conversion_examples_gallery/behavior/deeplabcut.rst
@@ -9,12 +9,13 @@ Convert DeepLabCut imaging data to NWB using :py:class:`~neuroconv.datainterface
     >>> from dateutil import tz
     >>> from pathlib import Path
     >>> from neuroconv import DeepLabCutInterface
+    Loading DLC 2.2.1.1...
+    DLC loaded in light mode; you cannot use any GUI (labeling, relabeling and standalone GUI)
     >>>
     >>> file_path = BEHAVIOR_DATA_PATH / "DLC" / "m3v1mp4DLC_resnet50_openfieldAug20shuffle1_30000.h5"
     >>> config_file_path = BEHAVIOR_DATA_PATH / "DLC" / "config.yaml"
     >>>
-    >>> interface = DeepLabCutInterface(file_path=file_path, config_file_path=config_file_path, subject_name="ind1",
-verbose=False)
+    >>> interface = DeepLabCutInterface(file_path=file_path, config_file_path=config_file_path, subject_name="ind1", verbose=False)
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=tz.gettz("US/Pacific"))

--- a/src/neuroconv/__init__.py
+++ b/src/neuroconv/__init__.py
@@ -1,4 +1,11 @@
 from .nwbconverter import NWBConverter
-from .datainterfaces import *
 from .tools import spikeinterface, roiextractors, neo
 from .tools.yaml_conversion_specification import run_conversion_from_yaml
+
+
+def __getattr__(name: str):
+    from importlib import import_module
+
+    interface_location = dict(DeepLabCutInterface="datainterfaces.behavior.deeplabcut")
+    if name == "DeepLabCutInterface":
+        return getattr(import_module("." + interface_location[name], __name__), name)

--- a/tests/test_on_data/test_gin_behavior.py
+++ b/tests/test_on_data/test_gin_behavior.py
@@ -1,12 +1,12 @@
 import unittest
 from datetime import datetime
-from parameterized import parameterized, param
+from parameterized import parameterized
 
 from pynwb import NWBHDF5IO
+
 from neuroconv import NWBConverter
 from neuroconv.datainterfaces.behavior.movie import MovieInterface
-
-# from neuroconv.datainterfaces.behavior.deeplabcut import DeepLabCutInterface
+from neuroconv import DeepLabCutInterface
 
 from .setup_paths import OUTPUT_PATH, BEHAVIOR_DATA_PATH
 


### PR DESCRIPTION
Demonstration of comment: https://github.com/catalystneuro/neuroconv/pull/71#discussion_r939743746

If implemented for the other interfaces, would resolve the break in back-compatability while still granting the performance and safety improvement offered by lazier external imports.

Works for me locally but we'll see what the CI says in the morning.