### PR TITLE
Include session_id in automatic dandi upload test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Documentation and tutorial enhancements
 * Remove `Path(path_to_save_nwbfile).is_file()` from each of the gallery pages. [PR #177](https://github.com/catalystneuro/neuroconv/pull/177)
 
+### Testing
+* Added a `session_id` to the test file for the `automatic_dandi_upload` helper function. [PR #199](https://github.com/catalystneuro/neuroconv/pull/199)
+
 # v0.2.2
 
 ### Testing

--- a/tests/test_minimal/test_tools.py
+++ b/tests/test_minimal/test_tools.py
@@ -186,7 +186,7 @@ class TestAutomaticDANDIUpload(TestCase):
         self.nwb_folder_path = self.tmpdir / "test_nwb"
         self.nwb_folder_path.mkdir()
         metadata = get_default_nwbfile_metadata()
-        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
+        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone(), session_id="test_automatic_upload")
         metadata.update(Subject=dict(subject_id="foo"))
         with NWBHDF5IO(path=self.nwb_folder_path / "test_nwb_1.nwb", mode="w") as io:
             io.write(make_nwbfile_from_metadata(metadata=metadata))


### PR DESCRIPTION
## Motivation

A part of our helper functions for running a fully automated transfer+conversion+upload workflow is a one-liner for an automatic dandi upload (given the api token is set as an environment variable). This goes to https://gui-staging.dandiarchive.org/dandiset/200560/draft/files?location=sub-foo, which I just noticed has a `None` as the session ID. So this sets it to be a bit clearer.
