### PR TITLE
Bump/test ROIExtractors latest release

### DIFF
--- a/src/neuroconv/datainterfaces/ophys/requirements.txt
+++ b/src/neuroconv/datainterfaces/ophys/requirements.txt
@@ -1,1 +1,1 @@
-roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@881ebd035c93dbb36542bb1cbfb0a37d33a38c54
+roiextractors>=0.5.0


### PR DESCRIPTION
In advance of the upcoming latest NeuroConv release, testing against latest ROIExtractors release.

@h-mayorquin had mentioned something about seeing some errors but it worked fine when I tried, see what the CI says.