### PR TITLE
Changelog Detector

### DIFF
--- a/.github/workflows/assess-file-changes.yml
+++ b/.github/workflows/assess-file-changes.yml
@@ -10,6 +10,9 @@ on:
       CONVERSION_GALLERY_CHANGED:
         description: "Whether or not the files under /docs/conversion_examples_gallery/ were changed."
         value: ${{ jobs.build.outputs.CONVERSION_GALLERY_CHANGED }}
+      CHANGELOG_UPDATED:
+        description: "Whether or the CHANGELOG.md file was updated."
+        value: ${{ jobs.build.outputs.CHANGELOG_UPDATED }}
 
 jobs:
   build:
@@ -18,6 +21,7 @@ jobs:
     outputs:
       SOURCE_CHANGED: ${{ steps.source-changed.outputs.SOURCE_CHANGED }}
       CONVERSION_GALLERY_CHANGED: ${{ steps.source-changed.outputs.CONVERSION_GALLERY_CHANGED }}
+      CHANGELOG_UPDATED: ${{ steps.assess-changes.outputs.CHANGELOG_UPDATED }}
 
     name: Test changed-files
     steps:
@@ -32,22 +36,30 @@ jobs:
       - name: Assess Source Code Changes
         id: source-changed
         run: |
-          echo "::set-output name=SOURCE_CHANGED::false"
-          echo "::set-output name=CONVERSION_GALLERY_CHANGED::false"
+          echo "SOURCE_CHANGED=false" >> $GITHUB_OUTPUT
+          echo "CONVERSION_GALLERY_CHANGED=false" >> $GITHUB_OUTPUT
+          echo "CHANGELOG_UPDATED=false" >> $GITHUB_OUTPUT
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             echo $file
             if [[ $file == "src/"* || $file == "tests/"* || $file == "requirements-minimal.txt" || $file == "requirements-testing.txt" || $file == "setup.py" ]]
             then
               echo "Source changed"
-              echo "::set-output name=SOURCE_CHANGED::true"
+              echo "SOURCE_CHANGED=true" >> $GITHUB_OUTPUT
             else
               echo "Source not changed"
             fi
             if [[ $file == "docs/conversion_examples_gallery/"* ]]
             then
               echo "Conversion gallery changed"
-              echo "::set-output name=CONVERSION_GALLERY_CHANGED::true"
+              echo "CONVERSION_GALLERY_CHANGED=true" >> $GITHUB_OUTPUT
             else
               echo "Conversion gallery not changed"
+            fi
+            if [[ $file == "CHANGELOG.md" ]]
+            then
+              echo "Changelog updated"
+              echo "CHANGELOG_UPDATED=true" >> $GITHUB_OUTPUT
+            else
+              echo "Changelog not updated"
             fi
           done

--- a/.github/workflows/assess-file-changes.yml
+++ b/.github/workflows/assess-file-changes.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     # Map the job outputs to step outputs
     outputs:
-      SOURCE_CHANGED: ${{ steps.source-changed.outputs.SOURCE_CHANGED }}
-      CONVERSION_GALLERY_CHANGED: ${{ steps.source-changed.outputs.CONVERSION_GALLERY_CHANGED }}
+      SOURCE_CHANGED: ${{ steps.assess-changes.outputs.SOURCE_CHANGED }}
+      CONVERSION_GALLERY_CHANGED: ${{ steps.assess-changes.outputs.CONVERSION_GALLERY_CHANGED }}
       CHANGELOG_UPDATED: ${{ steps.assess-changes.outputs.CHANGELOG_UPDATED }}
 
     name: Test changed-files
@@ -34,7 +34,7 @@ jobs:
         uses: tj-actions/changed-files@v29.0.4
 
       - name: Assess Source Code Changes
-        id: source-changed
+        id: assess-changes
         run: |
           echo "SOURCE_CHANGED=false" >> $GITHUB_OUTPUT
           echo "CONVERSION_GALLERY_CHANGED=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -11,7 +11,7 @@ jobs:
         uses: styfle/cancel-workflow-action@0.9.1
 
   assess-file-changes:
-    uses: catalystneuro/neuroconv/.github/workflows/assess-file-changes.yml@main
+    uses: catalystneuro/neuroconv/.github/workflows/assess-file-changes.yml@check_for_changelog_updates
 
   detect-changelog-updates:
     needs: assess-file-changes

--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -13,6 +13,18 @@ jobs:
   assess-file-changes:
     uses: catalystneuro/neuroconv/.github/workflows/assess-file-changes.yml@main
 
+  detect-changelog-updates:
+    needs: assess-file-changes
+    name: Auto-detecting CHANGELOG.md updates
+    runs-on: ubuntu-latest
+    steps:
+      - if:  ${{ needs.assess-file-changes.outputs.CHANGELOG_UPDATED == 'true' }}
+        run: echo "CHANGELOG.md has been updated."
+      - if:  ${{ needs.assess-file-changes.outputs.CHANGELOG_UPDATED == 'false' }}
+        run: |
+          echo "CHANGELOG.md has not been updated."
+          0
+
   run-tests:
     needs: assess-file-changes
     if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added a set of dev branch gallery tests for PyNWB, HDMF, SI, and NEO. [PR #113](https://github.com/catalystneuro/neuroconv/pull/113)
 * Added tests for the `TypeError` and `ValueError` raising for the new `starting_frames` argument of `MovieDataInterface.run_conversion()`. [PR #113](https://github.com/catalystneuro/neuroconv/pull/113)
+* Added workflow for automatic detection of CHANGELOG.md updates for PRs. [PR #187](https://github.com/catalystneuro/neuroconv/pull/187)
 
 ### Fixes
 


### PR DESCRIPTION
Inspired by #184 for detecting if the `CHANGELOG.md` file was updated automatically, solving the case where both PR-submitter and PR-reviewer forget to check for that.

Already in use on the Fee lab: https://github.com/catalystneuro/fee-lab-to-nwb/pull/41

Also updating some lines related to setting of GitHub action environment variables, which is in a deprecating warning cycle from the old version (red text here) to the new version (green text here).