### PR TITLE
Add unit tests for add electrical series IV (chunking) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Testing
 * Added unittests for correctly writing the scaling factors to the nwbfile in the `add_electrical_series` function of the spikeinterface module. [PR #37](https://github.com/catalystneuro/neuroconv/pull/37)
 * Added unittest for compresion options in the `add_electrical_series` function of the spikeinterface module. [PR #64](https://github.com/catalystneuro/neuroconv/pull/37)
+* Added unittests for chunking in the `add_electrical_series` function of the spikeinterface module. [PR #84](https://github.com/catalystneuro/neuroconv/pull/84)
 
 # v0.1.1
 ### Fixes

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -13,7 +13,7 @@ from spikeinterface import BaseRecording, BaseSorting
 from spikeinterface.core.old_api_utils import OldToNewRecording, OldToNewSorting
 from spikeextractors import RecordingExtractor, SortingExtractor
 from numbers import Real
-from hdmf.data_utils import DataChunkIterator
+from hdmf.data_utils import DataChunkIterator, AbstractDataChunkIterator
 from hdmf.backends.hdf5.h5_utils import H5DataIO
 import psutil
 
@@ -494,7 +494,36 @@ def iterize_recording_traces(
     return_scaled: bool = False,
     iterator_type: str = "v2",
     iterator_opts: dict = None,
-):
+) -> AbstractDataChunkIterator:
+    """Function to wrap traces of spikeinterface recording extractors on an iterator.
+
+    Parameters
+    ----------
+    recording : BaseRecording
+        A recording extractor from spikeinterface
+    segment_index : int, optional
+        The recording segment to add to the NWBFile.
+    return_scaled : bool, defaults to False
+        When True recording extractor objects from spikeinterface return their traces in microvolts.
+    iterator_type: str (optional, defaults to 'v2')
+        The type of DataChunkIterator to use.
+        'v1' is the original DataChunkIterator of the hdmf data_utils.
+        'v2' is the locally developed SpikeInterfaceRecordingDataChunkIterator, which offers full control over chunking.
+    iterator_opts: dict (optional)
+        Dictionary of options for the iterator.
+        See https://hdmf.readthedocs.io/en/stable/hdmf.data_utils.html#hdmf.data_utils.GenericDataChunkIterator
+        for the full list of options.
+
+    Returns
+    -------
+    traces_as_iterator: AbstractDataChunkIterator
+        The traces of the recording extractor wrapped in an iterator object.
+
+    Raises
+    ------
+    ValueError
+        If the iterator_type is not 'v1', 'v2' or None.
+    """
 
     supported_iterator_types = ["v1", "v2", None]
     if iterator_type not in supported_iterator_types:
@@ -542,6 +571,7 @@ def add_electrical_series(
     Parameters
     ----------
     recording: SpikeInterfaceRecording
+        A recording extractor from spikeinterface
     nwbfile: NWBFile
         nwb file to which the recording information is to be added
     metadata: dict
@@ -576,12 +606,9 @@ def add_electrical_series(
         'v2' is the locally developed SpikeInterfaceRecordingDataChunkIterator, which offers full control over chunking.
     iterator_opts: dict (optional)
         Dictionary of options for the iterator.
-        Valid options are
-            buffer_gb: float (optional, defaults to 1 GB)
-                Recommended to be as much free RAM as available. Automatically calculates suitable buffer shape.
-            chunk_mb: float (optional, defaults to 1 MB)
-                Should be below 1 MB. Automatically calculates suitable chunk shape.
-        If manual specification of buffer_shape and chunk_shape are desired, these may be specified as well.
+        See https://hdmf.readthedocs.io/en/stable/hdmf.data_utils.html#hdmf.data_utils.GenericDataChunkIterator
+        for the full list of options.
+
     Missing keys in an element of metadata['Ecephys']['ElectrodeGroup'] will be auto-populated with defaults
     whenever possible.
     """

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -495,16 +495,17 @@ def iterize_recording_traces(
     iterator_type: str = "v2",
     iterator_opts: dict = None,
 ):
-    supported_values = ["v1", "v2", None]
-    if iterator_type not in supported_values:
-        raise NotImplementedError(f"iterator_type ({iterator_type}) should be either 'v1', 'v2' (recommended) or None")
+
+    supported_iterator_types = ["v1", "v2", None]
+    if iterator_type not in supported_iterator_types:
+        message = f"iterator_type {iterator_type} should be either 'v1', 'v2' (recommended) or None"
+        raise ValueError(message)
 
     iterator_opts = dict() if iterator_opts is None else iterator_opts
 
     if iterator_type is None:
         check_if_recording_traces_fit_into_memory(recording=recording, segment_index=segment_index)
         traces_as_iterator = recording.get_traces(return_scaled=return_scaled, segment_index=segment_index)
-
     elif iterator_type == "v2":
         traces_as_iterator = SpikeInterfaceRecordingDataChunkIterator(
             recording=recording,
@@ -513,14 +514,9 @@ def iterize_recording_traces(
             **iterator_opts,
         )
     elif iterator_type == "v1":
-        if isinstance(recording.get_traces(end_frame=5, return_scaled=return_scaled), np.memmap) and np.all(
-            recording.get_channel_offsets() == 0
-        ):
-            traces_as_iterator = DataChunkIterator(
-                data=recording.get_traces(return_scaled=return_scaled), **iterator_opts
-            )
-        else:
-            raise ValueError("iterator_type='v1' only supports memmapable trace types! Use iterator_type='v2' instead.")
+        traces_as_iterator = DataChunkIterator(
+            data=recording.get_traces(return_scaled=return_scaled, segment_index=segment_index), **iterator_opts
+        )
 
     return traces_as_iterator
 

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -11,6 +11,8 @@ import pynwb.ecephys
 from spikeinterface.core.testing_tools import generate_recording, generate_sorting
 from spikeinterface.extractors import NumpyRecording
 from hdmf.backends.hdf5.h5_utils import H5DataIO
+from hdmf.data_utils import DataChunkIterator
+
 from hdmf.testing import TestCase
 
 
@@ -26,7 +28,6 @@ from neuroconv.tools.spikeinterface import (
 from neuroconv.tools.spikeinterface.spikeinterfacerecordingdatachunkiterator import (
     SpikeInterfaceRecordingDataChunkIterator,
 )
-from neuroconv.utils import FilePathType
 from neuroconv.tools.nwb_helpers import get_module
 
 testing_session_time = datetime.now().astimezone()
@@ -148,31 +149,8 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         assert compression_parameters["compression"] == compression
         assert "compression_opts" not in compression_parameters
 
-    def test_non_iterative_write(self):
 
-        # Estimate num of frames required to exceed memory capabilities
-        dtype = self.test_recording_extractor.get_dtype()
-        element_size_in_bytes = dtype.itemsize
-        num_channels = self.test_recording_extractor.get_num_channels()
-
-        available_memory_in_bytes = psutil.virtual_memory().available
-
-        excess = 1.5  # Of what is available in memory
-        num_frames_to_overflow = (available_memory_in_bytes * excess) / (element_size_in_bytes * num_channels)
-
-        # Mock recording extractor with as much frames as necessary to overflow memory
-        mock_recorder = Mock()
-        mock_recorder.get_dtype.return_value = dtype
-        mock_recorder.get_num_channels.return_value = num_channels
-        mock_recorder.get_num_frames.return_value = num_frames_to_overflow
-
-        reg_expression = f"Memory error, full electrical series is (.*?) GB are available. Use iterator_type='V2'"
-
-        with self.assertRaisesRegex(MemoryError, reg_expression):
-            check_if_recording_traces_fit_into_memory(recording=mock_recorder)
-
-
-class TestAddElectricalSeriesSavingTimestampsvsRates(unittest.TestCase):
+class TestAddElectricalSeriesSavingTimestampsVsRates(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Use common recording objects and values."""
@@ -375,6 +353,92 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, reg_expression):
             add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
+
+
+class TestAddElectricalSeriesChunking(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Use common recording objects and values."""
+        cls.sampling_frequency = 1.0
+        cls.num_channels = 3
+        cls.num_frames = 100
+        cls.channel_ids = ["a", "b", "c"]
+        cls.traces_list = [np.ones(shape=(cls.num_frames, cls.num_channels))]
+        # Flat traces [1, 1, 1] per channel
+        cls.test_recording_extractor = NumpyRecording(
+            cls.traces_list, cls.sampling_frequency, channel_ids=cls.channel_ids
+        )
+
+        # Combinations of gains and default
+        cls.gains_default = [1, 1, 1]
+        cls.offset_default = [0, 0, 0]
+
+        cls.test_recording_extractor.set_channel_gains(gains=cls.gains_default)
+        cls.test_recording_extractor.set_channel_offsets(offsets=cls.offset_default)
+
+    def setUp(self):
+        """Start with a fresh NWBFile, ElectrodeTable, and remapped BaseRecordings each time."""
+        self.nwbfile = NWBFile(
+            session_description="session_description1", identifier="file_id1", session_start_time=testing_session_time
+        )
+
+    def test_default_chunking(self):
+
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile)
+
+        acquisition_module = self.nwbfile.acquisition
+        electrical_series = acquisition_module["ElectricalSeries_raw"]
+        h5dataiowrapped_electrical_series = electrical_series.data
+        electrical_series_data_as_iterator = h5dataiowrapped_electrical_series.data
+
+        assert isinstance(electrical_series_data_as_iterator, SpikeInterfaceRecordingDataChunkIterator)
+
+    def test_iterator_opts_propagation(self):
+        iterator_opts = dict(chunk_shape=(10, 3))
+        add_electrical_series(
+            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_opts=iterator_opts
+        )
+
+        acquisition_module = self.nwbfile.acquisition
+        electrical_series = acquisition_module["ElectricalSeries_raw"]
+        h5dataiowrapped_electrical_series = electrical_series.data
+        electrical_series_data_as_iterator = h5dataiowrapped_electrical_series.data
+
+        assert electrical_series_data_as_iterator.chunk_shape == iterator_opts["chunk_shape"]
+
+    def test_old_iterator(self):
+
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type="v1")
+
+        acquisition_module = self.nwbfile.acquisition
+        electrical_series = acquisition_module["ElectricalSeries_raw"]
+        h5dataiowrapped_electrical_series = electrical_series.data
+        electrical_series_data_as_iterator = h5dataiowrapped_electrical_series.data
+
+        assert isinstance(electrical_series_data_as_iterator, DataChunkIterator)
+
+    def test_non_iterative_write(self):
+
+        # Estimate num of frames required to exceed memory capabilities
+        dtype = self.test_recording_extractor.get_dtype()
+        element_size_in_bytes = dtype.itemsize
+        num_channels = self.test_recording_extractor.get_num_channels()
+
+        available_memory_in_bytes = psutil.virtual_memory().available
+
+        excess = 1.5  # Of what is available in memory
+        num_frames_to_overflow = (available_memory_in_bytes * excess) / (element_size_in_bytes * num_channels)
+
+        # Mock recording extractor with as much frames as necessary to overflow memory
+        mock_recorder = Mock()
+        mock_recorder.get_dtype.return_value = dtype
+        mock_recorder.get_num_channels.return_value = num_channels
+        mock_recorder.get_num_frames.return_value = num_frames_to_overflow
+
+        reg_expression = f"Memory error, full electrical series is (.*?) GB are available. Use iterator_type='V2'"
+
+        with self.assertRaisesRegex(MemoryError, reg_expression):
+            check_if_recording_traces_fit_into_memory(recording=mock_recorder)
 
 
 class TestAddElectrodes(TestCase):


### PR DESCRIPTION
Following on #64 and #37 this PR adds unit tests for the chunking capabilities of `add_electrical_series` and refactors the function  with a separation of the functionality for wrapping the traces in an iterator in a separate function.