### PR TITLE
Amend rate and fps warning in video interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 ### Testing
 * Added a `session_id` to the test file for the `automatic_dandi_upload` helper function. [PR #199](https://github.com/catalystneuro/neuroconv/pull/199)
 
+### Fixes
+* `VideoInterface`. Only raise a warning if the difference between the rate estimated from timestamps and the fps (frames per seconds) is larger than two decimals. [PR #200](https://github.com/catalystneuro/neuroconv/pull/200)
+* Fixed the bug in a `VideoInterface` where it would use `DataChunkIterator` even if the conversion options indicated that it should not. [PR #200](https://github.com/catalystneuro/neuroconv/pull/200)
+
 # v0.2.2
 
 ### Testing

--- a/tests/test_behavior/test_video_interface.py
+++ b/tests/test_behavior/test_video_interface.py
@@ -271,7 +271,8 @@ class TestMovieInterface(TestCase):
             metadata = self.nwb_converter.get_metadata()
             for video_metadata in metadata["Behavior"]["Movies"]:
                 video_interface_name = video_metadata["name"]
-                assert acquisition_module[video_interface_name].rate == 1 / (timestamps[1] - timestamps[0])
+                expected_rate = round(1 / (timestamps[1] - timestamps[0]), 2)
+                assert acquisition_module[video_interface_name].rate == expected_rate
                 assert acquisition_module[video_interface_name].timestamps is None
 
     def test_starting_frames_type_error(self):


### PR DESCRIPTION
For the conversion that I am working on (Murthy) I am transforming multiple videos. Their timestamps are 60 fps but when estimated with our `calculate_regular_series_rate` the estimate becomes 60.0000001 which is unequal to the 60 that the video context is extracting (the correct one). This raises a warning and stores the rate as 60.00001 which is an inaccuracy that arises from our floating point estimate. 

This PR solves this problem for by making the comparison with the estimated rates rounded to two decimals. Standard constant frame rate formats don't meaningfully differ by that amount. 

Also, I realized that the `VideoInterface` was using `DataChunkIterator` even when the conversion option `chunk_data` was False. I changed that.