### PR TITLE
Remove unneeded GIN files on S3 copy

### DIFF
--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -113,7 +113,7 @@ jobs:
         run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
       - name: Cleanup unneeded files to minimize AWS billing
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
-        run: |  
+        run: |
           rm -rf ./ephy_testing_data/.datalad/
           rm -rf ./ephy_testing_data/.git/
           rm -rf ./ephy_testing_data/.gitattributes

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -63,8 +63,10 @@ jobs:
 
       - name: "Force GIN: ephys download"
         if: steps.cache-ephys-datasets.outputs.cache-hit == false
+        run: datalad install -rg https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
+      - name: Cleanup unneeded files to minimize AWS billing
+        if: steps.cache-ephys-datasets.outputs.cache-hit == false
         run: |
-          datalad install -rg https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
           rm -rf ./ephy_testing_data/.git/
           rm -rf ./ephy_testing_data/.gitattributes
           rm -rf ./ephy_testing_data/.gitignore
@@ -86,8 +88,10 @@ jobs:
 
       - name: "Force GIN: ophys download"
         if: steps.cache-ophys-datasets.outputs.cache-hit == false
+        run: datalad install -rg https://gin.g-node.org/CatalystNeuro/ophys_testing_data
+      - name: Cleanup unneeded files to minimize AWS billing
+        if: steps.cache-ophys-datasets.outputs.cache-hit == false
         run: |
-          datalad install -rg https://gin.g-node.org/CatalystNeuro/ophys_testing_data
           rm -rf ./ephy_testing_data/.datalad/
           rm -rf ./ephy_testing_data/.git/
           rm -rf ./ephy_testing_data/.gitattributes
@@ -106,8 +110,10 @@ jobs:
 
       - name: "Force GIN: behavior download"
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
-        run: |
-          datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
+        run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
+      - name: Cleanup unneeded files to minimize AWS billing
+        if: steps.cache-behavior-datasets.outputs.cache-hit == false
+        run: |  
           rm -rf ./ephy_testing_data/.datalad/
           rm -rf ./ephy_testing_data/.git/
           rm -rf ./ephy_testing_data/.gitattributes

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -63,7 +63,15 @@ jobs:
 
       - name: "Force GIN: ephys download"
         if: steps.cache-ephys-datasets.outputs.cache-hit == false
-        run: datalad install -rg https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
+        run: |
+          datalad install -rg https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
+          rm -rf ./ephy_testing_data/.gitattributes
+          rm -rf ./ephy_testing_data/.gitignore
+          rm -rf ./ephy_testing_data/config.yml
+          rm -rf ./ephy_testing_data/datacite.yml
+          rm -rf ./ephy_testing_data/LICENSE
+          rm -rf ./ephy_testing_data/README.md
+          rm -rf ./ephy_testing_data/utils.py
       - name: Upload ephys dataset to S3
         if: steps.cache-ephys-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -65,6 +65,7 @@ jobs:
         if: steps.cache-ephys-datasets.outputs.cache-hit == false
         run: |
           datalad install -rg https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
+          rm -rf ./ephy_testing_data/.git/
           rm -rf ./ephy_testing_data/.gitattributes
           rm -rf ./ephy_testing_data/.gitignore
           rm -rf ./ephy_testing_data/config.yml
@@ -85,7 +86,13 @@ jobs:
 
       - name: "Force GIN: ophys download"
         if: steps.cache-ophys-datasets.outputs.cache-hit == false
-        run: datalad install -rg https://gin.g-node.org/CatalystNeuro/ophys_testing_data
+        run: |
+          datalad install -rg https://gin.g-node.org/CatalystNeuro/ophys_testing_data
+          rm -rf ./ephy_testing_data/.datalad/
+          rm -rf ./ephy_testing_data/.git/
+          rm -rf ./ephy_testing_data/.gitattributes
+          rm -rf ./ephy_testing_data/.gitignore
+          rm -rf ./ephy_testing_data/README.md  
       - name: Upload ophys dataset to S3
         if: steps.cache-ophys-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
@@ -99,7 +106,13 @@ jobs:
 
       - name: "Force GIN: behavior download"
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
-        run: datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
+        run: |
+          datalad install -rg https://gin.g-node.org/CatalystNeuro/behavior_testing_data
+          rm -rf ./ephy_testing_data/.datalad/
+          rm -rf ./ephy_testing_data/.git/
+          rm -rf ./ephy_testing_data/.gitattributes
+          rm -rf ./ephy_testing_data/.gitignore
+          rm -rf ./ephy_testing_data/README.md  
       - name: Upload behavior dataset to S3
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -92,7 +92,7 @@ jobs:
           rm -rf ./ephy_testing_data/.git/
           rm -rf ./ephy_testing_data/.gitattributes
           rm -rf ./ephy_testing_data/.gitignore
-          rm -rf ./ephy_testing_data/README.md  
+          rm -rf ./ephy_testing_data/README.md
       - name: Upload ophys dataset to S3
         if: steps.cache-ophys-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0
@@ -112,7 +112,7 @@ jobs:
           rm -rf ./ephy_testing_data/.git/
           rm -rf ./ephy_testing_data/.gitattributes
           rm -rf ./ephy_testing_data/.gitignore
-          rm -rf ./ephy_testing_data/README.md  
+          rm -rf ./ephy_testing_data/README.md
       - name: Upload behavior dataset to S3
         if: steps.cache-behavior-datasets.outputs.cache-hit == false
         uses: keithweaver/aws-s3-github-action@v1.0.0


### PR DESCRIPTION
These files aren't needed for our testing purposes with the S3 copy of the data, and since the AWS CLI recursive inclusion/exclusion rules are so tricky, it's easier to just remove them prior to sync to reduce the number of billed requests (and storage space, but that's a way smaller amount).