### PR TITLE
Spikeglx to use datetime object in metadata

### DIFF
--- a/docs/conversion_examples_gallery/recording/spikeglx.rst
+++ b/docs/conversion_examples_gallery/recording/spikeglx.rst
@@ -25,8 +25,7 @@ Convert SpikeGLX data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
     >>> tzinfo = tz.gettz("US/Pacific")
-    >>> session_start_time = datetime.fromisoformat(metadata["NWBFile"]["session_start_time"])
-    >>> session_start_time = session_start_time.replace(tzinfo=tzinfo).isoformat()
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=tz.gettz("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
@@ -91,7 +91,7 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
         metadata = super().get_metadata()
         session_start_time = get_session_start_time(self.meta)
         if session_start_time:
-            metadata = dict_deep_update(metadata, dict(NWBFile=dict(session_start_time=str(session_start_time))))
+            metadata = dict_deep_update(metadata, dict(NWBFile=dict(session_start_time=session_start_time)))
 
         # Device metadata
         device = self.get_device_metadata()


### PR DESCRIPTION
Simple PR. This should allow a simpler attachment of the timezone property to the metadata.