### PR TITLE
Upload cache to S3 bucket

### DIFF
--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -115,7 +115,7 @@ jobs:
           command: sync
           source: behavior_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: --exclude "behavior_testing_data/.gitignore" --exclude ".gitignore" --exclude "/.gitignore" --exclude "./.gitignore" --exclude "*/.gitignore" --exclude "*.gitignore" 
+          flags: --delete
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -23,6 +23,8 @@ jobs:
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"
 
+
+
       - name: Get ephys_testing_data current head hash
         id: ephys
         run: echo "::set-output name=HASH_EPHY_DATASET::$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"
@@ -31,7 +33,7 @@ jobs:
         id: cache-ephys-datasets
         with:
           path: ./ephy_testing_data
-          key: ecephys-datasets-041422-ubuntu-latest-${{ steps.ecephys.outputs.HASH_EPHY_DATASET }}
+          key: ephys-datasets-081922-ubuntu-latest-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
           
       - name: Get ophys_testing_data current head hash
         id: ophys

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -85,7 +85,7 @@ jobs:
           command: sync
           source: ./ephy_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data
-          flags: --exclude "*"
+          flags: --include "neuroscope" --exclude "*"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -80,14 +80,15 @@ jobs:
           cd ..
       - name: Upload ephys dataset to S3
         # if: steps.cache-ephys-datasets.outputs.cache-hit == false
