### PR TITLE
Add spikeinterface support to AxonaLFP 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 * Coerced the recording extractors with `spikeextractors_backend=True` to BaseRecording objects for Axona, Blackrock, Openephys, and SpikeGadgets. [PR #38](https://github.com/catalystneuro/neuroconv/pull/38)
 * Added function to add PlaneSegmentation objects to an nwbfile in `roiextractors` and corresponding unit tests. [PR #23](https://github.com/catalystneuro/neuroconv/pull/23)
 * `use_times` argument to be deprecated on the ecephys pipeline. The function `add_electrical_series` now determines whether the timestamps of the spikeinterface recording extractor are uniform or not and automatically stores the data according to best practices [PR #40](https://github.com/catalystneuro/neuroconv/pull/40)
-* Add `NWBFile` metadata key at the level of the base data interface so it can always be inherited to be available. [PR #51](https://github.com/catalystneuro/neuroconv/pull/51)
+* Add `NWBFile` metadata key at the level of the base data interface so it can always be inherited to be available. [PR #51](https://github.com/catalystneuro/neuroconv/pull/51).
+* Added spikeinterface support to Axona LFP and coerece gin tests for LFP to be spikeinterface objects [PR #85](https://github.com/catalystneuro/neuroconv/pull/85)
+
 
 ### Documentation and tutorial enhancements:
 * Unified the documentation of NeuroConv structure in the User Guide readthedocs. [PR #39](https://github.com/catalystneuro/neuroconv/pull/39)
@@ -27,6 +29,7 @@
 ### Testing
 * Added unittests for correctly writing the scaling factors to the nwbfile in the `add_electrical_series` function of the spikeinterface module. [PR #37](https://github.com/catalystneuro/neuroconv/pull/37)
 * Added unittest for compresion options in the `add_electrical_series` function of the spikeinterface module. [PR #64](https://github.com/catalystneuro/neuroconv/pull/37)
+* Added unittests for chunking in the `add_electrical_series` function of the spikeinterface module. [PR #84](https://github.com/catalystneuro/neuroconv/pull/84)
 
 # v0.1.1
 ### Fixes

--- a/src/neuroconv/datainterfaces/ecephys/axona/axona_utils.py
+++ b/src/neuroconv/datainterfaces/ecephys/axona/axona_utils.py
@@ -19,11 +19,11 @@ def get_eeg_sampling_frequency(file_path: FilePathType):
         Full file_path of Axona `.eegX` or `.egfX` file.
     Returns:
     --------
-    Fs : int
+    Fs : float
         Sampling frequency
     """
     Fs_entry = parse_generic_header(file_path, ["sample_rate"])
-    Fs = int(float(Fs_entry.get("sample_rate").split(" ")[0]))
+    Fs = float(Fs_entry.get("sample_rate").split(" ")[0])
 
     return Fs
 

--- a/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
@@ -1,7 +1,7 @@
 """Authors: Heberto Mayorquin, Steffen Buergers."""
 
 import spikeextractors as se
-from spikeinterface.extractors import AxonaRecordingExtractor
+from spikeinterface.extractors import AxonaRecordingExtractor, NumpyRecording
 
 from pynwb import NWBFile
 
@@ -113,7 +113,7 @@ class AxonaUnitRecordingExtractorInterface(AxonaRecordingExtractorInterface):
 class AxonaLFPDataInterface(BaseLFPExtractorInterface):
     """..."""
 
-    RX = se.NumpyRecordingExtractor
+    RX = NumpyRecording
 
     @classmethod
     def get_source_schema(cls):
@@ -125,9 +125,11 @@ class AxonaLFPDataInterface(BaseLFPExtractorInterface):
         )
 
     def __init__(self, file_path: FilePathType):
-        super().__init__(
-            timeseries=read_all_eeg_file_lfp_data(file_path), sampling_frequency=get_eeg_sampling_frequency(file_path)
-        )
+
+        data = read_all_eeg_file_lfp_data(file_path).T
+        sampling_frequency = get_eeg_sampling_frequency(file_path)
+        super().__init__(traces_list=[data], sampling_frequency=sampling_frequency)
+
         self.source_data = dict(file_path=file_path)
 
 

--- a/tests/test_internals/test_si.py
+++ b/tests/test_internals/test_si.py
@@ -11,6 +11,8 @@ import pynwb.ecephys
 from spikeinterface.core.testing_tools import generate_recording, generate_sorting
 from spikeinterface.extractors import NumpyRecording
 from hdmf.backends.hdf5.h5_utils import H5DataIO
+from hdmf.data_utils import DataChunkIterator
+
 from hdmf.testing import TestCase
 
 
@@ -26,7 +28,6 @@ from neuroconv.tools.spikeinterface import (
 from neuroconv.tools.spikeinterface.spikeinterfacerecordingdatachunkiterator import (
     SpikeInterfaceRecordingDataChunkIterator,
 )
-from neuroconv.utils import FilePathType
 from neuroconv.tools.nwb_helpers import get_module
 
 testing_session_time = datetime.now().astimezone()
@@ -148,31 +149,8 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         assert compression_parameters["compression"] == compression
         assert "compression_opts" not in compression_parameters
 
-    def test_non_iterative_write(self):
 
-        # Estimate num of frames required to exceed memory capabilities
-        dtype = self.test_recording_extractor.get_dtype()
-        element_size_in_bytes = dtype.itemsize
-        num_channels = self.test_recording_extractor.get_num_channels()
-
-        available_memory_in_bytes = psutil.virtual_memory().available
-
-        excess = 1.5  # Of what is available in memory
-        num_frames_to_overflow = (available_memory_in_bytes * excess) / (element_size_in_bytes * num_channels)
-
-        # Mock recording extractor with as much frames as necessary to overflow memory
-        mock_recorder = Mock()
-        mock_recorder.get_dtype.return_value = dtype
-        mock_recorder.get_num_channels.return_value = num_channels
-        mock_recorder.get_num_frames.return_value = num_frames_to_overflow
-
-        reg_expression = f"Memory error, full electrical series is (.*?) GB are available. Use iterator_type='V2'"
-
-        with self.assertRaisesRegex(MemoryError, reg_expression):
-            check_if_recording_traces_fit_into_memory(recording=mock_recorder)
-
-
-class TestAddElectricalSeriesSavingTimestampsvsRates(unittest.TestCase):
+class TestAddElectricalSeriesSavingTimestampsVsRates(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Use common recording objects and values."""
@@ -375,6 +353,117 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, reg_expression):
             add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
+
+
+class TestAddElectricalSeriesChunking(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Use common recording objects and values."""
+        cls.sampling_frequency = 1.0
+        cls.num_channels = 3
+        cls.num_frames = 20
+        cls.channel_ids = ["a", "b", "c"]
+        cls.traces_list = [np.ones(shape=(cls.num_frames, cls.num_channels))]
+        # Flat traces [1, 1, 1] per channel
+        cls.test_recording_extractor = NumpyRecording(
+            cls.traces_list, cls.sampling_frequency, channel_ids=cls.channel_ids
+        )
+
+        # Combinations of gains and default
+        cls.gains_default = [2, 2, 2]
+        cls.offset_default = [1, 1, 1]
+
+        cls.test_recording_extractor.set_channel_gains(gains=cls.gains_default)
+        cls.test_recording_extractor.set_channel_offsets(offsets=cls.offset_default)
+
+    def setUp(self):
+        """Start with a fresh NWBFile, ElectrodeTable, and remapped BaseRecordings each time."""
+        self.nwbfile = NWBFile(
+            session_description="session_description1", identifier="file_id1", session_start_time=testing_session_time
+        )
+
+    def test_default_chunking(self):
+
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile)
+
+        acquisition_module = self.nwbfile.acquisition
+        electrical_series = acquisition_module["ElectricalSeries_raw"]
+        h5dataiowrapped_electrical_series = electrical_series.data
+        electrical_series_data_iterator = h5dataiowrapped_electrical_series.data
+
+        assert isinstance(electrical_series_data_iterator, SpikeInterfaceRecordingDataChunkIterator)
+
+        extracted_data = np.concatenate([data_chunk.data for data_chunk in electrical_series_data_iterator])
+        expected_data = self.test_recording_extractor.get_traces(segment_index=0)
+        np.testing.assert_array_almost_equal(expected_data, extracted_data)
+
+    def test_iterator_opts_propagation(self):
+        iterator_opts = dict(chunk_shape=(10, 3))
+        add_electrical_series(
+            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_opts=iterator_opts
+        )
+
+        acquisition_module = self.nwbfile.acquisition
+        electrical_series = acquisition_module["ElectricalSeries_raw"]
+        h5dataiowrapped_electrical_series = electrical_series.data
+        electrical_series_data_iterator = h5dataiowrapped_electrical_series.data
+
+        assert electrical_series_data_iterator.chunk_shape == iterator_opts["chunk_shape"]
+
+    def test_hdfm_iterator(self):
+
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type="v1")
+
+        acquisition_module = self.nwbfile.acquisition
+        electrical_series = acquisition_module["ElectricalSeries_raw"]
+        h5dataiowrapped_electrical_series = electrical_series.data
+        electrical_series_data_iterator = h5dataiowrapped_electrical_series.data
+
+        assert isinstance(electrical_series_data_iterator, DataChunkIterator)
+
+        extracted_data = np.concatenate([data_chunk.data for data_chunk in electrical_series_data_iterator])
+        expected_data = self.test_recording_extractor.get_traces(segment_index=0)
+        np.testing.assert_array_almost_equal(expected_data, extracted_data)
+
+    def test_non_iterative_write(self):
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
+
+        acquisition_module = self.nwbfile.acquisition
+        electrical_series = acquisition_module["ElectricalSeries_raw"]
+        isinstance(electrical_series.data, np.ndarray)
+
+    def test_non_iterative_write_assertion(self):
+
+        # Estimate num of frames required to exceed memory capabilities
+        dtype = self.test_recording_extractor.get_dtype()
+        element_size_in_bytes = dtype.itemsize
+        num_channels = self.test_recording_extractor.get_num_channels()
+
+        available_memory_in_bytes = psutil.virtual_memory().available
+
+        excess = 1.5  # Of what is available in memory
+        num_frames_to_overflow = (available_memory_in_bytes * excess) / (element_size_in_bytes * num_channels)
+
+        # Mock recording extractor with as much frames as necessary to overflow memory
+        mock_recorder = Mock()
+        mock_recorder.get_dtype.return_value = dtype
+        mock_recorder.get_num_channels.return_value = num_channels
+        mock_recorder.get_num_frames.return_value = num_frames_to_overflow
+
+        reg_expression = f"Memory error, full electrical series is (.*?) GB are available. Use iterator_type='V2'"
+
+        with self.assertRaisesRegex(MemoryError, reg_expression):
+            check_if_recording_traces_fit_into_memory(recording=mock_recorder)
+
+    def test_invalid_iterator_type_assertion(self):
+
+        iterator_type = "invalid_iterator_type"
+
+        reg_expression = "iterator_type (.*?)"
+        with self.assertRaisesRegex(ValueError, reg_expression):
+            add_electrical_series(
+                recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=iterator_type
+            )
 
 
 class TestAddElectrodes(TestCase):

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -96,22 +96,17 @@ class TestEcephysNwbConversions(unittest.TestCase):
             nwb_lfp_electrical_series = nwbfile.processing["ecephys"]["LFP"]["ElectricalSeries_lfp"]
             nwb_lfp_unscaled = nwb_lfp_electrical_series.data[:]
             nwb_lfp_conversion = nwb_lfp_electrical_series.conversion
-            # Technically, check_recordings_equal only tests a snippet of data. Above tests are for metadata mostly.
-            # For GIN test data, sizes should be OK to load all into RAM even on CI
-            if isinstance(recording, RecordingExtractor):
-                npt.assert_array_equal(x=recording.get_traces(return_scaled=False).T, y=nwb_lfp_unscaled)
-                npt.assert_array_almost_equal(
-                    x=recording.get_traces(return_scaled=True).T * 1e-6, y=nwb_lfp_unscaled * nwb_lfp_conversion
-                )
-            else:
-                npt.assert_array_equal(x=recording.get_traces(return_scaled=False), y=nwb_lfp_unscaled)
-                # This can only be tested if both gain and offest are present
-                if recording.has_scaled_traces():
-                    nwb_lfp_conversion_vector = nwb_lfp_electrical_series.channel_conversion[:]
-                    nwb_lfp_offset = nwb_lfp_electrical_series.offset
-                    recording_data_volts = recording.get_traces(return_scaled=True) * 1e-6
-                    nwb_data_volts = nwb_lfp_unscaled * nwb_lfp_conversion_vector * nwb_lfp_conversion + nwb_lfp_offset
-                    npt.assert_array_almost_equal(x=recording_data_volts, y=nwb_data_volts)
+            if not isinstance(recording, BaseRecording):
+                raise ValueError("recordings of interfaces should be BaseRecording objects from spikeinterface ")
+
+            npt.assert_array_equal(x=recording.get_traces(return_scaled=False), y=nwb_lfp_unscaled)
+            # This can only be tested if both gain and offest are present
+            if recording.has_scaled_traces():
+                nwb_lfp_conversion_vector = nwb_lfp_electrical_series.channel_conversion[:]
+                nwb_lfp_offset = nwb_lfp_electrical_series.offset
+                recording_data_volts = recording.get_traces(return_scaled=True) * 1e-6
+                nwb_data_volts = nwb_lfp_unscaled * nwb_lfp_conversion_vector * nwb_lfp_conversion + nwb_lfp_offset
+                npt.assert_array_almost_equal(x=recording_data_volts, y=nwb_data_volts)
 
     parameterized_recording_list = [
         param(


### PR DESCRIPTION
This PR does two things:
1) Adds spikeinterface supports for the Axona LFP interface.
2) Now that all our of LFP interfaces support spikeinterface the gin tests for LFP can be simplified in the same way as #38 did for the raw recorders.

This forms part of a bigger effort as described on:
#60