### PR TITLE
Add PlexonRecordingInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Documentation and tutorial enhancements
 * Remove `Path(path_to_save_nwbfile).is_file()` from each of the gallery pages. [PR #177](https://github.com/catalystneuro/neuroconv/pull/177)
 
+### Features
+* Added the `PlexonRecordingInterface` for writing data stored in Plexon (.plx) format. [PR #206](https://github.com/catalystneuro/neuroconv/pull/206)
+
 ### Testing
 * Added a `session_id` to the test file for the `automatic_dandi_upload` helper function. [PR #199](https://github.com/catalystneuro/neuroconv/pull/199)
 
@@ -10,8 +13,7 @@
 * `VideoInterface`. Only raise a warning if the difference between the rate estimated from timestamps and the fps (frames per seconds) is larger than two decimals. [PR #200](https://github.com/catalystneuro/neuroconv/pull/200)
 * Fixed the bug in a `VideoInterface` where it would use `DataChunkIterator` even if the conversion options indicated that it should not. [PR #200](https://github.com/catalystneuro/neuroconv/pull/200)
 
-### Features
-* Added function to add acoustic series as AcousticWaveformSeries object as __acquisition__ or __stimulus__ to NWB. [PR #201](https://github.com/catalystneuro/neuroconv/pull/201)
+
 
 # v0.2.2
 
@@ -33,7 +35,6 @@
 * Added a note in User Guide/DataInterfaces to help installing custom dependencies for users who use Z-shell (`zsh`). [PR #180](https://github.com/catalystneuro/neuroconv/pull/180)
 * Added `MovieInterface` example in the conversion gallery. [PR #183](https://github.com/catalystneuro/neuroconv/pull/183)
 
-
 ### Features
 * Added `ConverterPipe`, a class that allows chaining previously intialized interfaces for batch conversion and corresponding tests [PR #169](https://github.com/catalystneuro/neuroconv/pull/169)
 * Added automatic extraction of metadata for `NeuralynxRecordingInterface` including filtering information for channels, device and recording time information [PR #170](https://github.com/catalystneuro/neuroconv/pull/170)
@@ -42,6 +43,7 @@
 
 ### Pending deprecation
 * Replaced the `MovieInterface` with `VideoInterface` and introduced deprecation warnings for the former. [PR #74](https://github.com/catalystneuro/neuroconv/pull/74)
+
 
 
 # v0.2.1

--- a/docs/conversion_examples_gallery/conversion_example_gallery.rst
+++ b/docs/conversion_examples_gallery/conversion_example_gallery.rst
@@ -21,6 +21,7 @@ Recording
     Neuralynx <recording/neuralynx>
     NeuroScope <recording/neuroscope>
     OpenEphys <recording/openephys>
+    Plexon <recording/plexon>
     Spikegadgets <recording/spikegadgets>
     SpikeGLX <recording/spikeglx>
     EDF <recording/edf>

--- a/docs/conversion_examples_gallery/recording/plexon.rst
+++ b/docs/conversion_examples_gallery/recording/plexon.rst
@@ -7,7 +7,7 @@ Install NeuroConv with the additional dependencies necessary for reading Plexon 
 
     pip install neuroconv[plexon]
 
-Convert edf data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.plexon.plexondatainterface.PlexonRecordingInterface`.
+Convert edf data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.plexon.plexondatainterface.PlexonRecordingInterface`. Currently, only .plx is supported.
 
 .. code-block:: python
 

--- a/docs/conversion_examples_gallery/recording/plexon.rst
+++ b/docs/conversion_examples_gallery/recording/plexon.rst
@@ -1,0 +1,31 @@
+European Data Format (EDF) conversion
+-------------------------------------
+
+Install NeuroConv with the additional dependencies necessary for reading EDF data.
+
+.. code-block:: bash
+
+    pip install neuroconv[plexon]
+
+Convert edf data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.plexon.plexondatainterface.PlexonRecordingInterface`.
+
+.. code-block:: python
+
+    >>> from datetime import datetime
+    >>> from dateutil import tz
+    >>> from pathlib import Path
+    >>> from neuroconv.datainterfaces import PlexonRecordingInterface
+    >>>
+    >>> file_path = f"{ECEPHY_DATA_PATH}/plexon/File_plexon_3.plx"
+    >>> # Change the file_path to the location in your system
+    >>> interface = PlexonRecordingInterface(file_path=file_path, verbose=False)
+    >>>
+    >>> # Extract what metadata we can from the source files
+    >>> metadata = interface.get_metadata()
+    >>> # For data provenance we add the time zone information to the conversion
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=tz.gettz("US/Pacific"))
+    >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>>
+    >>> # Choose a path for saving the nwb file and run the conversion
+    >>> nwbfile_path = f"{path_to_save_nwbfile}"
+    >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)

--- a/docs/conversion_examples_gallery/recording/plexon.rst
+++ b/docs/conversion_examples_gallery/recording/plexon.rst
@@ -1,7 +1,7 @@
-European Data Format (EDF) conversion
+Plexon conversion
 -------------------------------------
 
-Install NeuroConv with the additional dependencies necessary for reading EDF data.
+Install NeuroConv with the additional dependencies necessary for reading Plexon data.
 
 .. code-block:: bash
 

--- a/src/neuroconv/datainterfaces/__init__.py
+++ b/src/neuroconv/datainterfaces/__init__.py
@@ -33,6 +33,7 @@ from .ecephys.phy.phydatainterface import PhySortingInterface
 from .ecephys.kilosort.kilosortdatainterface import KiloSortSortingInterface
 from .ecephys.edf.edfdatainterface import EDFRecordingInterface
 from .ecephys.tdt.tdtdatainterface import TdtRecordingInterface
+from .ecephys.plexon.plexondatainterface import PlexonRecordingInterface
 
 # Icephys
 from .icephys.abf.abfdatainterface import AbfInterface
@@ -84,6 +85,7 @@ interface_list = [
     AxonaUnitRecordingInterface,
     EDFRecordingInterface,
     TdtRecordingInterface,
+    PlexonRecordingInterface,
     # Icephys
     AbfInterface,
     # Ophys

--- a/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
@@ -1,0 +1,26 @@
+"""Authors: Cody Baker."""
+from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
+
+from ....utils.types import FilePathType
+
+
+class PlexonRecordingInterface(BaseRecordingExtractorInterface):
+    """
+    Primary data interface class for converting Plexon data.
+
+    Uses the :py:class:`~spikeinterface.extractors.PlexonRecordingExtractor`.
+    """
+
+    def __init__(self, file_path: FilePathType, verbose: bool = True):
+        """
+        Load and prepare data for Plexon.
+
+        Parameters
+        ----------
+        file_path: string or Path
+            Path to the Plexon file.
+        verbose: boolean
+            Allows verbosity.
+            Default is True.
+        """
+        super().__init__(file_path=file_path, verbose=verbose)

--- a/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
@@ -18,7 +18,7 @@ class PlexonRecordingInterface(BaseRecordingExtractorInterface):
         Parameters
         ----------
         file_path: string or Path
-            Path to the Plexon file.
+            Path to the .plx file.
         verbose: boolean
             Allows verbosity.
             Default is True.

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -308,9 +308,14 @@ class TestEcephysNwbConversions(unittest.TestCase):
                 channel_ids=recording.get_channel_ids(), renamed_channel_ids=renamed_channel_ids
             )
 
-            check_recordings_equal(RX1=recording, RX2=nwb_recording, return_scaled=False)
-            if recording.has_scaled_traces() and nwb_recording.has_scaled_traces():
-                check_recordings_equal(RX1=recording, RX2=nwb_recording, return_scaled=True)
+            # Edge case that only occurs in testing, but should eventually be fixed nonetheless
+            # The NwbRecordingExtractor on spikeinterface experiences an issue when duplicated channel_ids
+            # are specified, which occurs during check_recordings_equal when there is only one channel
+            si_test_ch = [nwb_recording.get_channel_ids()[0], nwb_recording.get_channel_ids()[-1]]
+            if len(si_test_ch) == len(set(si_test_ch)):
+                check_recordings_equal(RX1=recording, RX2=nwb_recording, return_scaled=False)
+                if recording.has_scaled_traces() and nwb_recording.has_scaled_traces():
+                    check_recordings_equal(RX1=recording, RX2=nwb_recording, return_scaled=True)
 
     parameterized_sorting_list = [
         param(

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -311,8 +311,7 @@ class TestEcephysNwbConversions(unittest.TestCase):
             # Edge case that only occurs in testing, but should eventually be fixed nonetheless
             # The NwbRecordingExtractor on spikeinterface experiences an issue when duplicated channel_ids
             # are specified, which occurs during check_recordings_equal when there is only one channel
-            si_test_ch = [nwb_recording.get_channel_ids()[0], nwb_recording.get_channel_ids()[-1]]
-            if len(si_test_ch) == len(set(si_test_ch)):
+            if nwb_recording.get_channel_ids()[0] != nwb_recording.get_channel_ids()[-1]:
                 check_recordings_equal(RX1=recording, RX2=nwb_recording, return_scaled=False)
                 if recording.has_scaled_traces() and nwb_recording.has_scaled_traces():
                     check_recordings_equal(RX1=recording, RX2=nwb_recording, return_scaled=True)

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -41,6 +41,7 @@ from neuroconv.datainterfaces import (
     AxonaLFPDataInterface,
     EDFRecordingInterface,
     TdtRecordingInterface,
+    PlexonRecordingInterface,
 )
 
 
@@ -136,6 +137,14 @@ class TestEcephysNwbConversions(unittest.TestCase):
                 file_path=str(DATA_PATH / "blackrock" / "blackrock_2_1" / "l101210-001.ns2"),
             ),
             case_name="multi_stream_case_ns2",
+        ),
+        param(
+            data_interface=PlexonRecordingInterface,
+            interface_kwargs=dict(
+                # Only File_plexon_3.plx has an ecephys recording stream
+                file_path=str(DATA_PATH / "plexon" / "File_plexon_3.plx"),
+            ),
+            case_name="plexon_recording",
         ),
     ]
     this_python_version = version.parse(python_version())


### PR DESCRIPTION
fix #204 

## Motivation

Adding a PlexonRecordingInterface.

Only the 3rd file in the GIN repo has a recording stream: https://gin.g-node.org/NeuralEnsemble/ephy_testing_data/src/master/plexon

The rest seem to focus on storing the data as waveforms; once Alessio opens up his PR for `write_waveforms` we may want to consider adding `WaveformInterfaces` for the formats that support that data structure.

The header is Intan-like and does not have much extra beyond typical channel properties. Also no session start time.

Example output file: [PlexonRecordingInterface_plexon_recording.zip](https://github.com/catalystneuro/neuroconv/files/10077579/PlexonRecordingInterface_plexon_recording.zip)



## How to test the behavior?

Test on GIN data added.

Have to temporarily disable round-trip SI test since [this line](https://github.com/SpikeInterface/spikeinterface/blob/master/spikeinterface/core/testing.py#L28) in `check_recordings_equal` causes duplicated channel IDs to be specified, which HDF5 does not allow (`TypeError: Indexing elements must be in increasing order`). Have raised [an issue](https://github.com/SpikeInterface/spikeinterface/issues/1092) for this on SI (personal opinion: it's bad input to the `get_traces` call; issue with `check_recordings_equal`, not the `NwbRecordingExtractor`).



## Checklist

- [X] Have you thoroughly read our [Developer Guide](https://neuroconv.readthedocs.io/en/main/developer_guide.html)?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/neuroconv/pulls) for the same change?
- [X] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
- [X] Did you update the [CHANGLOG.md](https://github.com/catalystneuro/neuroconv/blob/main/CHANGELOG.md) file on your branch to describe your changes?
