### PR TITLE
Update some Imaging default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   The df over f traces are now added to a `DfOverF` container instead of the `Fluorescence` container.
   The metadata schema has been changed for the `BaseSegmentationExtractorInterface` to allow metadata for `DfOverF`,
   and `Flurorescence` is now not required in the metadata schema. [PR #41](https://github.com/catalystneuro/neuroconv/pull/41)
+* Improved default values of OpticalChannel object names and other descriptions for Imaging data. [PR #88](https://github.com/catalystneuro/neuroconv/pull/88)
 
 ### Documentation and tutorial enhancements:
 * Unified the documentation of NeuroConv structure in the User Guide readthedocs. [PR #39](https://github.com/catalystneuro/neuroconv/pull/39)

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -47,12 +47,12 @@ def get_default_ophys_metadata():
     default_optical_channel = dict(
         name="OpticalChannel",
         emission_lambda=np.nan,
-        description="no description",
+        description="An optical channel of the microscope.",
     )
 
     default_imaging_plane = dict(
         name="ImagingPlane",
-        description="no description",
+        description="The plane or volume being imaged by the microscope.",
         excitation_lambda=np.nan,
         indicator="unknown",
         location="unknown",
@@ -61,7 +61,7 @@ def get_default_ophys_metadata():
     )
 
     default_fluorescence_roi_response_series = dict(
-        name="RoiResponseSeries", description="array of raw fluorescence traces", unit="n.a."
+        name="RoiResponseSeries", description="Array of raw fluorescence traces.", unit="n.a."
     )
 
     default_fluorescence = dict(
@@ -69,7 +69,7 @@ def get_default_ophys_metadata():
         roi_response_series=[default_fluorescence_roi_response_series],
     )
 
-    default_dff_roi_response_series = dict(name="RoiResponseSeries", description="array of df/F traces", unit="n.a.")
+    default_dff_roi_response_series = dict(name="RoiResponseSeries", description="Array of df/F traces.", unit="n.a.")
 
     default_df_over_f = dict(
         name="DfOverF",
@@ -78,8 +78,7 @@ def get_default_ophys_metadata():
 
     default_two_photon_series = dict(
         name="TwoPhotonSeries",
-        description="no description",
-        comments="Generalized from RoiInterface",
+        description="Imaging data from two-photon excitation microscopy.",
         unit="n.a.",
     )
 
@@ -116,11 +115,12 @@ def get_nwb_imaging_metadata(imgextractor: ImagingExtractor):
     imgextractor: ImagingExtractor
     """
     metadata = get_default_ophys_metadata()
-    # Optical Channel name:
-    channel_name_list = imgextractor.get_channel_names()
-    if channel_name_list is None:
-        channel_name_list = ["OpticalChannel"] * imgextractor.get_num_channels()
 
+    channel_name_list = imgextractor.get_channel_names() or (
+        ["OpticalChannel"]
+        if imgextractor.get_num_channels() == 1
+        else [f"OpticalChannel{idx}" for idx in range(imgextractor.get_num_channels())]
+    )
     for index, channel_name in enumerate(channel_name_list):
         if index == 0:
             metadata["Ophys"]["ImagingPlane"][0]["optical_channel"][index]["name"] = channel_name
@@ -129,7 +129,7 @@ def get_nwb_imaging_metadata(imgextractor: ImagingExtractor):
                 dict(
                     name=channel_name,
                     emission_lambda=np.nan,
-                    description=f"{channel_name} description",
+                    description="An optical channel of the microscope.",
                 )
             )
     # set imaging plane rate:

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -119,7 +119,7 @@ def get_nwb_imaging_metadata(imgextractor: ImagingExtractor):
     # Optical Channel name:
     channel_name_list = imgextractor.get_channel_names()
     if channel_name_list is None:
-        channel_name_list = ["generic_name"] * imgextractor.get_num_channels()
+        channel_name_list = ["OpticalChannel"] * imgextractor.get_num_channels()
 
     for index, channel_name in enumerate(channel_name_list):
         if index == 0:


### PR DESCRIPTION
While converting some data, I noticed the default name for the optical channels isn't as good as it could be.

![image](https://user-images.githubusercontent.com/51133164/184553756-40eabc3c-c703-4bb2-87d7-a199d18c1003.png)

So I've updated the default naming of OpticalChannel objects to match the class name.

Also a couple other improvements to default descriptions.


## Checklist

- [X] Have you thoroughly read our [Developer Guide](https://neuroconv.readthedocs.io/en/main/developer_guide.html)?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/neuroconv/pulls) for the same change?
- [X] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
- [x] Did you update the [CHANGLOG.md](https://github.com/catalystneuro/neuroconv/blob/main/CHANGELOG.md) file on your branch to describe your changes?
