### PR TITLE
improve typehint for Phy

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/phy/phydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/phy/phydatainterface.py
@@ -12,7 +12,7 @@ class PhySortingInterface(BaseSortingExtractorInterface):
     def __init__(
         self,
         folder_path: FolderPathType,
-        exclude_cluster_groups: Optional[list] = None,
+        exclude_cluster_groups: Optional[list[str]] = None,
         verbose: bool = True,
         spikeextractors_backend: bool = False,
     ):


### PR DESCRIPTION
indicating exclude_cluster_groups should be a list of strings


## Checklist

- [ ] Have you thoroughly read our [Developer Guide](https://neuroconv.readthedocs.io/en/main/developer_guide.html)?
- [ ] Have you ensured the PR description clearly describes the problem and solutions?
- [ ] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/neuroconv/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
- [ ] Did you update the [CHANGLOG.md](https://github.com/catalystneuro/neuroconv/blob/main/CHANGELOG.md) file on your branch to describe your changes?