-        uses: jakejarvis/s3-sync-action@master
+        uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
-          args: --exclude '*' --include 'ephy_testing_data/neuroscope/*'
-        env:
-          AWS_S3_BUCKET: ${{ secrets.S3_GIN_BUCKET_ARN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: "us-east-2"
+          command: sync
+          source: .
+          destination: ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data
+          flags: --dryrun --exclude '*' --include 'ephy_testing_data/neuroscope/*'
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-east-2
 
       - name: "Force GIN: ophys download"
         if: steps.cache-ophys-datasets.outputs.cache-hit == false

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -115,7 +115,7 @@ jobs:
           command: sync
           source: ./behavior_testing_data/
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: --follow-symlinks --exclude '.git/*' --exclude '.gitattributes/*' --exclude "*gitignore*" --exclude '.datalad/*'
+          flags: --follow-symlinks --exclude "./behavior_testing_data/.gitignore" 
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -115,7 +115,7 @@ jobs:
           command: sync
           source: behavior_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: "--follow-symlinks --exclude='.git/*' --exclude='.gitattributes/*' --exclude='.gitignore' --exclude='*.py' --exclude='*.md' --only-show-errors"
+          flags: "--follow-symlinks --exclude '.git/*' --exclude '.gitattributes/*' --exclude '.gitignore' --exclude '.datalad/*'"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           command: cp
           source: ./ophys_testing_data
-          destination: ${{ secrets.S3_GIN_BUCKET }}
+          destination: ${{ secrets.S3_GIN_BUCKET }}/ophys_testing_data
           flags: "--recursive"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -88,7 +88,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-2
-          SOURCE_DIR: ephy_testing_data
+          SOURCE_DIR: ./ephy_testing_data
 
       - name: "Force GIN: ophys download"
         if: steps.cache-ophys-datasets.outputs.cache-hit == false

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -113,7 +113,7 @@ jobs:
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: sync
-          source: /behavior_testing_data/
+          source: ./behavior_testing_data/
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
           flags: --follow-symlinks --exclude '.git/*' --exclude '.gitattributes/*' --exclude "*.gitignore" --exclude '.datalad/*'
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -31,7 +31,7 @@ jobs:
         id: cache-ephys-datasets
         with:
           path: ./ephy_testing_data
-          key: ephys-datasets-041422-ubuntu-latest-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
+          key: ecephys-datasets-041422-ubuntu-latest-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
 
       - name: Get ophys_testing_data current head hash
         id: ophys

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -23,16 +23,6 @@ jobs:
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"
 
-      - name: Get ephy_testing_data current head hash
-        id: ephys
-        run: echo "::set-output name=HASH_EPHY_DATASET::$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"
-      - name: Cache ephys dataset - ${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
-        uses: actions/cache@v2
-        id: cache-ephys-datasets
-        with:
-          path: ./ephy_testing_data
-          key: ecephys-datasets-041422-ubuntu-latest-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
-
       - name: Get ophys_testing_data current head hash
         id: ophys
         run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"
@@ -59,37 +49,6 @@ jobs:
         if: steps.cache-ephys-datasets.outputs.cache-hit == false || steps.cache-ophys-datasets.outputs.cache-hit == false || steps.cache-behavior-datasets.outputs.cache-hit == false
         run: conda install -c conda-forge datalad==0.16.3
 
-      - name: "Force GIN: ephys download"
-        if: steps.cache-ephys-datasets.outputs.cache-hit == false
-        run: |
-          datalad install https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
-          cd ephy_testing_data
-          datalad get -r ./neuralynx/Cheetah_v5.7.4/original_data/
-          datalad get -r ./neuralynx/Cheetah_v5.6.3/original_data/
-          datalad get -r ./neuralynx/Cheetah_v5.4.0/original_data/
-          datalad get -r ./neuroscope/
-          datalad get -r ./openephysbinary/v0.4.4.1_with_video_tracking/
-          datalad get -r ./blackrock/
-          datalad get -r ./intan/
-          datalad get -r ./spikegadgets/
-          datalad get -r ./spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0/
-          datalad get -r ./spikeglx/TEST_20210920_0_g0/
-          datalad get -r ./phy/phy_example_0/
-          datalad get -r ./axona/
-          datalad get -r ./cellexplorer/
-          cd ..
-      - name: Upload ephys dataset to S3
-        if: steps.cache-ephys-datasets.outputs.cache-hit == false
-        uses: keithweaver/aws-s3-github-action@v1.0.0
-        with:
-          command: sync
-          source: ephy_testing_data
-          destination: ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data
-          flags: "--follow-symlinks --exclude='.git/*' --exclude='.gitattributes/*' --exclude='.gitignore' --exclude='*.py' --exclude='*.md' --only-show-errors"
-          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: us-east-2
-
       - name: "Force GIN: ophys download"
         if: steps.cache-ophys-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/ophys_testing_data
@@ -108,16 +67,14 @@ jobs:
       - name: "Force GIN: behavior download"
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
-      - run: cd behavior_testing_data
       - name: Upload behavior dataset to S3
         #if: steps.cache-behavior-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: sync
-          source: .
+          source: behavior_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
           flags: --exclude "*.*" --exclude "/.*" --exclude ".*"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2
-      - run: cd ..

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -87,8 +87,9 @@ jobs:
           AWS_S3_BUCKET: ${{ secrets.S3_GIN_BUCKET_ARN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-2
-          SOURCE_DIR: ./ephy_testing_data
+          AWS_REGION: "us-east-2"
+          SOURCE_DIR: "./ephy_testing_data"
+          DEST_DIR: "/ephy_testing_data"
 
       - name: "Force GIN: ophys download"
         if: steps.cache-ophys-datasets.outputs.cache-hit == false

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           args: --exclude '*' --include 'neuroscope'
         env:
-          AWS_S3_BUCKET: ${{ secrets.S3_GIN_BUCKET }}
+          AWS_S3_BUCKET: ${{ secrets.S3_GIN_BUCKET_ARN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -112,10 +112,13 @@ jobs:
         #if: steps.cache-behavior-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
-          command: sync
-          source: behavior_testing_data
+          command: |
+            cd behavior_testing_data
+            sync
+            cd ..
+          source: .
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: --delete
+          flags: --exclude "*.*"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -115,7 +115,7 @@ jobs:
           command: sync
           source: behavior_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: --follow-symlinks --exclude '.git/*' --exclude '.gitattributes/*' --exclude "behavior_testing_data/.gitignore" --exclude '.datalad/*'
+          flags: --follow-symlinks --exclude '.git/*' --exclude '.gitattributes/*' --exclude "*.gitignore" --exclude '.datalad/*'
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -23,6 +23,16 @@ jobs:
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"
 
+      - name: Get ephys_testing_data current head hash
+        id: ephys
+        run: echo "::set-output name=HASH_EPHY_DATASET::$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"
+      - name: Cache ephys dataset - ${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
+        uses: actions/cache@v2
+        id: cache-ephys-datasets
+        with:
+          path: ./ephy_testing_data
+          key: ecephys-datasets-041422-${{ matrix.os }}-${{ steps.ecephys.outputs.HASH_EPHY_DATASET }}
+          
       - name: Get ophys_testing_data current head hash
         id: ophys
         run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"
@@ -49,6 +59,37 @@ jobs:
         if: steps.cache-ephys-datasets.outputs.cache-hit == false || steps.cache-ophys-datasets.outputs.cache-hit == false || steps.cache-behavior-datasets.outputs.cache-hit == false
         run: conda install -c conda-forge datalad==0.16.3
 
+      - name: "Force GIN: ephys download"
+        if: steps.cache-ephys-datasets.outputs.cache-hit == false
+        run: |
+          datalad install https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
+          cd ephy_testing_data
+          datalad get -r ./neuralynx/Cheetah_v5.7.4/original_data/
+          datalad get -r ./neuralynx/Cheetah_v5.6.3/original_data/
+          datalad get -r ./neuralynx/Cheetah_v5.4.0/original_data/
+          datalad get -r ./neuroscope/
+          datalad get -r ./openephysbinary/v0.4.4.1_with_video_tracking/
+          datalad get -r ./blackrock/
+          datalad get -r ./intan/
+          datalad get -r ./spikegadgets/
+          datalad get -r ./spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0/
+          datalad get -r ./spikeglx/TEST_20210920_0_g0/
+          datalad get -r ./phy/phy_example_0/
+          datalad get -r ./axona/
+          datalad get -r ./cellexplorer/
+          cd ..
+      - name: Upload ephys dataset to S3
+        # if: steps.cache-ephys-datasets.outputs.cache-hit == false
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: sync
+          source: ./ephy_testing_data
+          destination: ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data
+          flags: --exclude "*"
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-east-2
+
       - name: "Force GIN: ophys download"
         if: steps.cache-ophys-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/ophys_testing_data
@@ -68,7 +109,7 @@ jobs:
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
       - name: Upload behavior dataset to S3
-        #if: steps.cache-behavior-datasets.outputs.cache-hit == false
+        if: steps.cache-behavior-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: sync

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -61,31 +61,14 @@ jobs:
 
       - name: "Force GIN: ephys download"
         if: steps.cache-ephys-datasets.outputs.cache-hit == false
-        run: |
-          datalad install https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
-          cd ephy_testing_data
-          datalad get -r ./neuralynx/Cheetah_v5.7.4/original_data/
-          datalad get -r ./neuralynx/Cheetah_v5.6.3/original_data/
-          datalad get -r ./neuralynx/Cheetah_v5.4.0/original_data/
-          datalad get -r ./neuroscope/
-          datalad get -r ./openephysbinary/v0.4.4.1_with_video_tracking/
-          datalad get -r ./blackrock/
-          datalad get -r ./intan/
-          datalad get -r ./spikegadgets/
-          datalad get -r ./spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0/
-          datalad get -r ./spikeglx/TEST_20210920_0_g0/
-          datalad get -r ./phy/phy_example_0/
-          datalad get -r ./axona/
-          datalad get -r ./cellexplorer/
-          cd ..
+        run: datalad install -rg https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
       - name: Upload ephys dataset to S3
         # if: steps.cache-ephys-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: sync
-          source: .
+          source: ./ephy_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data
-          flags: --dryrun --exclude '*' --include 'ephy_testing_data/neuroscope/*'
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -107,9 +107,8 @@ jobs:
 
       - name: "Force GIN: behavior download"
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
-        run: |
-          datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
-          cd behavior_testing_data
+        run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
+      - run: cd behavior_testing_data
       - name: Upload behavior dataset to S3
         #if: steps.cache-behavior-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -80,15 +80,15 @@ jobs:
           cd ..
       - name: Upload ephys dataset to S3
         # if: steps.cache-ephys-datasets.outputs.cache-hit == false
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+      - uses: jakejarvis/s3-sync-action@master
         with:
-          command: sync
-          source: ./ephy_testing_data
-          destination: ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data
-          flags: --include "neuroscope" --exclude "*"
-          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: us-east-2
+          args: --exclude '*' --include 'neuroscope'
+        env:
+          AWS_S3_BUCKET: ${{ secrets.S3_GIN_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-2
+          SOURCE_DIR: ephy_testing_data
 
       - name: "Force GIN: ophys download"
         if: steps.cache-ophys-datasets.outputs.cache-hit == false
@@ -97,10 +97,9 @@ jobs:
         if: steps.cache-ophys-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
-          command: cp
+          command: sync
           source: ./ophys_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/ophys_testing_data
-          flags: "--recursive"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2
@@ -115,7 +114,6 @@ jobs:
           command: sync
           source: behavior_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: --exclude "*.*" --exclude "/.*" --exclude ".*"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -115,7 +115,7 @@ jobs:
           command: sync
           source: behavior_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: --follow-symlinks --exclude "behavior_testing_data/.gitignore" --exclude ".gitignore" --exclude "/.gitignore" --exclude "./.gitignore" --exclude "*/.gitignore" --exclude "*.gitignore" 
+          flags: --exclude "behavior_testing_data/.gitignore" --exclude ".gitignore" --exclude "/.gitignore" --exclude "./.gitignore" --exclude "*/.gitignore" --exclude "*.gitignore" 
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -85,6 +85,7 @@ jobs:
           command: sync
           source: ./ephy_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data
+          flags: "--follow-symlinks"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -79,11 +79,11 @@ jobs:
           datalad get -r ./cellexplorer/
           cd ..
       - name: Upload ephys dataset to S3
-        #if: steps.cache-ephys-datasets.outputs.cache-hit == false
+        if: steps.cache-ephys-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: sync
-          source: ./ephy_testing_data
+          source: ephy_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data
           flags: "--follow-symlinks --exclude='.git/*' --exclude='.gitattributes/*' --exclude='.gitignore' --exclude='*.py' --exclude='*.md' --only-show-errors"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -112,10 +112,10 @@ jobs:
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
-          command: cp
-          source: ./behavior_testing_data
+          command: sync
+          source: behavior_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: "--recursive"
+          flags: "--follow-symlinks --exclude='.git/*' --exclude='.gitattributes/*' --exclude='.gitignore' --exclude='*.py' --exclude='*.md' --only-show-errors"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -115,7 +115,7 @@ jobs:
           command: sync
           source: behavior_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: --follow-symlinks --exclude '.git/*' --exclude '.gitattributes/*' --exclude ".gitignore" --exclude '.datalad/*'
+          flags: --follow-symlinks --exclude '.git/*' --exclude '.gitattributes/*' --exclude "behavior_testing_data/.gitignore" --exclude '.datalad/*'
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -85,7 +85,6 @@ jobs:
           command: sync
           source: ./ephy_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data
-          flags: "--recursive"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2
@@ -100,7 +99,6 @@ jobs:
           command: sync
           source: ./ophys_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/ophys_testing_data
-          flags: "--recursive"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2
@@ -115,7 +113,6 @@ jobs:
           command: sync
           source: ./behavior_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: "--recursive"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -24,14 +24,14 @@ jobs:
           git config --global user.name "CI Almighty"
 
       - name: Get ephy_testing_data current head hash
-        id: ecephys
+        id: ephys
         run: echo "::set-output name=HASH_EPHY_DATASET::$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"
-      - name: Cache ephys dataset - ${{ steps.ecephys.outputs.HASH_EPHY_DATASET }}
+      - name: Cache ephys dataset - ${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
         uses: actions/cache@v2
-        id: cache-ecephys-datasets
+        id: cache-ephys-datasets
         with:
           path: ./ephy_testing_data
-          key: ecephys-datasets-041422-ubuntu-latest-${{ steps.ecephys.outputs.HASH_EPHY_DATASET }}
+          key: ephys-datasets-041422-ubuntu-latest-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
 
       - name: Get ophys_testing_data current head hash
         id: ophys
@@ -56,11 +56,11 @@ jobs:
 
 
       - name: Install datalad if needed
-        if: steps.cache-ecephys-datasets.outputs.cache-hit == false || steps.cache-ophys-datasets.outputs.cache-hit == false || steps.cache-behavior-datasets.outputs.cache-hit == false
+        if: steps.cache-ephys-datasets.outputs.cache-hit == false || steps.cache-ophys-datasets.outputs.cache-hit == false || steps.cache-behavior-datasets.outputs.cache-hit == false
         run: conda install -c conda-forge datalad==0.16.3
 
       - name: "Force GIN: ecephys download"
-        if: steps.cache-ecephys-datasets.outputs.cache-hit == false
+        if: steps.cache-ephys-datasets.outputs.cache-hit == false
         run: |
           datalad install https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
           cd ephy_testing_data
@@ -78,23 +78,43 @@ jobs:
           datalad get -r ./axona/
           datalad get -r ./cellexplorer/
           cd ..
+      - name: Upload ephys dataset to S3
+        #if: steps.cache-ephys-datasets.outputs.cache-hit == false
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: ./ephy_testing_data
+          destination: ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data
+          flags: "--recursive"
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-east-2
 
       - name: "Force GIN: ophys download"
         if: steps.cache-ophys-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/ophys_testing_data
-
-      - name: "Force GIN: behavior download"
-        if: steps.cache-behavior-datasets.outputs.cache-hit == false
-        run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
-
-
-
       - name: Upload ophys dataset to S3
+        if: steps.cache-ophys-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: cp
           source: ./ophys_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/ophys_testing_data
+          flags: "--recursive"
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-east-2
+
+      - name: "Force GIN: behavior download"
+        if: steps.cache-behavior-datasets.outputs.cache-hit == false
+        run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
+      - name: Upload behavior dataset to S3
+        #if: steps.cache-behavior-datasets.outputs.cache-hit == false
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: ./behavior_testing_data
+          destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
           flags: "--recursive"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -82,13 +82,12 @@ jobs:
         # if: steps.cache-ephys-datasets.outputs.cache-hit == false
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --dryrun --follow-symlinks --exclude '*' --include 'neuroscope'
+          args: --dryrun --follow-symlinks --exclude '*' --exclude '*/' --exclude '/*' --exclude '*/*' --include 'ephy_testing_data/neuroscope/*'
         env:
           AWS_S3_BUCKET: ${{ secrets.S3_GIN_BUCKET_ARN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: "us-east-2"
-          SOURCE_DIR: "ephy_testing_data"
           DEST_DIR: "ephy_testing_data"
 
       - name: "Force GIN: ophys download"

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           path: ./ephy_testing_data
           key: ephys-datasets-081922-ubuntu-latest-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
-          
+
       - name: Get ophys_testing_data current head hash
         id: ophys
         run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -82,13 +82,12 @@ jobs:
         # if: steps.cache-ephys-datasets.outputs.cache-hit == false
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --dryrun --follow-symlinks --exclude '*' --exclude '*/' --exclude '/*' --exclude '*/*' --include 'ephy_testing_data/neuroscope/*'
+          args: --exclude '*' --include 'ephy_testing_data/neuroscope/*'
         env:
           AWS_S3_BUCKET: ${{ secrets.S3_GIN_BUCKET_ARN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: "us-east-2"
-          DEST_DIR: "ephy_testing_data"
 
       - name: "Force GIN: ophys download"
         if: steps.cache-ophys-datasets.outputs.cache-hit == false

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -1,7 +1,7 @@
 name: Updated Caches and Upload to S3
-on:
-  schedule:
-    - cron: "0 0 * * *"
+on: push
+  #schedule:
+  #  - cron: "0 0 * * *"
 jobs:
   run:
     name: Update cache on ${{ matrix.os }} with Python ${{ matrix.python-version }}

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -31,7 +31,7 @@ jobs:
         id: cache-ephys-datasets
         with:
           path: ./ephy_testing_data
-          key: ecephys-datasets-041422-${{ matrix.os }}-${{ steps.ecephys.outputs.HASH_EPHY_DATASET }}
+          key: ecephys-datasets-041422-ubuntu-latest-${{ steps.ecephys.outputs.HASH_EPHY_DATASET }}
           
       - name: Get ophys_testing_data current head hash
         id: ophys

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -56,7 +56,7 @@ jobs:
 
 
       - name: Install datalad if needed
-        if: steps.cache-ephys-datasets.outputs.cache-hit == false | steps.cache-ophys-datasets.outputs.cache-hit == false | steps.cache-behavior-datasets.outputs.cache-hit == false
+        if: steps.cache-ephys-datasets.outputs.cache-hit == false || steps.cache-ophys-datasets.outputs.cache-hit == false || steps.cache-behavior-datasets.outputs.cache-hit == false
         run: conda install -c conda-forge datalad==0.16.3
 
       - name: "Force GIN: ephys download"
@@ -106,10 +106,10 @@ jobs:
           aws_region: us-east-2
 
       - name: "Force GIN: behavior download"
-        #if: steps.cache-behavior-datasets.outputs.cache-hit == false
+        if: steps.cache-behavior-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
       - name: Upload behavior dataset to S3
-        if: steps.cache-behavior-datasets.outputs.cache-hit == false
+        #if: steps.cache-behavior-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: sync

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -17,9 +17,6 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Install datalad
-        run: conda install -c conda-forge datalad==0.16.3
-
       - name: Setup Environment
         run: |
           pip install -U pip
@@ -34,7 +31,34 @@ jobs:
         id: cache-ecephys-datasets
         with:
           path: ./ephy_testing_data
-          key: ecephys-datasets-041422-${{ matrix.os }}-${{ steps.ecephys.outputs.HASH_EPHY_DATASET }}
+          key: ecephys-datasets-041422-ubuntu-latest-${{ steps.ecephys.outputs.HASH_EPHY_DATASET }}
+
+      - name: Get ophys_testing_data current head hash
+        id: ophys
+        run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"
+      - name: Cache ophys dataset - ${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
+        uses: actions/cache@v2
+        id: cache-ophys-datasets
+        with:
+          path: ./ophys_testing_data
+          key: ophys-datasets-042022-ubuntu-latest-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
+
+      - name: Get behavior_testing_data current head hash
+        id: behavior
+        run: echo "::set-output name=HASH_BEHAVIOR_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/behavior_testing_data.git HEAD | cut -f1)"
+      - name: Cache behavior dataset - ${{ steps.behavior.outputs.HASH_BEHAVIOR_DATASET }}
+        uses: actions/cache@v2
+        id: cache-behavior-datasets
+        with:
+          path: ./behavior_testing_data
+          key: behavior-datasets-042022-ubuntu-latest-${{ steps.behavior.outputs.HASH_behavior_DATASET }}
+
+
+
+      - name: Install datalad if needed
+        if: steps.cache-ecephys-datasets.outputs.cache-hit == false || steps.cache-ophys-datasets.outputs.cache-hit == false || steps.cache-behavior-datasets.outputs.cache-hit == false
+        run: conda install -c conda-forge datalad==0.16.3
+
       - name: "Force GIN: ecephys download"
         if: steps.cache-ecephys-datasets.outputs.cache-hit == false
         run: |
@@ -55,31 +79,15 @@ jobs:
           datalad get -r ./cellexplorer/
           cd ..
 
-      - name: Get ophys_testing_data current head hash
-        id: ophys
-        run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"
-      - name: Cache ophys dataset - ${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
-        uses: actions/cache@v2
-        id: cache-ophys-datasets
-        with:
-          path: ./ophys_testing_data
-          key: ophys-datasets-042022-${{ matrix.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
       - name: "Force GIN: ophys download"
         if: steps.cache-ophys-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/ophys_testing_data
 
-      - name: Get behavior_testing_data current head hash
-        id: behavior
-        run: echo "::set-output name=HASH_BEHAVIOR_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/behavior_testing_data.git HEAD | cut -f1)"
-      - name: Cache behavior dataset - ${{ steps.behavior.outputs.HASH_BEHAVIOR_DATASET }}
-        uses: actions/cache@v2
-        id: cache-behavior-datasets
-        with:
-          path: ./behavior_testing_data
-          key: behavior-datasets-042022-${{ matrix.os }}-${{ steps.behavior.outputs.HASH_behavior_DATASET }}
       - name: "Force GIN: behavior download"
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
+
+
 
       - name: Upload ophys dataset to S3
         uses: keithweaver/aws-s3-github-action@v1.0.0

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -95,6 +95,7 @@ jobs:
           command: cp
           source: ./ophys_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}
+          flags: "--recursive"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          os: [ubuntu-latest, macos-latest, windows-latest]
+          os: ubuntu-latest
     steps:
       - uses: s-weigand/setup-conda@v1
       - uses: actions/checkout@v2
@@ -22,17 +22,6 @@ jobs:
       - if: ${{ matrix.os == 'ubuntu-latest' }}
         name: Get datalad - Linux
         run: conda install -c conda-forge datalad==0.16.3
-      - if: ${{ matrix.os == 'macos-latest' }}
-        name: Get git-annex and datalad - MacOS
-        run: brew install git-annex
-      - if: ${{ matrix.os == 'windows-latest' }}
-        name: Get git-annex - Windows
-        uses: crazy-max/ghaction-chocolatey@v1.6.0
-        with:
-          args: install git-annex --ignore-checksums
-      - if: ${{ matrix.os == 'windows-latest' || matrix.os == 'macos-latest' }}
-        name: Get datalad - Windows and Mac
-        run: pip install datalad==0.16.3
 
       - name: Setup Environment
         run: |

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -79,7 +79,7 @@ jobs:
           datalad get -r ./cellexplorer/
           cd ..
       - name: Upload ephys dataset to S3
-        if: steps.cache-ephys-datasets.outputs.cache-hit == false
+        #if: steps.cache-ephys-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: sync
@@ -106,7 +106,7 @@ jobs:
           aws_region: us-east-2
 
       - name: "Force GIN: behavior download"
-        if: steps.cache-behavior-datasets.outputs.cache-hit == false
+        #if: steps.cache-behavior-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
       - name: Upload behavior dataset to S3
         if: steps.cache-behavior-datasets.outputs.cache-hit == false

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -59,7 +59,7 @@ jobs:
         if: steps.cache-ephys-datasets.outputs.cache-hit == false || steps.cache-ophys-datasets.outputs.cache-hit == false || steps.cache-behavior-datasets.outputs.cache-hit == false
         run: conda install -c conda-forge datalad==0.16.3
 
-      - name: "Force GIN: ecephys download"
+      - name: "Force GIN: ephys download"
         if: steps.cache-ephys-datasets.outputs.cache-hit == false
         run: |
           datalad install https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
@@ -79,10 +79,10 @@ jobs:
           datalad get -r ./cellexplorer/
           cd ..
       - name: Upload ephys dataset to S3
-        #if: steps.cache-ephys-datasets.outputs.cache-hit == false
+        if: steps.cache-ephys-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
-          command: cp
+          command: sync
           source: ./ephy_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data
           flags: "--recursive"
@@ -97,7 +97,7 @@ jobs:
         if: steps.cache-ophys-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
-          command: cp
+          command: sync
           source: ./ophys_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/ophys_testing_data
           flags: "--recursive"
@@ -109,10 +109,10 @@ jobs:
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
       - name: Upload behavior dataset to S3
-        #if: steps.cache-behavior-datasets.outputs.cache-hit == false
+        if: steps.cache-behavior-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
-          command: cp
+          command: sync
           source: ./behavior_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
           flags: "--recursive"

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -113,9 +113,9 @@ jobs:
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: sync
-          source: ./behavior_testing_data/
+          source: .
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: --follow-symlinks --exclude "./behavior_testing_data/.gitignore" 
+          flags: --follow-symlinks --include "behavior_testing_data/*" --exclude "behavior_testing_data/.gitignore" 
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -56,7 +56,7 @@ jobs:
 
 
       - name: Install datalad if needed
-        if: steps.cache-ephys-datasets.outputs.cache-hit == false || steps.cache-ophys-datasets.outputs.cache-hit == false || steps.cache-behavior-datasets.outputs.cache-hit == false
+        if: steps.cache-ephys-datasets.outputs.cache-hit == false | steps.cache-ophys-datasets.outputs.cache-hit == false | steps.cache-behavior-datasets.outputs.cache-hit == false
         run: conda install -c conda-forge datalad==0.16.3
 
       - name: "Force GIN: ephys download"

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -4,23 +4,20 @@ on: push
   #  - cron: "0 0 * * *"
 jobs:
   run:
-    name: Update cache on ${{ matrix.os }} with Python ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
+    name: Update cache and upload to S3
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-          os: ubuntu-latest
     steps:
       - uses: s-weigand/setup-conda@v1
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow --tags
-      - name: Setup Python ${{ matrix.python-version }}
+      - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
 
-      - if: ${{ matrix.os == 'ubuntu-latest' }}
-        name: Get datalad - Linux
+      - name: Install datalad
         run: conda install -c conda-forge datalad==0.16.3
 
       - name: Setup Environment

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -113,9 +113,9 @@ jobs:
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: sync
-          source: .
+          source: behavior_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: --follow-symlinks --include "behavior_testing_data/*" --exclude "behavior_testing_data/.gitignore" 
+          flags: --follow-symlinks --exclude "behavior_testing_data/.gitignore" --exclude ".gitignore" --exclude "/.gitignore" --exclude "./.gitignore" --exclude "*/.gitignore" --exclude "*.gitignore" 
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -80,7 +80,7 @@ jobs:
           cd ..
       - name: Upload ephys dataset to S3
         # if: steps.cache-ephys-datasets.outputs.cache-hit == false
-      - uses: jakejarvis/s3-sync-action@master
+        uses: jakejarvis/s3-sync-action@master
         with:
           args: --exclude '*' --include 'neuroscope'
         env:

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -88,8 +88,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: "us-east-2"
-          SOURCE_DIR: "./ephy_testing_data"
-          DEST_DIR: "/ephy_testing_data"
+          SOURCE_DIR: "ephy_testing_data"
+          DEST_DIR: "ephy_testing_data"
 
       - name: "Force GIN: ophys download"
         if: steps.cache-ophys-datasets.outputs.cache-hit == false

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -82,10 +82,10 @@ jobs:
         #if: steps.cache-ephys-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
-          command: cp
+          command: sync
           source: ./ephy_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data
-          flags: "--recursive"
+          flags: "--follow-symlinks --exclude='.git/*' --exclude='.gitattributes/*' --exclude='.gitignore' --exclude='*.py' --exclude='*.md' --only-show-errors"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -115,7 +115,7 @@ jobs:
           command: sync
           source: ./behavior_testing_data/
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: --follow-symlinks --exclude '.git/*' --exclude '.gitattributes/*' --exclude "*.gitignore" --exclude '.datalad/*'
+          flags: --follow-symlinks --exclude '.git/*' --exclude '.gitattributes/*' --exclude "*gitignore*" --exclude '.datalad/*'
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -1,7 +1,7 @@
 name: Updated Caches and Upload to S3
-on: push
-  #schedule:
-  #  - cron: "0 0 * * *"
+on:
+  schedule:
+    - cron: "0 0 * * *"
 jobs:
   run:
     name: Update cache and upload to S3
@@ -65,7 +65,7 @@ jobs:
         if: steps.cache-ephys-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
       - name: Upload ephys dataset to S3
-        # if: steps.cache-ephys-datasets.outputs.cache-hit == false
+        if: steps.cache-ephys-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: sync

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -1,4 +1,4 @@
-name: Updated Caches
+name: Updated Caches and Upload to S3
 on:
   schedule:
     - cron: "0 0 * * *"
@@ -94,3 +94,13 @@ jobs:
       - name: "Force GIN: behavior download"
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
+
+      - name: Upload ophys dataset to S3
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: ./ophys_testing_data
+          destination: ${{ secrets.S3_GIN_BUCKET }}
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -107,18 +107,18 @@ jobs:
 
       - name: "Force GIN: behavior download"
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
-        run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
+        run: |
+          datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
+          cd behavior_testing_data
       - name: Upload behavior dataset to S3
         #if: steps.cache-behavior-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
-          command: |
-            cd behavior_testing_data
-            sync
-            cd ..
+          command: sync
           source: .
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: --exclude "*.*"
+          flags: --exclude "*.*" --exclude "/.*" --exclude ".*"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2
+      - run: cd ..

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -82,7 +82,7 @@ jobs:
         # if: steps.cache-ephys-datasets.outputs.cache-hit == false
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --exclude '*' --include 'neuroscope'
+          args: --dryrun --follow-symlinks --exclude '*' --include 'neuroscope'
         env:
           AWS_S3_BUCKET: ${{ secrets.S3_GIN_BUCKET_ARN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -82,10 +82,10 @@ jobs:
         #if: steps.cache-ephys-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
-          command: sync
+          command: cp
           source: ./ephy_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data
-          flags: "--follow-symlinks"
+          flags: "--recursive"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2
@@ -97,9 +97,10 @@ jobs:
         if: steps.cache-ophys-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
-          command: sync
+          command: cp
           source: ./ophys_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/ophys_testing_data
+          flags: "--recursive"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2
@@ -111,9 +112,10 @@ jobs:
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
-          command: sync
+          command: cp
           source: ./behavior_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
+          flags: "--recursive"
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -113,7 +113,7 @@ jobs:
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: sync
-          source: behavior_testing_data
+          source: /behavior_testing_data/
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
           flags: --follow-symlinks --exclude '.git/*' --exclude '.gitattributes/*' --exclude "*.gitignore" --exclude '.datalad/*'
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -115,7 +115,7 @@ jobs:
           command: sync
           source: behavior_testing_data
           destination: ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data
-          flags: "--follow-symlinks --exclude '.git/*' --exclude '.gitattributes/*' --exclude '.gitignore' --exclude '.datalad/*'"
+          flags: --follow-symlinks --exclude '.git/*' --exclude '.gitattributes/*' --exclude ".gitignore" --exclude '.datalad/*'
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2


### PR DESCRIPTION
The full mac workflow has been disabled for some time due to `git-annex` complexities. The full windows workflow has also been touchy over time. Linux is the only platform to never have issues with datalad or git-annex. Caches also cannot effectively be saved on one platform and loaded on another. As such, I've devised an easy workaround.

The workaround uploads the linux cache to an S3 bucket where it can then be downloaded from any arbitrary platform/python version without needing datalad or git-annex.

Took some fiddling around - a couple things to note for future reference...

i) AWS/S3 does not like the lazy symlinks that datalad/GIN leave around when you install a dataset without getting all the file contents. Workflow fails but without any meaningful error if you try to either follow a symlink file that has a non-existing destination or try to upload said symlink.

ii) I only wanted to upload/sync the set of files from the `ephy_testing_data` that we actually use so as to not take up extra space. However, the `exclude/include` commands for the AWS CLI are rather frustrating - even following all the suggestions of https://github.com/aws/aws-cli/issues/1588 and https://github.com/aws/aws-cli/issues/5614 I still can't get it to actually exclude any patterns from its folder recursion.