### PR TITLE
Showcase tzinfo idea for gallery and general usage

### DIFF
--- a/docs/conversion_examples_gallery/recording/spikeglx.rst
+++ b/docs/conversion_examples_gallery/recording/spikeglx.rst
@@ -5,8 +5,6 @@ Convert spikeglx data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.
 
 .. code-block:: python
 
-    >>> from datetime import datetime
-    >>> from dateutil import tz
     >>> from pathlib import Path
     >>> from neuroconv.datainterfaces import SpikeGLXRecordingInterface
     >>>
@@ -16,12 +14,8 @@ Convert spikeglx data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.
     >>> interface = SpikeGLXRecordingInterface(file_path=file_path, verbose=False)
     >>>
     >>> # Extract what metadata we can from the source files
-    >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> tzinfo = tz.gettz("US/Pacific")
-    >>> session_start_time = datetime.fromisoformat(metadata["NWBFile"]["session_start_time"])
-    >>> session_start_time = session_start_time.replace(tzinfo=tzinfo).isoformat()
-    >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> metadata = interface.get_metadata(tzinfo="US/Pacific")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
@@ -1,8 +1,9 @@
 """Authors: Cody Baker, Heberto Mayorquin and Ben Dichter."""
+import json
 from pathlib import Path
 from typing import Optional
-import json
 
+import dateutil
 from pynwb.ecephys import ElectricalSeries
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
@@ -87,9 +88,12 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
         )
         return metadata_schema
 
-    def get_metadata(self):
+    def get_metadata(self, tzinfo: Optional[Union[str, dateutil.zoneinfo.tzfile]] = None):
         metadata = super().get_metadata()
         session_start_time = get_session_start_time(self.meta)
+        if session_start_time and tzinfo:
+            tzinfo_object = dateutil.tz.gettz(tzinfo) if isinstance(tzinfo, str) else tzinfo
+            session_start_time.replace(tzinfo=tzinfo_object)
         if session_start_time:
             metadata = dict_deep_update(metadata, dict(NWBFile=dict(session_start_time=str(session_start_time))))
 
@@ -169,8 +173,8 @@ class SpikeGLXLFPInterface(SpikeGLXRecordingInterface):
         )
         return metadata_schema
 
-    def get_metadata(self):
-        metadata = super().get_metadata()
+    def get_metadata(self, tzinfo: Optional[Union[str, dateutil.zoneinfo.tzfile]] = None):
+        metadata = super().get_metadata(tzinfo=tzinfo)
         del metadata["Ecephys"]["ElectricalSeries_raw"]
         metadata["Ecephys"].update(
             ElectricalSeries_lfp=dict(


### PR DESCRIPTION
Another idea I had for simplifying much of the code in the galleries.

Basically a convenience functionality for setting timezone information in metadata. Not necessarily specific to `session_start_time`, but could have it alter any metadata info that is ultimately specified as ISO/datetime objects.

Saves ~6 lines per gallery (~2 unnecessary imports, ~4 lines that parse the existing ISO string as datetime just to cast it back in the update)