### PR TITLE
Added capture for memory leak in ImagingExtractorDataChunkIterator

### DIFF
--- a/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
@@ -80,6 +80,8 @@ class BaseImagingExtractorInterface(BaseExtractorInterface):
         overwrite: bool = False,
         stub_test: bool = False,
         stub_frames: int = 100,
+        iterator_type: Optional[str] = "v2",
+        iterator_options: Optional[dict] = None,
     ):
         from ...tools.roiextractors import write_imaging
 
@@ -96,4 +98,6 @@ class BaseImagingExtractorInterface(BaseExtractorInterface):
             metadata=metadata,
             overwrite=overwrite,
             verbose=self.verbose,
+            iterator_type=iterator_type,
+            iterator_options=iterator_options,
         )

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -20,7 +20,9 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
         maxshape = np.array(self.maxshape)
 
         # Early termination condition
-        if np.prod(maxshape) * self.dtype.itemsize / 1e9 < buffer_gb:
+        if (
+            np.prod(maxshape) * self.dtype.itemsize / 1e9 < buffer_gb
+        ):  # TODO: also getting overflow here; might be safer though due to sign on inequality. Should still fix
             return tuple(self.maxshape)
 
         buffer_bytes = chunk_bytes

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -3,8 +3,9 @@ import warnings
 from typing import Tuple, Optional
 
 import numpy as np
-from hdmf.data_utils import GenericDataChunkIterator
 from roiextractors import ImagingExtractor
+
+from ..hdmf import GenericDataChunkIterator
 
 
 class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
@@ -93,7 +94,7 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
 
         warnings.filterwarnings(action="error")
         try:
-            scaling_factor = np.floor((buffer_gb * 1e9 / (np.prod(min_buffer_shape) * itemsize)))
+            scaling_factor = np.floor((buffer_gb * 1e9 / (np.prod(min_buffer_shape, dtype=np.int64) * itemsize)))
         except RuntimeWarning:  # buffer overflow, which can lead to an unintended memory leak
             raise RuntimeError(
                 "The ImagingExtractorDataChunkIterator encountered a buffer overflow with values...\n\n"

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -94,7 +94,7 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
 
         warnings.filterwarnings(action="error")
         try:
-            scaling_factor = np.floor((buffer_gb * 1e9 / (np.prod(min_buffer_shape, dtype=np.int64) * itemsize)))
+            scaling_factor = np.floor(buffer_gb * 1e9 / (np.prod(min_buffer_shape, dtype=np.int64) * itemsize))
         except RuntimeWarning:  # buffer overflow, which can lead to an unintended memory leak
             raise RuntimeError(
                 "The ImagingExtractorDataChunkIterator encountered a buffer overflow with values...\n\n"
@@ -107,8 +107,11 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
         max_buffer_shape = tuple([int(scaling_factor * min_buffer_shape[0])]) + image_size
         scaled_buffer_shape = tuple(
             [
-                min(max(int(dimension_length), chunk_shape[dimension_index]), self._get_maxshape()[dimension_index])
-                for dimension_index, dimension_length in enumerate(max_buffer_shape)
+                min(
+                    max(int(target_dimension_length), chunk_shape[dimension_index]),  # Minimum shape is chunk shape
+                    self._get_maxshape()[dimension_index],  # Maximuum size is the maxshape for each axis
+                )
+                for dimension_index, target_dimension_length in enumerate(max_buffer_shape)
             ]
         )
         return scaled_buffer_shape


### PR DESCRIPTION
Branched from #193 

WIP (need to add test and figure out how to fix it)

The `ImagingExtractorDataChunkIterator` resulted in a memory leak during my non-stub attempt to write a file for the Ahrens project.

I've identified the source (thanks to warnings from numpy) but to make things safe (otherwise the excess RAM usage eventually kills my entire device) I've added a capture that elevates the problem to an error and makes it more informative.

Error message appears like

![image](https://user-images.githubusercontent.com/51133164/198495514-7cf3671c-bb51-41e0-a86b-6a7fcb91afe2.png)
