### PR TITLE
Run import tests as if they were in a fresh environment 

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,6 +37,11 @@ jobs:
 
       - name: Install neuroconv with minimal requirements
         run: pip install .[test]
+      - name: Run import tests
+        run: |
+          pytest tests/imports.py::TestImportStructure::test_top_level
+          pytest tests/imports.py::TestImportStructure::test_tools
+          pytest tests/imports.py::TestImportStructure::test_datainterfaces
       - name: Run minimal tests
         run: pytest tests/test_minimal -n auto --dist loadscope
 
@@ -49,6 +54,7 @@ jobs:
 
       - name: Install with icephys requirements
         run: pip install .[icephys]
+
       #- name: Run icephys tests  # There are no icephys specific tests without data
       #  run: pytest tests/test_icephys -n auto --dist loadscope
 

--- a/tests/imports.py
+++ b/tests/imports.py
@@ -1,8 +1,8 @@
-from unittest import TestCase
+# This module is meant for the tests to be run as stand-alone so as to emulate a fresh import
+# Run them by using:
+# pytest tests/import_structure.py::TestImportStructure::test_name
 
-import neuroconv
-from neuroconv import datainterfaces
-from neuroconv import tools
+from unittest import TestCase
 
 
 def _strip_magic_module_attributes(ls: list) -> list:
@@ -21,37 +21,42 @@ def _strip_magic_module_attributes(ls: list) -> list:
 
 
 class TestImportStructure(TestCase):
-    def test_outer_import_structure(self):
-        current_structure = _strip_magic_module_attributes(ls=dir(neuroconv))
+    def test_top_level(self):
+        import neuroconv
+
+        current_structure = _strip_magic_module_attributes(ls=neuroconv.__dict__)
         expected_structure = [
             # Sub-modules
             "nwbconverter",
-            "basedatainterface",
-            "baseextractorinterface",
-            "datainterfaces",
-            "tools",
-            "utils",
+            "tools",  # Attached to namespace by NWBConverter import
+            "utils",  # Attached to namesapce by NWBconverter import
             # Exposed attributes
             "NWBConverter",
             "run_conversion_from_yaml",
         ]
         self.assertCountEqual(first=current_structure, second=expected_structure)
 
-    def test_tools_import_structure(self):
+    def test_tools(self):
         """Python dir() calls (and __dict__ as well) update dynamically based on global imports."""
-        current_structure = _strip_magic_module_attributes(ls=dir(tools))
-        minimal_expected_structure = [
+
+        from neuroconv import tools
+
+        current_structure = _strip_magic_module_attributes(ls=tools.__dict__)
+        expected_structure = [
+            # Sub-Packages
+            "yaml_conversion_specification",  # Attached to namespace  by top __init__ call of NWBConverter
             # Sub-modules
-            "importing",
-            "yaml_conversion_specification",  # imported by outer level __init__
-            # Helper functions
+            "importing",  # Attached to namespace by importing get_package
+            "nwb_helpers",  # Attached to namespace by top __init__ call of NWBConverter
+            # Functions imported on the __init__
             "get_package",
         ]
-        for member in minimal_expected_structure:
-            self.assertIn(member=member, container=current_structure)
+        self.assertCountEqual(first=current_structure, second=expected_structure)
 
-    def test_datainterfaces_import_structure(self):
-        current_structure = _strip_magic_module_attributes(ls=dir(datainterfaces))
+    def test_datainterfaces(self):
+        from neuroconv import datainterfaces
+
+        current_structure = _strip_magic_module_attributes(ls=datainterfaces.__dict__)
         expected_structure = [
             # Sub-modules
             "behavior",


### PR DESCRIPTION
As discussed [previously](https://github.com/catalystneuro/neuroconv/pull/124#issuecomment-1233244770) it would be better if the import tests emulated as much as possible a fresh environment. By that I mean what you get when you run **only** `import neuroconv` or `from neuroconv import tools`, etc. This PR addresses this is in the simplest way I could think off.  One of the problems to solve was that pytest runs all the tests sharing the same process so the attributes of the module are path dependent (i.e. they change according to the point in which the test is run among all the other tests) which is messy when running the full testing suit. 

This PR addresses this by running each of the import tests as independent pytest process and relies on a non-standard name to avoid being called from the full testing suit (i.e. running just `pytest` does not run it).

There are more complicated solutions and for the sake of discussions here are the two big constrains that I thought of:
1. The import tests should be run in their own process so the attributes of the module are not modified by history.
2. The import tests should be excluded from the full testing suit as they will fail when they are within the full suit process.

For solving the first problem a natural solution is to use an extension to the --forked or --boxing option with the testing plugging we already use `pytest-xdist`. However, this is not well supported on windows and might lead to an OS incomplete testing suite again (https://pypi.org/project/pytest-xdist/#running-tests-in-a-boxed-subprocess, https://github.com/pytest-dev/pytest-forked).  Another option is to use a sub-process and call pytest using programmatic facilities from each of them but that also seems like an overkill for this scenario. Simpler to just run each test independently with a specific command I think. 

The second problem can be solved either using [markers](https://docs.pytest.org/en/7.1.x/example/markers.html)  or the [nonrecursedir](https://docs.pytest.org/en/7.1.x/example/markers.html) option of pytest. The solution that I have here is simpler as it relies on a non-standard testing name to exclude the functions from the full suite without requiring us to alter the configuration of pytest or the calls that we already have on place (complexity which can be better used for another problem in the future). Of the two solutions for this problem, the first breaks backward compatibility of usage (as the marks are required in the calls) and the second might not play well with some IDEs (as the tests for importing will not be discovered).  

This runs on my machine but I will test the CI, hence the draft status.

 