### PR TITLE
Do not wrap data in H5DataIO if compression is None

### DIFF
--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -689,9 +689,12 @@ def add_electrical_series(
         iterator_type=iterator_type,
         iterator_opts=iterator_opts,
     )
-    eseries_kwargs.update(
-        data=H5DataIO(data=ephys_data_iterator, compression=compression, compression_opts=compression_opts)
-    )
+    if compression is None:
+        eseries_kwargs.update(data=ephys_data_iterator)
+    else:
+        eseries_kwargs.update(
+            data=H5DataIO(data=ephys_data_iterator, compression=compression, compression_opts=compression_opts)
+        )
 
     # Timestamps vs rate
     timestamps = checked_recording.get_times(segment_index=segment_index)

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -689,7 +689,7 @@ def add_electrical_series(
         iterator_type=iterator_type,
         iterator_opts=iterator_opts,
     )
-    if compression is None:
+    if compression == "zarr":
         eseries_kwargs.update(data=ephys_data_iterator)
     else:
         eseries_kwargs.update(


### PR DESCRIPTION
Fix #202 

@alejoe91 Can you give this a try? Just set `compression=None` for now to make sure it works and we can discuss how best to add support for Zarr compression specification