### PR TITLE
[Bug fix]: Context output during raised error

### DIFF
--- a/src/neuroconv/tools/nwb_helpers.py
+++ b/src/neuroconv/tools/nwb_helpers.py
@@ -153,6 +153,7 @@ def make_or_load_nwbfile(
     )
 
     load_kwargs = dict()
+    success = True
     if nwbfile_path:
         load_kwargs.update(path=nwbfile_path)
         if nwbfile_path_in.is_file() and not overwrite:
@@ -166,12 +167,15 @@ def make_or_load_nwbfile(
         elif nwbfile is None:
             nwbfile = make_nwbfile_from_metadata(metadata=metadata)
         yield nwbfile
+    except Exception as e:
+        success = False
+        raise e
     finally:
         if nwbfile_path:
             try:
                 io.write(nwbfile)
 
-                if verbose:
+                if success and verbose:
                     print(f"NWB file saved at {nwbfile_path}!")
             finally:
                 io.close()

--- a/src/neuroconv/tools/nwb_helpers.py
+++ b/src/neuroconv/tools/nwb_helpers.py
@@ -154,9 +154,10 @@ def make_or_load_nwbfile(
 
     load_kwargs = dict()
     success = True
-    if nwbfile_path:
-        load_kwargs.update(path=nwbfile_path)
-        if nwbfile_path_in.is_file() and not overwrite:
+    file_initially_exists = nwbfile_path_in.is_file()
+    if nwbfile_path_in:
+        load_kwargs.update(path=nwbfile_path_in)
+        if file_initially_exists and not overwrite:
             load_kwargs.update(mode="r+", load_namespaces=True)
         else:
             load_kwargs.update(mode="w")
@@ -171,11 +172,15 @@ def make_or_load_nwbfile(
         success = False
         raise e
     finally:
-        if nwbfile_path:
+        if nwbfile_path_in:
             try:
-                io.write(nwbfile)
+                if success:
+                    io.write(nwbfile)
 
-                if success and verbose:
-                    print(f"NWB file saved at {nwbfile_path}!")
+                    if verbose:
+                        print(f"NWB file saved at {nwbfile_path_in}!")
             finally:
                 io.close()
+
+                if not success and not file_initially_exists:
+                    nwbfile_path_in.unlink()

--- a/src/neuroconv/tools/nwb_helpers.py
+++ b/src/neuroconv/tools/nwb_helpers.py
@@ -154,7 +154,7 @@ def make_or_load_nwbfile(
 
     load_kwargs = dict()
     success = True
-    file_initially_exists = nwbfile_path_in.is_file()
+    file_initially_exists = nwbfile_path_in.is_file() if nwbfile_path_in is not None else None
     if nwbfile_path_in:
         load_kwargs.update(path=nwbfile_path_in)
         if file_initially_exists and not overwrite:

--- a/tests/test_minimal/test_tools.py
+++ b/tests/test_minimal/test_tools.py
@@ -1,9 +1,11 @@
 import os
 import unittest
+from unittest.mock import patch
 from datetime import datetime
 from tempfile import mkdtemp
 from pathlib import Path
 from shutil import rmtree
+from io import StringIO
 
 import pytest
 from pynwb import NWBHDF5IO, ProcessingModule, TimeSeries
@@ -277,6 +279,16 @@ class TestMakeOrLoadNWBFile(TestCase):
                 nwbfile_path=nwbfile_path, nwbfile=make_nwbfile_from_metadata(metadata=self.metadata), overwrite=False
             ) as nwbfile:
                 nwbfile.add_acquisition(self.time_series_1)
+
+    def test_make_or_load_nwbfile_no_print_on_error_in_context(self):
+        """Test the expected stdout in case an error occurs during the context."""
+        with patch("sys.stdout", new=StringIO()) as fake_out:
+            try:
+                with make_or_load_nwbfile(nwbfile_path=self.tmpdir / "doesnt_matter.nwb", metadata=self.metadata) as _:
+                    raise ValueError("test")
+            except ValueError:
+                pass
+            self.assertEqual(fake_out.getvalue(), "")
 
     def test_make_or_load_nwbfile_write(self):
         nwbfile_path = self.tmpdir / "test_make_or_load_nwbfile_write.nwb"

--- a/tests/test_minimal/test_tools.py
+++ b/tests/test_minimal/test_tools.py
@@ -284,11 +284,20 @@ class TestMakeOrLoadNWBFile(TestCase):
         """Test the expected stdout in case an error occurs during the context."""
         with patch("sys.stdout", new=StringIO()) as fake_out:
             try:
-                with make_or_load_nwbfile(nwbfile_path=self.tmpdir / "doesnt_matter.nwb", metadata=self.metadata) as _:
+                with make_or_load_nwbfile(nwbfile_path=self.tmpdir / "doesnt_matter_1.nwb", metadata=self.metadata):
                     raise ValueError("test")
             except ValueError:
                 pass
             self.assertEqual(fake_out.getvalue(), "")
+
+    def test_make_or_load_nwbfile_no_file_save_on_error_in_context(self):
+        nwbfile_path = Path(self.tmpdir / "doesnt_matter_2.nwb")
+        try:
+            with make_or_load_nwbfile(nwbfile_path=nwbfile_path, metadata=self.metadata):
+                raise ValueError("test")
+        except ValueError:
+            pass
+        assert not nwbfile_path.exists()
 
     def test_make_or_load_nwbfile_write(self):
         nwbfile_path = self.tmpdir / "test_make_or_load_nwbfile_write.nwb"


### PR DESCRIPTION
Standalone fix peeled from #117 - an issue was discovered when an error was raised *during* the context (not in the enter/exit) for making or loading NWBFiles where the success statement would print prior to the traceback.

This fixes the issue and added an explicit test for it.