### PR TITLE
[Proposal] Combine simple examples in gallery with NWBConverter

### DIFF
--- a/docs/conversion_examples_gallery/combinations/recording_and_sorting.rst
+++ b/docs/conversion_examples_gallery/combinations/recording_and_sorting.rst
@@ -1,0 +1,43 @@
+Conversion combining electrophysiological recordings and spike sorting data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A common workflow is to record electrophysiological data and then extract spiking units from the stream. The following is an
+example of how to combine electrophysiological recordings and spike sorting data in the same conversion.
+
+Note that for this specific example were using SpikeGLXRecordingInterface (insert link) and PhySortingInterface (insert link)but any
+of the other examples in our conversion gallery (insert link to recorders and sorters) can be combined in this way.
+
+.. code-block:: python
+
+    >>> from datetime import datetime
+    >>> from dateutil import tz
+    >>> from pathlib import Path
+    >>> from neuroconv.datainterfaces import SpikeGLXRecordingInterface
+    >>> from neuroconv.datainterfaces import PhySortingInterface
+    >>>
+    >>> from neuroconv import NWBConverter
+    >>> ECEPHY_DATA_PATH = Path("/home/heberto/ephy_testing_data/")
+    >>>
+    >>> # For this interface we need to pass the location of the ``.bin`` file
+    >>> file_path = f"{ECEPHY_DATA_PATH}/spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0/Noise4Sam_g0_t0.imec0.ap.bin"
+    >>> # Change the file_path to the location in your system
+    >>> interface_spikeglx = SpikeGLXRecordingInterface(file_path=file_path, verbose=False)
+    >>>
+    >>> folder_path = f"{ECEPHY_DATA_PATH}/phy/phy_example_0"
+    >>> # Change the folder_path to the location of the data in your system
+    >>> interface_phy = PhySortingInterface(folder_path=folder_path, verbose=False)
+    >>>
+    >>>  # Now that we have defined the two interfaces we pass them to the NWBConverter which will coordinate the
+    >>>  # concurrent conversion of the data
+    >>> converter = NWBConverter(data_interfaces=[interface_spikeglx, interface_phy])
+    >>>
+    >>> # Extract what metadata we can from the source files
+    >>> metadata = converter.get_metadata()
+    >>> # For data provenance we add the time zone information to the conversion
+    >>> tzinfo = tz.gettz("US/Pacific")
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=tz.gettz("US/Pacific")).isoformat()
+    >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>>
+    >>> # Choose a path for saving the nwb file and run the conversion
+    >>> nwbfile_path = f"test.nwb"
+    >>> converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)

--- a/docs/conversion_examples_gallery/conversion_example_gallery.rst
+++ b/docs/conversion_examples_gallery/conversion_example_gallery.rst
@@ -80,3 +80,12 @@ Behavior
 
     DeepLabCut <behavior/deeplabcut>
     SLEAP <behavior/sleap>
+
+Examples of common interface combinations
+-----------------------------------------
+
+.. toctree::
+    :maxdepth: 1
+
+    Combine electrophysiological recordings and spike sorting <combinations/recording_and_sorting>
+    SLEAP <behavior/sleap>


### PR DESCRIPTION
Right now we have the conversion gallery which as simple as possible illustrates how to do conversion with a simple interface:
https://neuroconv.readthedocs.io/en/main/conversion_examples_gallery/conversion_example_gallery.html#extracellular-electrophysiology

In order to combine more than one interface we use the NWBConverter object but the tutorial, in my view, is not as simple as the one for the simple gallery:
https://neuroconv.readthedocs.io/en/main/user_guide/nwbconverter.html

To be specific, the complexities that I see to the end user are the following:
1) They need to define a class themselves and inherit from the converter
2)  To define all the properties they need to use a structure of nested dictionaries for the source data, conversion options and metadata. 

I feel that this creates an unnecessary gap in complexity between single interface conversion and multiple interface conversion and I want to propose some solutions.  This PR is an unpolished prototype of what I believe is the simplest idea:

If we add the possibility to the `NWBConverter` object to take as an input already initialized interfaces (as defined in the conversion gallery) then we retain all the functionality of the NWBConverter object that we had before. In addition, users can use all the information of the single interface conversion examples in the gallery to build their interfaces and then just combine them using a simple input pass to the `NWBConverter` object. 

To illustrate this idea I add to this PR the necessary changes to enable this and a conversion gallery example which shows how to combine recording and sorting interfaces in a single conversion. 

