### PR TITLE
Remove unnecessary call to `get_roi_locations` in segmentation pipeline

### DIFF
--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -620,8 +620,6 @@ def add_plane_segmentation(
         accepted_ids = [int(roi_id in segmentation_extractor.get_accepted_list()) for roi_id in roi_ids]
         rejected_ids = [int(roi_id in segmentation_extractor.get_rejected_list()) for roi_id in roi_ids]
 
-        roi_locations = segmentation_extractor.get_roi_locations().T
-
         imaging_plane_metadata = metadata_copy["Ophys"]["ImagingPlane"][plane_segmentation_index]
         imaging_plane_name = imaging_plane_metadata["name"]
         imaging_plane = nwbfile.imaging_planes[imaging_plane_name]


### PR DESCRIPTION
This PR removes an unecessary call to `get_roi_locations` on the segmentation pipeline. This is called early and in fact unecessarily when `include_roi_centroids` is True as it is called again and used only in that case.