### PR TITLE
[Hotfix]: disable auto-import of DLC interface

### DIFF
--- a/docs/conversion_examples_gallery/behavior/deeplabcut.rst
+++ b/docs/conversion_examples_gallery/behavior/deeplabcut.rst
@@ -5,21 +5,20 @@ Convert DeepLabCut imaging data to NWB using :py:class:`~neuroconv.datainterface
 
 .. code-block:: python
 
-    >>> from datetime import datetime
-    >>> from dateutil import tz
-    >>> from pathlib import Path
-    >>> from neuroconv import DeepLabCutInterface
-    >>>
-    >>> file_path = BEHAVIOR_DATA_PATH / "DLC" / "m3v1mp4DLC_resnet50_openfieldAug20shuffle1_30000.h5"
-    >>> config_file_path = BEHAVIOR_DATA_PATH / "DLC" / "config.yaml"
-    >>>
-    >>> interface = DeepLabCutInterface(file_path=file_path, config_file_path=config_file_path, subject_name="ind1", verbose=False)
-    >>> metadata = interface.get_metadata()
-    >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=tz.gettz("US/Pacific"))
-    >>> metadata["NWBFile"].update(session_start_time=session_start_time)
-    >>> # Choose a path for saving the nwb file and run the conversion
-    >>> interface.run_conversion(nwbfile_path=path_to_save_nwbfile, metadata=metadata)
-    >>> # If the conversion was successful this should evaluate to ``True`` as the file was created.
-    >>> Path(path_to_save_nwbfile).is_file()
-    True
+     from datetime import datetime
+     from dateutil import tz
+     from pathlib import Path
+     from neuroconv import DeepLabCutInterface
+    
+     file_path = BEHAVIOR_DATA_PATH / "DLC" / "m3v1mp4DLC_resnet50_openfieldAug20shuffle1_30000.h5"
+     config_file_path = BEHAVIOR_DATA_PATH / "DLC" / "config.yaml"
+    
+     interface = DeepLabCutInterface(file_path=file_path, config_file_path=config_file_path, subject_name="ind1", verbose=False)
+     metadata = interface.get_metadata()
+     # For data provenance we add the time zone information to the conversion
+     session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=tz.gettz("US/Pacific"))
+     metadata["NWBFile"].update(session_start_time=session_start_time)
+     # Choose a path for saving the nwb file and run the conversion
+     interface.run_conversion(nwbfile_path=path_to_save_nwbfile, metadata=metadata)
+     # If the conversion was successful this should evaluate to ``True`` as the file was created.
+     Path(path_to_save_nwbfile).is_file()

--- a/docs/conversion_examples_gallery/behavior/deeplabcut.rst
+++ b/docs/conversion_examples_gallery/behavior/deeplabcut.rst
@@ -9,10 +9,10 @@ Convert DeepLabCut imaging data to NWB using :py:class:`~neuroconv.datainterface
      from dateutil import tz
      from pathlib import Path
      from neuroconv import DeepLabCutInterface
-    
+
      file_path = BEHAVIOR_DATA_PATH / "DLC" / "m3v1mp4DLC_resnet50_openfieldAug20shuffle1_30000.h5"
      config_file_path = BEHAVIOR_DATA_PATH / "DLC" / "config.yaml"
-    
+
      interface = DeepLabCutInterface(file_path=file_path, config_file_path=config_file_path, subject_name="ind1", verbose=False)
      metadata = interface.get_metadata()
      # For data provenance we add the time zone information to the conversion

--- a/src/neuroconv/datainterfaces/__init__.py
+++ b/src/neuroconv/datainterfaces/__init__.py
@@ -46,7 +46,8 @@ from .ophys.hdf5.hdf5datainterface import Hdf5ImagingInterface
 from .ophys.scanimage.scanimageimaginginterface import ScanImageImagingInterface
 
 from .behavior.movie.moviedatainterface import MovieInterface
-from .behavior.deeplabcut.deeplabcutdatainterface import DeepLabCutInterface
+
+# from .behavior.deeplabcut.deeplabcutdatainterface import DeepLabCutInterface  # Causing problem on M1 macs. See PR #71
 
 from .icephys.abf.abfdatainterface import AbfInterface
 
@@ -87,7 +88,7 @@ interface_list = [
     TiffImagingInterface,
     Hdf5ImagingInterface,
     MovieInterface,
-    DeepLabCutInterface,
+    # DeepLabCutInterface,
     AbfInterface,
     ScanImageImagingInterface,
     EDFRecordingInterface,

--- a/tests/test_on_data/test_gin_behavior.py
+++ b/tests/test_on_data/test_gin_behavior.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from parameterized import parameterized, param
 
 from pynwb import NWBHDF5IO
-from neuroconv import NWBConverter, MovieInterface, DeepLabCutInterface
+from neuroconv import NWBConverter, MovieInterface
+
+from neuroconv.datainterfaces.behavior.deeplabcut.deeplabcutinterface import DeepLabCutInterface
 
 from .setup_paths import OUTPUT_PATH, BEHAVIOR_DATA_PATH
 

--- a/tests/test_on_data/test_gin_behavior.py
+++ b/tests/test_on_data/test_gin_behavior.py
@@ -5,7 +5,7 @@ from parameterized import parameterized, param
 from pynwb import NWBHDF5IO
 from neuroconv import NWBConverter, MovieInterface
 
-from neuroconv.datainterfaces.behavior.deeplabcut.deeplabcutinterface import DeepLabCutInterface
+from neuroconv.datainterfaces.behavior.deeplabcut.deeplabcutdatainterface import DeepLabCutInterface
 
 from .setup_paths import OUTPUT_PATH, BEHAVIOR_DATA_PATH
 


### PR DESCRIPTION
Simpler fix for issue in PR #71 pending ecosystem-wide agreement on lazy import approach.

@bendichter can you test this resolves your issue for the time being?