### PR TITLE
Spikeglx parse date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Documentation and tutorial enhancements
 * Remove `Path(path_to_save_nwbfile).is_file()` from each of the gallery pages. [PR #177](https://github.com/catalystneuro/neuroconv/pull/177)
+* Improve docstring for `SpikeGLXRecordingInterface. [PR #226](https://github.com/catalystneuro/neuroconv/pull/226)
 
 ### Features
 * Added `AudioInterface` for files in `WAV` format using the `add_acoustic_waveform_series` utility function

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglx_utils.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglx_utils.py
@@ -61,14 +61,17 @@ def get_session_start_time(recording_metadata: dict) -> datetime:
 
     Returns
     -------
-    datetime
+    datetime or None
         the session start time in datetime format.
     """
 
     session_start_time = recording_metadata.get("fileCreateTime", None)
+    if session_start_time.startswith("0000-00-00"):
+        # date was removed. This sometimes happens with human data to protect the
+        # anonymity of medical patients.
+        return
     if session_start_time:
         session_start_time = datetime.fromisoformat(session_start_time)
-
     return session_start_time
 
 

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
@@ -1,12 +1,10 @@
 """Authors: Cody Baker, Heberto Mayorquin and Ben Dichter."""
 from pathlib import Path
-from typing import Optional
 import json
 
 from pynwb.ecephys import ElectricalSeries
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
-from ..baselfpextractorinterface import BaseLFPExtractorInterface
 from ....utils import get_schema_from_method_signature, get_schema_from_hdmf_class, FilePathType, dict_deep_update
 from .spikeglx_utils import (
     get_session_start_time,
@@ -48,10 +46,22 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         file_path: FilePathType,
-        stub_test: Optional[bool] = False,
-        spikeextractors_backend: Optional[bool] = False,
+        stub_test: bool = False,
+        spikeextractors_backend: bool = False,
         verbose: bool = True,
     ):
+        """
+        Parameters
+        ----------
+        file_path: FilePathType
+            Path to .bin file. Point to .ap.bin for SpikeGLXRecordingInterface and .lf.bin for SpikeGLXLFPInterface.
+        stub_test: bool
+            Whether to shorten file for testing purposes. Default: False.
+        spikeextractors_backend: bool
+            Whether to use the legacy spikeextractors library backend. Default: False.
+        verbose: bool
+            Whether to output verbose text. Default: True.
+        """
         from probeinterface import read_spikeglx
 
         self.stub_test = stub_test


### PR DESCRIPTION
I am working on converting data from https://datadryad.org/stash/dataset/doi:10.5061%2Fdryad.d2547d840

It looks like the date of data collection was removed from the data. This is commonly done to protect the anonymity of medical patients.