### PR TITLE
Bump probeinterface version

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/requirements.txt
+++ b/src/neuroconv/datainterfaces/ecephys/requirements.txt
@@ -1,3 +1,3 @@
 spikeinterface>=0.95.1
 spikeextractors>=0.9.10
-packaging<22.0
+probeinterface>=0.2.15


### PR DESCRIPTION
#195 bypassed an issue between `packaging` and `probeinterface` regarding openephys versioning - looks like this has now been fixed, so testing it here