### PR TITLE
Auto-cancel previous workflow runs

### DIFF
--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
 
 jobs:
+  cancel-previous-runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+
   assess-file-changes:
     uses: catalystneuro/neuroconv/.github/workflows/assess-file-changes.yml@main
 


### PR DESCRIPTION
Noticed this one on PyNWB and thought it might be useful given how heavy our tests are. When there's a new push to a PR where the tests of a previous push were running, this will automatically cancel them. I kind of do this already myself when I need to free up resources (or avoid feeling bad about the cost to the environment) but it's a bit annoying to do it manually.