### PR TITLE
Sync with latest ROIExtractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * The `OpenEphysSortingExtractorInterface` has been renamed to `OpenEphysSortingInterface`. [PR #74](https://github.com/catalystneuro/neuroconv/pull/74)
 * The `KilosortSortingInterface` has been renamed to `KiloSortSortingInterface` to be more consistent with SpikeInterface. [PR #107](https://github.com/catalystneuro/neuroconv/pull/107)
 * The `Neuroscope` interfaces have been renamed to `NeuroScope` to be more consistent with SpikeInterface. [PR #107](https://github.com/catalystneuro/neuroconv/pull/107)
+* The `tools.roiextractors.add_epoch` functionality has been retired in the newest versions of ROIExtractors. [PR #112](https://github.com/catalystneuro/neuroconv/pull/112)
 
 ### Fixes
 * Prevented the CEDRecordingInterface from writing non-ecephys channel data. [PR #37](https://github.com/catalystneuro/neuroconv/pull/37)

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -17,7 +17,7 @@ opencv-python==4.5.1.48
 spikeextractors==0.9.10
 spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@4346eff5706408435e8aa8345be22fdd452afa27
 neo @ git+https://github.com/NeuralEnsemble/python-neo@50abfbce832edb1c0f8364ac34c8a6442e1a3edf
-roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@3f08c5021f9f32d3870714fb803e1733a295a92c
+roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@ae627920abd04b60e636b567ab1716abf7270212
 pyintan==0.3.0
 pyopenephys==1.1.2
 sonpy>=1.7.1

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -12,7 +12,7 @@ dandi==0.39.6
 spikeextractors>=0.9.10
 spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@4346eff5706408435e8aa8345be22fdd452afa27
 neo>=0.9.0
-roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@3f08c5021f9f32d3870714fb803e1733a295a92c
+roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@ae627920abd04b60e636b567ab1716abf7270212
 lxml>=4.6.5
 scipy>=1.4.1
 click  # must be unspecified version to handle platform/pyVersion

--- a/src/neuroconv/tools/roiextractors/__init__.py
+++ b/src/neuroconv/tools/roiextractors/__init__.py
@@ -6,7 +6,6 @@ from .roiextractors import (
     add_plane_segmentation,
     add_fluorescence_traces,
     add_two_photon_series,
-    add_epochs,
     write_imaging,
     get_nwb_segmentation_metadata,
     add_summary_images,

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -412,34 +412,6 @@ def _imaging_frames_to_hdmf_iterator(
     return ImagingExtractorDataChunkIterator(imaging_extractor=imaging, **iterator_options)
 
 
-def add_epochs(imaging, nwbfile):
-    """
-    Auxiliary static method for nwbextractor.
-
-    Adds epochs from recording object to nwbfile object.
-    """
-    # add/update epochs
-    for (name, ep) in imaging._epochs.items():
-        if nwbfile.epochs is None:
-            nwbfile.add_epoch(
-                start_time=imaging.frame_to_time(ep["start_frame"]),
-                stop_time=imaging.frame_to_time(ep["end_frame"]),
-                tags=name,
-            )
-        else:
-            if [name] in nwbfile.epochs["tags"][:]:
-                ind = nwbfile.epochs["tags"][:].index([name])
-                nwbfile.epochs["start_time"].data[ind] = imaging.frame_to_time(ep["start_frame"])
-                nwbfile.epochs["stop_time"].data[ind] = imaging.frame_to_time(ep["end_frame"])
-            else:
-                nwbfile.add_epoch(
-                    start_time=imaging.frame_to_time(ep["start_frame"]),
-                    stop_time=imaging.frame_to_time(ep["end_frame"]),
-                    tags=name,
-                )
-    return nwbfile
-
-
 def write_imaging(
     imaging: ImagingExtractor,
     nwbfile_path: OptionalFilePathType = None,
@@ -544,7 +516,6 @@ def write_imaging(
             iterator_type=iterator_type,
             iterator_options=iterator_options,
         )
-        add_epochs(imaging=imaging, nwbfile=nwbfile_out)
     return nwbfile_out
 
 


### PR DESCRIPTION
Recent improvements to ROIExtractors altered the behavior of a component of the `write_imaging` method, specifically `add_epochs`.

For the same justification that it was removed in ROIExtractors, this method has always gone untested and unused across the supported formats, and unused in actual conversion projects as well. Epoch information, similar to trials information, is instead typically added via secondary data interfaces that read it from non-imaging files.