### PR TITLE
Add SLEAP conversion gallery example

### DIFF
--- a/docs/api/interfaces.behavior.rst
+++ b/docs/api/interfaces.behavior.rst
@@ -8,3 +8,7 @@ Movie Data
 DeepLabCut
 ----------
 .. automodule:: neuroconv.datainterfaces.behavior.deeplabcut.deeplabcutdatainterface
+
+Behavior
+--------
+.. automodule:: neuroconv.datainterfaces.behavior.sleap.sleapdatainterface

--- a/docs/conversion_examples_gallery/behavior/sleap.rst
+++ b/docs/conversion_examples_gallery/behavior/sleap.rst
@@ -1,5 +1,5 @@
 SLEAP data conversion
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading sleap data.
 
@@ -7,19 +7,19 @@ Install NeuroConv with the additional dependencies necessary for reading sleap d
 
     pip install neuroconv[sleap]
 
-Convert SLEAP pose estimation data to NWB using :py:class:`~neuroconv.datainterfaces.behavior.sleap.sleapdatainterface.SleapInterface`.
+Convert SLEAP pose estimation data to NWB using :py:class:`~neuroconv.datainterfaces.behavior.sleap.sleapdatainterface.SLEAPInterface`.
 
 .. code-block:: python
 
     >>> from datetime import datetime
     >>> from dateutil import tz
     >>> from pathlib import Path
-    >>> from neuroconv.datainterfaces import SleapInterface
+    >>> from neuroconv.datainterfaces import SLEAPInterface
     >>>
     >>> # Change the file_path so it points to the slp file in your system
     >>> file_path = BEHAVIOR_DATA_PATH / "sleap" / "predictions_1.2.7_provenance_and_tracking.slp"
     >>>
-    >>> interface = SleapInterface(file_path=file_path, verbose=False)
+    >>> interface = SLEAPInterface(file_path=file_path, verbose=False)
     >>>
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()

--- a/docs/conversion_examples_gallery/behavior/sleap.rst
+++ b/docs/conversion_examples_gallery/behavior/sleap.rst
@@ -1,0 +1,36 @@
+SLEAP data conversion
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Install NeuroConv with the additional dependencies necessary for reading sleap data.
+
+.. code-block:: bash
+
+    pip install neuroconv[sleap]
+
+Convert SLEAP pose estimation data to NWB using :py:class:`~neuroconv.datainterfaces.behavior.sleap.sleapdatainterface.SleapInterface`.
+
+.. code-block:: python
+
+    >>> from datetime import datetime
+    >>> from dateutil import tz
+    >>> from pathlib import Path
+    >>> from neuroconv.datainterfaces import SleapInterface
+    >>>
+    >>> # Change the file_path so it points to the slp file in your system
+    >>> file_path = BEHAVIOR_DATA_PATH / "sleap" / "predictions_1.2.7_provenance_and_tracking.slp"
+    >>>
+    >>> interface = SleapInterface(file_path=file_path, verbose=False)
+    >>>
+    >>> # Extract what metadata we can from the source files
+    >>> metadata = interface.get_metadata()
+    >>> # session_start_time is required for conversion. If it cannot be inferred
+    >>> # automatically from the source files you must supply one.
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=tz.gettz("US/Pacific")).isoformat()
+    >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>>
+    >>> # Choose a path for saving the nwb file and run the conversion
+    >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "saved_file.nwb"
+    >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)
+    >>>
+    >>> Path(nwbfile_path).is_file()
+    True

--- a/docs/conversion_examples_gallery/conversion_example_gallery.rst
+++ b/docs/conversion_examples_gallery/conversion_example_gallery.rst
@@ -79,3 +79,4 @@ Behavior
     :maxdepth: 1
 
     DeepLabCut <behavior/deeplabcut>
+    SLEAP <behavior/sleap>

--- a/src/neuroconv/datainterfaces/behavior/sleap/sleapdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/sleap/sleapdatainterface.py
@@ -66,5 +66,3 @@ class SleapInterface(BaseDataInterface):
 
             labels = self.sleap_io.load_slp(self.file_path)
             nwbfile_out = self.sleap_io.append_labels_data_to_nwb(labels, nwbfile_out)
-
-        return nwbfile_out

--- a/tests/imports.py
+++ b/tests/imports.py
@@ -68,6 +68,7 @@ class TestImportStructure(TestCase):
             # Behavior
             "DeepLabCutInterface",
             "MovieInterface",
+            "SleapInterface",
             # Ecephys
             "AxonaRecordingInterface",
             "AxonaPositionDataInterface",


### PR DESCRIPTION
Adds the upcoming sleap data interface to the conversion gallery and documentation API. This should come after #160.