### PR TITLE
change FilePathType and FolderPathType from TypeVar to Union

### DIFF
--- a/src/neuroconv/utils/types.py
+++ b/src/neuroconv/utils/types.py
@@ -1,12 +1,11 @@
 """Authors: Luiz Tauffer, Cody Baker, Saksham Sharda and Ben Dichter."""
 from pathlib import Path
 from typing import Optional, Union
-from typing import TypeVar
 
 import numpy as np
 
-FilePathType = TypeVar("FilePathType", str, Path)
-FolderPathType = TypeVar("FolderPathType", str, Path)
+FilePathType = Union[str, Path]
+FolderPathType = Union[str, Path]
 OptionalFilePathType = Optional[FilePathType]
 OptionalFolderPathType = Optional[FolderPathType]
 ArrayType = Union[list, np.ndarray]


### PR DESCRIPTION
## Motivation

See this [stackoverflow answer](https://stackoverflow.com/a/58903907). TypeVar enforces consistency across all uses of that typehint, whereas Union is just a simple union and does not enforce consistency. If we have two paths in a single function call, one should be allowed to be a Path while the other is a str, so Union is more appropriate.

## Checklist

- [ ] Have you thoroughly read our [Developer Guide](https://neuroconv.readthedocs.io/en/main/developer_guide.html)?
- [ ] Have you ensured the PR description clearly describes the problem and solutions?
- [ ] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/neuroconv/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
- [ ] Did you update the [CHANGLOG.md](https://github.com/catalystneuro/neuroconv/blob/main/CHANGELOG.md) file on your branch to describe your changes?
