### PR TITLE
Bump `spikeinterface` version to `0.95.1` or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 ### Fixes
 * Prevented the CEDRecordingInterface from writing non-ecephys channel data. [PR #37](https://github.com/catalystneuro/neuroconv/pull/37)
 * Fixed description in `write_sorting` and in `add_units_table` to have "neuroconv" in the description. [PR #104](https://github.com/catalystneuro/neuroconv/pull/104)
+* Updated `spikeinterface` version number to 0.95.1 to fix issue with `SpikeGLXInterface` probe annotations.
+  The issue is described [here](https://github.com/SpikeInterface/spikeinterface/issues/923). [PR #132](https://github.com/catalystneuro/neuroconv/pull/132)
 
 ### Improvements
 * Unified the `run_conversion` method of `BaseSegmentationExtractorInterface` with that of all the other base interfaces. The method `write_segmentation` now uses the common `make_or_load_nwbfile` context manager [PR #29](https://github.com/catalystneuro/neuroconv/pull/29)

--- a/src/neuroconv/datainterfaces/ecephys/requirements.txt
+++ b/src/neuroconv/datainterfaces/ecephys/requirements.txt
@@ -1,1 +1,2 @@
 spikeinterface>=0.95.1
+spikeextractors>=0.9.10

--- a/src/neuroconv/datainterfaces/ecephys/requirements.txt
+++ b/src/neuroconv/datainterfaces/ecephys/requirements.txt
@@ -1,4 +1,4 @@
 neo>=0.11
 spikeinterface>=0.95.1
 spikeextractors>=0.9.10
-probeinterface<=0.2.9 # https://github.com/catalystneuro/neuroconv/issues/127
+probeinterface>=0.2.10

--- a/src/neuroconv/datainterfaces/ecephys/requirements.txt
+++ b/src/neuroconv/datainterfaces/ecephys/requirements.txt
@@ -1,4 +1,4 @@
 neo @ git+https://github.com/NeuralEnsemble/python-neo@50abfbce832edb1c0f8364ac34c8a6442e1a3edf
-spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@4346eff5706408435e8aa8345be22fdd452afa27
+spikeinterface>=0.95.1
 spikeextractors>=0.9.10
 probeinterface<=0.2.9 # https://github.com/catalystneuro/neuroconv/issues/127

--- a/src/neuroconv/datainterfaces/ecephys/requirements.txt
+++ b/src/neuroconv/datainterfaces/ecephys/requirements.txt
@@ -1,4 +1,4 @@
-neo @ git+https://github.com/NeuralEnsemble/python-neo@50abfbce832edb1c0f8364ac34c8a6442e1a3edf
+neo>=0.11
 spikeinterface>=0.95.1
 spikeextractors>=0.9.10
 probeinterface<=0.2.9 # https://github.com/catalystneuro/neuroconv/issues/127

--- a/src/neuroconv/datainterfaces/ecephys/requirements.txt
+++ b/src/neuroconv/datainterfaces/ecephys/requirements.txt
@@ -1,4 +1,2 @@
-neo>=0.11
 spikeinterface>=0.95.1
 spikeextractors>=0.9.10
-probeinterface>=0.2.10

--- a/src/neuroconv/datainterfaces/ecephys/requirements.txt
+++ b/src/neuroconv/datainterfaces/ecephys/requirements.txt
@@ -1,2 +1,1 @@
 spikeinterface>=0.95.1
-spikeextractors>=0.9.10

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
@@ -23,8 +23,8 @@ def add_recording_extractor_properties(recording_extractor):
     channel_ids = recording_extractor.get_channel_ids()
 
     if probe.get_shank_count() > 1:
-        group_name = [contact_id.split(":")[0] for contact_id in probe.contact_ids]
-        shank_electrode_number = [int(contact_id.split(":")[1][1:]) for contact_id in probe.contact_ids]
+        group_name = [contact_id.split("e")[0] for contact_id in probe.contact_ids]
+        shank_electrode_number = [int(contact_id.split("e")[1]) for contact_id in probe.contact_ids]
     else:
         shank_electrode_number = recording_extractor.ids_to_indices(channel_ids)
         group_name = ["s0"] * len(channel_ids)

--- a/tests/test_on_data/test_metadata/test_spikeglx_metadata.py
+++ b/tests/test_on_data/test_metadata/test_spikeglx_metadata.py
@@ -62,8 +62,8 @@ def test_spikelgx_recording_property_addition():
     probe = pi.read_spikeglx(meta_filename)
     n_channels = probe.device_channel_indices.size
 
-    expected_shank_electrode_number = [int(contact_id.split(":")[1][1:]) for contact_id in probe.contact_ids]
-    expected_group_name = [contact_id.split(":")[0] for contact_id in probe.contact_ids]
+    expected_shank_electrode_number = [int(contact_id.split("e")[1]) for contact_id in probe.contact_ids]
+    expected_group_name = [contact_id.split("e")[0] for contact_id in probe.contact_ids]
     expected_contact_shapes = ["square"] * n_channels
 
     # Initialize the interface and get the added properties


### PR DESCRIPTION
## Motivation

Bump `spikeinterface` version to `0.95.1` to fix issue with probe annotations `KeyError` for "imDatPrb_type". This ought to resolve #127, an issue also described at https://github.com/SpikeInterface/spikeinterface/issues/923 which is fixed in `0.95.1.`

## How to test the behavior?
```
Show here how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Have you thoroughly read our [Developer Guide](https://neuroconv.readthedocs.io/en/main/developer_guide.html)?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/neuroconv/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
- [x] Did you update the [CHANGLOG.md](https://github.com/catalystneuro/neuroconv/blob/main/CHANGELOG.md) file on your branch to describe your changes?
