### PR TITLE
Drop spikeextractor backend support for NeuralynxRecordingInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Removed deprecation warnings for `save_path` argument (which is now `nwbfile_path` everywhere in the package). [PR #124](https://github.com/catalystneuro/neuroconv/pull/124)
 * Changed default device name for the ecephys pipeline. Device_ecephys -> DeviceEcephys [PR #154](https://github.com/catalystneuro/neuroconv/pull/154)
 * Change names of written electrical series on the ecephys pipeline. ElectricalSeries_raw -> ElectricalSeriesRaw, ElectricalSeries_processed -> ElectricalSeriesProcessed, ElectricalSeries_lfp -> ElectricalSeriesLFP  [PR #153](https://github.com/catalystneuro/neuroconv/pull/153)
+* Drop spikeextractor backend support for NeuralynxRecordingInterface [PR #174](https://github.com/catalystneuro/neuroconv/pull/174)
 
 ### Fixes
 * Prevented the CEDRecordingInterface from writing non-ecephys channel data. [PR #37](https://github.com/catalystneuro/neuroconv/pull/37)

--- a/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -81,37 +81,14 @@ class NeuralynxRecordingInterface(BaseRecordingExtractorInterface):
     """Primary data interface for converting Neuralynx data. Uses
     :py:class:`~spikeinterface.extractors.NeuralynxRecordingExtractor`."""
 
-    def __init__(self, folder_path: FolderPathType, spikeextractors_backend: bool = False, verbose: bool = True):
+    def __init__(self, folder_path: FolderPathType, verbose: bool = True):
 
         self.nsc_files = natsorted([str(x) for x in Path(folder_path).iterdir() if ".ncs" in x.suffixes])
 
-        if spikeextractors_backend:
-            from spikeinterface.core.old_api_utils import OldToNewRecording
+        super().__init__(folder_path=folder_path, verbose=verbose)
+        self.recording_extractor = self.recording_extractor.select_segments(segment_indices=0)
 
-            self.initialize_in_spikeextractors(folder_path=folder_path, verbose=verbose)
-            self.recording_extractor = OldToNewRecording(oldapi_recording_extractor=self.recording_extractor)
-        else:
-            super().__init__(folder_path=folder_path, verbose=verbose)
-            self.recording_extractor = self.recording_extractor.select_segments(segment_indices=0)
-
-        # General
         self.add_recording_extractor_properties()
-
-    def initialize_in_spikeextractors(self, folder_path, verbose):
-        from spikeextractors import MultiRecordingChannelExtractor, NeuralynxRecordingExtractor
-
-        self.Extractor = MultiRecordingChannelExtractor
-        self.subset_channels = None
-        self.source_data = dict(folder_path=folder_path, verbose=verbose)
-        self.verbose = verbose
-
-        extractors = [NeuralynxRecordingExtractor(filename=filename, seg_index=0) for filename in self.nsc_files]
-        self.recording_extractor = self.Extractor(extractors)
-
-        gains = [extractor.get_channel_gains()[0] for extractor in extractors]
-        for extractor in extractors:
-            extractor.clear_channel_gains()
-        self.recording_extractor.set_channel_gains(gains=gains)
 
     def add_recording_extractor_properties(self):
 

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -132,17 +132,15 @@ class TestEcephysNwbConversions(unittest.TestCase):
                 case_name="smrx",
             )
         )
-    for spikeextractors_backend in [True, False]:
-        parameterized_recording_list.append(
-            param(
-                data_interface=NeuralynxRecordingInterface,
-                interface_kwargs=dict(
-                    folder_path=str(DATA_PATH / "neuralynx" / "Cheetah_v5.7.4" / "original_data"),
-                    spikeextractors_backend=spikeextractors_backend,
-                ),
-                case_name=f"spikeextractors_backend={spikeextractors_backend}",
-            )
+    parameterized_recording_list.append(
+        param(
+            data_interface=NeuralynxRecordingInterface,
+            interface_kwargs=dict(
+                folder_path=str(DATA_PATH / "neuralynx" / "Cheetah_v5.7.4" / "original_data"),
+            ),
+            case_name=f"",
         )
+    )
 
     for spikeextractors_backend in [True, False]:
         parameterized_recording_list.append(


### PR DESCRIPTION
With this PR we drop support for spikextractor backend support for NeuralynxRecordingInterface. The reason for this is that the old backend does not support multi segment extractor. Plus, this should should make #170 way more simple to implement. I still need to add tests for multi segment neuralynx data but this is a simplifying step into that direction.