### PR TITLE
stub Movie interface timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@
 ### Documentation and tutorial enhancements
 * Added a note in User Guide/DataInterfaces to help installing custom dependencies for users who use Z-shell (`zsh`). [PR #180](https://github.com/catalystneuro/neuroconv/pull/180)
 
-
-# v0.2.1
-
 ### Features
 * Added `ConverterPipe`, a class that allows chaining previously intialized interfaces for batch conversion and corresponding tests [PR #169](https://github.com/catalystneuro/neuroconv/pull/169)
+* Added stubbing capabilities to timestamp extraction in the `MovieInterface` avoiding scanning through the whole file when `stub_test=True` [PR #181](https://github.com/catalystneuro/neuroconv/pull/181)
+
+
+# v0.2.1
 
 ### Fixes
 

--- a/src/neuroconv/datainterfaces/behavior/movie/movie_utils.py
+++ b/src/neuroconv/datainterfaces/behavior/movie/movie_utils.py
@@ -21,12 +21,14 @@ class VideoCaptureContext:
         self._frame_count = None
         self._movie_open_msg = "The Movie file is not open!"
 
-    def get_movie_timestamps(self):
+    def get_movie_timestamps(self, max_frames=None):
         """Return numpy array of the timestamps(s) for a movie file."""
         cv2 = get_package(package_name="cv2", installation_instructions="pip install opencv-python")
 
         timestamps = []
-        for _ in tqdm(range(self.get_movie_frame_count()), desc="retrieving timestamps"):
+        total_frames = self.get_movie_frame_count()
+        frames_to_extract = min(total_frames, max_frames) if max_frames else total_frames
+        for _ in tqdm(range(frames_to_extract), desc="retrieving timestamps"):
             success, _ = self.vc.read()
             if not success:
                 break

--- a/tests/test_behavior/test_movie_interface.py
+++ b/tests/test_behavior/test_movie_interface.py
@@ -207,7 +207,10 @@ class TestMovieInterface(TestCase):
             )
 
     def test_movie_stub(self):
-        conversion_opts = dict(Movie=dict(starting_times=self.starting_times, external_mode=False, stub_test=True))
+        timestamps = [1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15]
+        conversion_opts = dict(
+            Movie=dict(starting_times=self.starting_times, timestamps=timestamps, external_mode=False, stub_test=True)
+        )
         self.nwb_converter.run_conversion(
             nwbfile_path=self.nwbfile_path,
             overwrite=True,
@@ -221,6 +224,7 @@ class TestMovieInterface(TestCase):
             for no in range(len(metadata["Behavior"]["Movies"])):
                 movie_interface_name = metadata["Behavior"]["Movies"][no]["name"]
                 assert mod[movie_interface_name].data.shape[0] == 10
+                assert mod[movie_interface_name].timestamps.shape[0] == 10
 
     def test_movie_irregular_timestamps(self):
         timestamps = [1, 2, 4]


### PR DESCRIPTION
While working in the current conversion with Murthy I am facing with some rather large video files and stubbing is very useful for fast iteration. However,  the timestamps themselves are not stubbed and OpenCV goes frame by frame through the whole video rendering the stubbing process useless (even in `external_mode=True`). This PR implements stubbing in the timestamp extraction as well limiting the frame reading in OpenCV.

I added a test and tested this on the Murthy conversion. 