### PR TITLE
Swap to Pydantic for schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Upcoming
 
+### Features
+* Swapped from `jsonschema.validation` to Pydantic schema parsing for source schemas. [PR #264](https://github.com/catalystneuro/neuroconv/pull/264)
+* Enable validation of all initializations at the DataInterface level. [PR #264](https://github.com/catalystneuro/neuroconv/pull/264)
+
+
+
 # v0.2.3
 
 ### Documentation and tutorial enhancements

--- a/src/neuroconv/basedatainterface.py
+++ b/src/neuroconv/basedatainterface.py
@@ -16,7 +16,7 @@ class BaseDataInterface(ABC):
     @classmethod
     def get_source_model(cls):
         """Infer the Pydantic model for the source_data from the method signature (annotation typing)."""
-        return ValidatedFunction(function=cls.__init__, config=None).model
+        return ValidatedFunction(function=cls.__init__, config=None)
 
     @classmethod
     def get_source_schema(cls):

--- a/src/neuroconv/basedatainterface.py
+++ b/src/neuroconv/basedatainterface.py
@@ -5,9 +5,8 @@ from typing import Optional
 
 from pynwb import NWBFile
 from pydantic.schema import model_schema
-from pydantic.decorator import ValidatedFunction
 
-from .utils import get_base_schema, get_schema_from_method_signature
+from .utils import get_base_schema, get_schema_from_method_signature, get_pydantic_model_from_method_signature
 
 
 class BaseDataInterface(ABC):
@@ -16,7 +15,7 @@ class BaseDataInterface(ABC):
     @classmethod
     def get_source_model(cls):
         """Infer the Pydantic model for the source_data from the method signature (annotation typing)."""
-        return ValidatedFunction(function=cls.__init__, config=None)
+        return get_pydantic_model_from_method_signature(function=cls.__init__, exclude=["self"])
 
     @classmethod
     def get_source_schema(cls):

--- a/src/neuroconv/basedatainterface.py
+++ b/src/neuroconv/basedatainterface.py
@@ -29,7 +29,7 @@ class BaseDataInterface(ABC):
         return get_schema_from_method_signature(cls.run_conversion, exclude=["nwbfile", "metadata"])
 
     def _validate_source(self, source_data: dict):
-        self.get_source_schema().parse_obj(obj=source_data)
+        self.get_source_model().parse_obj(obj=source_data)
 
     def __init__(self, **source_data):
         self.source_data = source_data

--- a/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
@@ -13,7 +13,7 @@ from neuroconv.tools.nwb_helpers import (
 from neuroconv.utils import (
     get_schema_from_hdmf_class,
     get_base_schema,
-    OptionalFilePathType,
+    FilePathType,
 )
 from pynwb import NWBFile, TimeSeries
 
@@ -113,7 +113,7 @@ class AudioInterface(BaseDataInterface):
 
     def run_conversion(
         self,
-        nwbfile_path: OptionalFilePathType = None,
+        nwbfile_path: Optional[FilePathType] = None,
         nwbfile: Optional[NWBFile] = None,
         metadata: Optional[dict] = None,
         stub_test: bool = False,

--- a/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
@@ -7,7 +7,7 @@ from pynwb.file import NWBFile
 from ....basedatainterface import BaseDataInterface
 from ....tools.nwb_helpers import make_or_load_nwbfile
 from ....tools import get_package
-from ....utils import dict_deep_update, FilePathType, OptionalFilePathType
+from ....utils import dict_deep_update, FilePathType
 
 
 class DeepLabCutInterface(BaseDataInterface):
@@ -53,7 +53,7 @@ class DeepLabCutInterface(BaseDataInterface):
 
     def run_conversion(
         self,
-        nwbfile_path: OptionalFilePathType = None,
+        nwbfile_path: Optional[FilePathType] = None,
         nwbfile: Optional[NWBFile] = None,
         metadata: Optional[dict] = None,
         overwrite: bool = False,

--- a/src/neuroconv/datainterfaces/behavior/sleap/sleapdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/sleap/sleapdatainterface.py
@@ -7,7 +7,7 @@ from pynwb.file import NWBFile
 from ....basedatainterface import BaseDataInterface
 from ....tools.nwb_helpers import make_or_load_nwbfile
 from ....tools import get_package
-from ....utils import dict_deep_update, FilePathType, OptionalFilePathType
+from ....utils import dict_deep_update, FilePathType
 
 from .sleap_utils import extract_timestamps
 
@@ -18,7 +18,7 @@ class SLEAPInterface(BaseDataInterface):
     def __init__(
         self,
         file_path: FilePathType,
-        video_file_path: OptionalFilePathType = None,
+        video_file_path: Optional[FilePathType] = None,
         verbose: bool = True,
         frames_per_second: Optional[float] = None,
     ):
@@ -46,7 +46,7 @@ class SLEAPInterface(BaseDataInterface):
 
     def run_conversion(
         self,
-        nwbfile_path: OptionalFilePathType = None,
+        nwbfile_path: Optional[FilePathType] = None,
         nwbfile: Optional[NWBFile] = None,
         metadata: Optional[dict] = None,
         overwrite: bool = False,

--- a/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
@@ -17,7 +17,7 @@ from .video_utils import VideoCaptureContext
 from ....basedatainterface import BaseDataInterface
 from ....tools import get_package
 from ....tools.nwb_helpers import get_module, make_or_load_nwbfile
-from ....utils import get_schema_from_hdmf_class, get_base_schema, calculate_regular_series_rate, OptionalFilePathType
+from ....utils import get_schema_from_hdmf_class, get_base_schema, calculate_regular_series_rate, FilePathType
 
 
 def _check_duplicates(videos_metadata, file_paths):
@@ -106,7 +106,7 @@ class VideoInterface(BaseDataInterface):
 
     def run_conversion(
         self,
-        nwbfile_path: OptionalFilePathType = None,
+        nwbfile_path: Optional[FilePathType] = None,
         nwbfile: Optional[NWBFile] = None,
         metadata: Optional[dict] = None,
         overwrite: bool = False,

--- a/src/neuroconv/datainterfaces/ecephys/alphaomega/alphaomegadatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/alphaomega/alphaomegadatainterface.py
@@ -1,7 +1,6 @@
 """Authors: Cody Baker."""
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
-
-from ....utils.types import FolderPathType
+from ....utils import FolderPathType
 
 
 class AlphaOmegaRecordingInterface(BaseRecordingExtractorInterface):
@@ -23,6 +22,7 @@ class AlphaOmegaRecordingInterface(BaseRecordingExtractorInterface):
             Allows verbose.
             Default is True.
         """
+        self.source_data_to_validate = dict(folder_path=folder_path, verbose=verbose)
         super().__init__(folder_path=folder_path, stream_id="RAW", verbose=verbose)
 
     def get_metadata(self):

--- a/src/neuroconv/datainterfaces/ecephys/baselfpextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baselfpextractorinterface.py
@@ -1,11 +1,12 @@
 """Authors: Cody Baker and Ben Dichter."""
 from typing import Optional, Union
 from pathlib import Path
+
 from pynwb import NWBFile
 from pynwb.ecephys import ElectricalSeries
 
 from .baserecordingextractorinterface import BaseRecordingExtractorInterface
-from ...utils import get_schema_from_hdmf_class, OptionalFilePathType
+from ...utils import get_schema_from_hdmf_class, FilePathType
 
 OptionalPathType = Optional[Union[str, Path]]
 
@@ -29,7 +30,7 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
 
     def run_conversion(
         self,
-        nwbfile_path: OptionalFilePathType = None,
+        nwbfile_path: Optional[FilePathType] = None,
         nwbfile: Optional[NWBFile] = None,
         metadata: Optional[dict] = None,
         overwrite: bool = False,

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -7,7 +7,7 @@ from pynwb.device import Device
 from pynwb.ecephys import ElectrodeGroup
 
 from ...baseextractorinterface import BaseExtractorInterface
-from ...utils import get_schema_from_hdmf_class, get_base_schema, OptionalFilePathType
+from ...utils import get_schema_from_hdmf_class, get_base_schema, FilePathType
 
 
 class BaseRecordingExtractorInterface(BaseExtractorInterface):
@@ -100,7 +100,7 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
 
     def run_conversion(
         self,
-        nwbfile_path: OptionalFilePathType = None,
+        nwbfile_path: Optional[FilePathType] = None,
         nwbfile: Optional[NWBFile] = None,
         metadata: Optional[dict] = None,
         overwrite: bool = False,

--- a/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
@@ -7,7 +7,7 @@ from pynwb.device import Device
 from pynwb.ecephys import ElectrodeGroup
 
 from ...baseextractorinterface import BaseExtractorInterface
-from ...utils import get_base_schema, get_schema_from_hdmf_class, OptionalFilePathType
+from ...utils import get_base_schema, get_schema_from_hdmf_class, FilePathType
 
 
 class BaseSortingExtractorInterface(BaseExtractorInterface):
@@ -100,7 +100,7 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
 
     def run_conversion(
         self,
-        nwbfile_path: OptionalFilePathType = None,
+        nwbfile_path: Optional[FilePathType] = None,
         nwbfile: Optional[NWBFile] = None,
         metadata: Optional[dict] = None,
         overwrite: bool = False,

--- a/src/neuroconv/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -12,7 +12,6 @@ from ....utils import (
     get_schema_from_hdmf_class,
     get_schema_from_method_signature,
     FilePathType,
-    OptionalFilePathType,
 )
 
 
@@ -22,16 +21,14 @@ class BlackrockRecordingInterface(BaseRecordingExtractorInterface):
 
     @classmethod
     def get_source_schema(cls):
-        source_schema = get_schema_from_method_signature(
-            class_method=cls.__init__, exclude=["block_index", "seg_index"]
-        )
+        source_schema = super().get_source_schema()
         source_schema["properties"]["file_path"]["description"] = "Path to Blackrock file."
         return source_schema
 
     def __init__(
         self,
         file_path: FilePathType,
-        nsx_override: OptionalFilePathType = None,
+        nsx_override: Optional[FilePathType] = None,
         verbose: bool = True,
         spikeextractors_backend: bool = False,
     ):
@@ -46,6 +43,13 @@ class BlackrockRecordingInterface(BaseRecordingExtractorInterface):
             False by default. When True the interface uses the old extractor from the spikextractors library instead
             of a new spikeinterface object.
         """
+        self.source_data_to_validate = dict(
+            file_path=file_path,
+            nsx_override=nsx_override,
+            verbose=verbose,
+            spikeextractors_backend=spikeextractors_backend,
+        )
+
         file_path = Path(file_path)
         if file_path.suffix == "":
             assert nsx_override is not None, (
@@ -117,10 +121,9 @@ class BlackrockSortingInterface(BaseSortingExtractorInterface):
 
     @classmethod
     def get_source_schema(cls):
-        metadata_schema = get_schema_from_method_signature(class_method=cls.__init__)
-        metadata_schema["additionalProperties"] = True
-        metadata_schema["properties"]["file_path"].update(description="Path to Blackrock file.")
-        return metadata_schema
+        source_schema = super().get_source_schema()
+        source_schema["properties"]["file_path"].update(description="Path to Blackrock file.")
+        return source_schema
 
     def __init__(self, file_path: FilePathType, sampling_frequency: float = None, verbose: bool = True):
         """

--- a/src/neuroconv/datainterfaces/ecephys/ced/ceddatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/ced/ceddatainterface.py
@@ -22,8 +22,7 @@ class CEDRecordingInterface(BaseRecordingExtractorInterface):
 
     @classmethod
     def get_source_schema(cls):
-        source_schema = get_schema_from_method_signature(class_method=cls.__init__, exclude=["smrx_channel_ids"])
-        source_schema.update(additionalProperties=True)
+        source_schema = super().get_source_schema()
         source_schema["properties"]["file_path"].update(description="Path to CED data file.")
         return source_schema
 
@@ -41,6 +40,7 @@ class CEDRecordingInterface(BaseRecordingExtractorInterface):
         if Path(file_path).suffix == ".smr":
             stream_id = "1"
 
+        self.source_data_to_validate = dict(file_path=file_path, verbose=verbose)
         super().__init__(file_path=file_path, stream_id=stream_id, verbose=verbose)
 
         # Subset raw channel properties

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -17,16 +17,12 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
     def __init__(self, file_path: FilePathType, verbose: bool = True):
         hdf5storage = get_package(package_name="hdf5storage")
 
+        self.source_data_to_validate = dict(file_path=file_path, verbose=verbose)
         super().__init__(spikes_matfile_path=file_path, verbose=verbose)
-        self.source_data = dict(file_path=file_path)
-        spikes_matfile_path = Path(file_path)
 
+        spikes_matfile_path = Path(file_path)
         session_path = Path(file_path).parent
         session_id = session_path.stem
-
-        assert (
-            spikes_matfile_path.is_file()
-        ), f"The file_path should point to an existing .spikes.cellinfo.mat file ({spikes_matfile_path})"
 
         try:
             spikes_mat = scipy.io.loadmat(file_name=str(spikes_matfile_path))
@@ -70,7 +66,7 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
                     self.sorting_extractor.set_unit_property(unit_id=unit_id, property_name="cell_type", value=value)
 
     def get_metadata(self):
-        session_path = Path(self.source_data["file_path"]).parent
+        session_path = Path(self.source_data_to_validate["file_path"]).parent
         session_id = session_path.stem
         # TODO: add condition for retrieving ecephys metadata if no recording or lfp are included in conversion
         metadata = dict(NWBFile=dict(session_id=session_id))

--- a/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -14,6 +14,7 @@ class NeuralynxRecordingInterface(BaseRecordingExtractorInterface):
     :py:class:`~spikeinterface.extractors.NeuralynxRecordingExtractor`."""
 
     def __init__(self, folder_path: FolderPathType, verbose: bool = True):
+        self.source_data_to_validate = dict(folder_path=folder_path, verbose=verbose)
         super().__init__(folder_path=folder_path, verbose=verbose, all_annotations=True)
 
         # convert properties of object dtype (e.g. datetime) and bool as these are not supported by nwb

--- a/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -9,10 +9,10 @@ from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..baselfpextractorinterface import BaseLFPExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
 from ....tools import get_package
-from ....utils import FilePathType, FolderPathType, OptionalFilePathType, get_schema_from_hdmf_class, dict_deep_update
+from ....utils import FilePathType, FolderPathType, get_schema_from_hdmf_class, dict_deep_update
 
 
-def subset_shank_channels(recording_extractor, xml_file_path: str):
+def subset_shank_channels(recording_extractor, xml_file_path: FilePathType):
     """Attempt to create a SubRecordingExtractor containing only channels related to neural data."""
     shank_channels = get_shank_channels(xml_file_path=xml_file_path)
 
@@ -26,7 +26,7 @@ def subset_shank_channels(recording_extractor, xml_file_path: str):
     return sub_recording
 
 
-def add_recording_extractor_properties(recording_extractor, xml_file_path: str, gain: Optional[float] = None):
+def add_recording_extractor_properties(recording_extractor, xml_file_path: FilePathType, gain: Optional[float] = None):
     """Automatically add properties to RecordingExtractor object."""
 
     if gain:
@@ -59,7 +59,7 @@ class NeuroScopeRecordingInterface(BaseRecordingExtractorInterface):
     :py:class:`~spikeinterface.extractors.NeuroScopeRecordingExtractor`."""
 
     @staticmethod
-    def get_ecephys_metadata(xml_file_path: str):
+    def get_ecephys_metadata(xml_file_path: FilePathType):
         """Auto-populates ecephys metadata from the xml_file_path."""
         channel_groups = get_channel_groups(xml_file_path=xml_file_path)
         ecephys_metadata = dict(
@@ -78,7 +78,7 @@ class NeuroScopeRecordingInterface(BaseRecordingExtractorInterface):
         self,
         file_path: FilePathType,
         gain: Optional[float] = None,
-        xml_file_path: OptionalFilePathType = None,
+        xml_file_path: Optional[FilePathType] = None,
         spikeextractors_backend: bool = False,
         verbose: bool = True,
     ):
@@ -156,7 +156,7 @@ class NeuroScopeMultiRecordingTimeInterface(NeuroScopeRecordingInterface):
         self,
         folder_path: FolderPathType,
         gain: Optional[float] = None,
-        xml_file_path: OptionalFilePathType = None,
+        xml_file_path: Optional[FilePathType] = None,
     ):
         """
         Load and prepare raw acquisition data and corresponding metadata from the Neuroscope format (.dat files).
@@ -204,7 +204,7 @@ class NeuroScopeLFPInterface(BaseLFPExtractorInterface):
         self,
         file_path: FilePathType,
         gain: Optional[float] = None,
-        xml_file_path: OptionalFilePathType = None,
+        xml_file_path: Optional[FilePathType] = None,
         spikeextractors_backend: bool = False,
     ):
         """
@@ -266,7 +266,7 @@ class NeuroScopeSortingInterface(BaseSortingExtractorInterface):
         folder_path: FolderPathType,
         keep_mua_units: bool = True,
         exclude_shanks: Optional[list] = None,
-        xml_file_path: OptionalFilePathType = None,
+        xml_file_path: Optional[FilePathType] = None,
         verbose: bool = True,
         spikeextractors_backend: bool = False,
         # TODO: we can enable this once

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysdatainterface.py
@@ -15,9 +15,7 @@ class OpenEphysRecordingInterface(BaseRecordingExtractorInterface):
     @classmethod
     def get_source_schema(cls):
         """Compile input schema for the RecordingExtractor."""
-        source_schema = get_schema_from_method_signature(
-            class_method=cls.__init__, exclude=["recording_id", "experiment_id", "stub_test"]
-        )
+        source_schema = super().get_source_schema()
         source_schema["properties"]["folder_path"]["description"] = "Path to directory containing OpenEphys files."
         return source_schema
 
@@ -71,11 +69,8 @@ class OpenEphysSortingInterface(BaseSortingExtractorInterface):
     @classmethod
     def get_source_schema(cls):
         """Compile input schema for the SortingExtractor."""
-        metadata_schema = get_schema_from_method_signature(
-            class_method=cls.__init__, exclude=["recording_id", "experiment_id"]
-        )
+        metadata_schema = super().get_source_schema()
         metadata_schema["properties"]["folder_path"].update(description="Path to directory containing OpenEphys files.")
-        metadata_schema["additionalProperties"] = False
         return metadata_schema
 
     def __init__(self, folder_path: FolderPathType, experiment_id: int = 0, recording_id: int = 0):

--- a/src/neuroconv/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from pydantic import FilePath
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
-from ....utils import FilePathType, OptionalFilePathType, OptionalArrayType
+from ....utils import FilePathType
 
 
 class SpikeGadgetsRecordingInterface(BaseRecordingExtractorInterface):

--- a/src/neuroconv/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
@@ -1,4 +1,8 @@
 """Authors: Heberto Mayorquin, Cody Baker."""
+from typing import List, Optional
+
+from pydantic import FilePath
+
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ....utils import FilePathType, OptionalFilePathType, OptionalArrayType
 
@@ -18,9 +22,9 @@ class SpikeGadgetsRecordingInterface(BaseRecordingExtractorInterface):
 
     def __init__(
         self,
-        file_path: FilePathType,
-        gains: OptionalArrayType = None,
-        probe_file_path: OptionalFilePathType = None,
+        file_path: FilePath,
+        gains: List[float] = None,
+        probe_file_path: Optional[FilePath] = None,
         verbose: bool = True,
         spikeextractors_backend: bool = False,
     ):
@@ -42,6 +46,13 @@ class SpikeGadgetsRecordingInterface(BaseRecordingExtractorInterface):
             False by default. When True the interface uses the old extractor from the spikextractors library instead
             of a new spikeinterface object.
         """
+        self.source_data_to_validate = dict(
+            file_path=file_path,
+            gains=gains,
+            probe_file_path=probe_file_path,
+            verbose=verbose,
+            spikeextractors_backend=spikeextractors_backend,
+        )
 
         if spikeextractors_backend:
             from spikeextractors import SpikeGadgetsRecordingExtractor, load_probe_file

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
@@ -65,6 +65,12 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
         """
         from probeinterface import read_spikeglx
 
+        self.source_data_to_validate = dict(
+            file_path=file_path,
+            stub_test=stub_test,
+            spikeextractors_backend=spikeextractors_backend,
+            verbose=verbose,
+        )
         self.stub_test = stub_test
         self.stream_id = fetch_stream_id_for_spikelgx_file(file_path)
 
@@ -80,12 +86,6 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
         else:
             file_path = Path(file_path)
             folder_path = file_path.parent
-            self.source_data_to_validate = dict(
-                file_path=file_path,
-                stub_test=stub_test,
-                spikeextractors_backend=spikeextractors_backend,
-                verbose=verbose,
-            )
             super().__init__(folder_path=folder_path, stream_id=self.stream_id, verbose=verbose)
             self.meta = self.recording_extractor.neo_reader.signals_info_dict[(0, self.stream_id)]["meta"]
 

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
@@ -73,15 +73,20 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
             from spikeinterface.core.old_api_utils import OldToNewRecording
 
             self.Extractor = SpikeGLXRecordingExtractor
-            super().__init__(file_path=str(file_path), verbose=verbose)
+            super().__init__(file_path=file_path, verbose=verbose)
             _assert_single_shank_for_spike_extractors(self.recording_extractor)
             self.meta = _fetch_metadata_dic_for_spikextractors_spikelgx_object(self.recording_extractor)
             self.recording_extractor = OldToNewRecording(oldapi_recording_extractor=self.recording_extractor)
         else:
             file_path = Path(file_path)
             folder_path = file_path.parent
+            self.source_data_to_validate = dict(
+                file_path=file_path,
+                stub_test=stub_test,
+                spikeextractors_backend=spikeextractors_backend,
+                verbose=verbose,
+            )
             super().__init__(folder_path=folder_path, stream_id=self.stream_id, verbose=verbose)
-            self.source_data["file_path"] = str(file_path)
             self.meta = self.recording_extractor.neo_reader.signals_info_dict[(0, self.stream_id)]["meta"]
 
         # Mount the probe

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
@@ -3,9 +3,10 @@ from pathlib import Path
 import json
 
 from pynwb.ecephys import ElectricalSeries
+from pydantic import FilePath
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
-from ....utils import get_schema_from_method_signature, get_schema_from_hdmf_class, FilePathType, dict_deep_update
+from ....utils import get_schema_from_method_signature, get_schema_from_hdmf_class, dict_deep_update
 from .spikeglx_utils import (
     get_session_start_time,
     _fetch_metadata_dic_for_spikextractors_spikelgx_object,
@@ -39,13 +40,13 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
 
     @classmethod
     def get_source_schema(cls):
-        source_schema = get_schema_from_method_signature(class_method=cls.__init__, exclude=["x_pitch", "y_pitch"])
+        source_schema = super().get_source_schema()
         source_schema["properties"]["file_path"]["description"] = "Path to SpikeGLX file."
         return source_schema
 
     def __init__(
         self,
-        file_path: FilePathType,
+        file_path: FilePath,
         stub_test: bool = False,
         spikeextractors_backend: bool = False,
         verbose: bool = True,

--- a/src/neuroconv/datainterfaces/icephys/baseicephysinterface.py
+++ b/src/neuroconv/datainterfaces/icephys/baseicephysinterface.py
@@ -1,5 +1,5 @@
 """Author: Luiz Tauffer."""
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 from warnings import warn
 
 from pynwb import NWBFile, NWBHDF5IO
@@ -7,7 +7,7 @@ from pynwb import NWBFile, NWBHDF5IO
 from ...baseextractorinterface import BaseExtractorInterface
 from ...tools.nwb_helpers import make_nwbfile_from_metadata
 from ...utils import (
-    OptionalFilePathType,
+    FilePathType,
     get_schema_from_hdmf_class,
     get_schema_from_method_signature,
     get_metadata_schema_for_icephys,
@@ -33,7 +33,7 @@ class BaseIcephysInterface(BaseExtractorInterface):
         source_schema = get_schema_from_method_signature(class_method=cls.__init__, exclude=[])
         return source_schema
 
-    def __init__(self, file_paths: list):
+    def __init__(self, file_paths: List[FilePathType]):
         from ...tools.neo import get_number_of_electrodes, get_number_of_segments
 
         super().__init__(file_paths=file_paths)
@@ -70,13 +70,13 @@ class BaseIcephysInterface(BaseExtractorInterface):
     def run_conversion(
         self,
         nwbfile: NWBFile = None,
-        nwbfile_path: OptionalFilePathType = None,
+        nwbfile_path: Optional[FilePathType] = None,
         metadata: dict = None,
         overwrite: bool = False,
         icephys_experiment_type: Optional[str] = None,
         skip_electrodes: Tuple[int] = (),
         # TODO: to be removed
-        save_path: OptionalFilePathType = None,  # pragma: no cover
+        save_path: Optional[FilePathType] = None,  # pragma: no cover
     ):
         """
         Primary function for converting raw (unprocessed) intracellular data to the NWB standard.

--- a/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
@@ -10,7 +10,7 @@ from ...utils import (
     get_schema_from_hdmf_class,
     fill_defaults,
     get_base_schema,
-    OptionalFilePathType,
+    FilePathType,
     dict_deep_update,
 )
 
@@ -74,7 +74,7 @@ class BaseImagingExtractorInterface(BaseExtractorInterface):
 
     def run_conversion(
         self,
-        nwbfile_path: OptionalFilePathType = None,
+        nwbfile_path: Optional[FilePathType] = None,
         nwbfile: Optional[NWBFile] = None,
         metadata: Optional[dict] = None,
         overwrite: bool = False,

--- a/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
@@ -6,7 +6,7 @@ from pynwb.device import Device
 from pynwb.ophys import Fluorescence, ImageSegmentation, ImagingPlane, TwoPhotonSeries
 
 from ...baseextractorinterface import BaseExtractorInterface
-from ...utils import get_schema_from_hdmf_class, fill_defaults, OptionalFilePathType, get_base_schema
+from ...utils import get_schema_from_hdmf_class, fill_defaults, FilePathType, get_base_schema
 
 
 class BaseSegmentationExtractorInterface(BaseExtractorInterface):
@@ -60,7 +60,7 @@ class BaseSegmentationExtractorInterface(BaseExtractorInterface):
 
     def run_conversion(
         self,
-        nwbfile_path: OptionalFilePathType = None,
+        nwbfile_path: Optional[FilePathType] = None,
         nwbfile: Optional[NWBFile] = None,
         metadata: Optional[dict] = None,
         overwrite: bool = False,

--- a/src/neuroconv/datainterfaces/ophys/extract/extractdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/extract/extractdatainterface.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from ..basesegmentationextractorinterface import BaseSegmentationExtractorInterface
-from ....utils import FilePathType, FloatType
+from ....utils import FilePathType
 
 
 class ExtractSegmentationInterface(BaseSegmentationExtractorInterface):
@@ -10,7 +10,7 @@ class ExtractSegmentationInterface(BaseSegmentationExtractorInterface):
     def __init__(
         self,
         file_path: FilePathType,
-        sampling_frequency: FloatType,
+        sampling_frequency: float,
         output_struct_name: Optional[str] = None,
         verbose: bool = True,
     ):

--- a/src/neuroconv/datainterfaces/ophys/hdf5/hdf5datainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/hdf5/hdf5datainterface.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from ..baseimagingextractorinterface import BaseImagingExtractorInterface
 from ....utils import FilePathType, FloatType, ArrayType
 
@@ -12,7 +14,7 @@ class Hdf5ImagingInterface(BaseImagingExtractorInterface):
         sampling_frequency: FloatType = None,
         start_time: FloatType = None,
         metadata: dict = None,
-        channel_names: ArrayType = None,
+        channel_names: List[str] = None,
         verbose: bool = True,
     ):
         super().__init__(

--- a/src/neuroconv/datainterfaces/ophys/hdf5/hdf5datainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/hdf5/hdf5datainterface.py
@@ -1,7 +1,7 @@
-from typing import List
+from typing import List, Optional
 
 from ..baseimagingextractorinterface import BaseImagingExtractorInterface
-from ....utils import FilePathType, FloatType, ArrayType
+from ....utils import FilePathType
 
 
 class Hdf5ImagingInterface(BaseImagingExtractorInterface):
@@ -11,9 +11,9 @@ class Hdf5ImagingInterface(BaseImagingExtractorInterface):
         self,
         file_path: FilePathType,
         mov_field: str = "mov",
-        sampling_frequency: FloatType = None,
-        start_time: FloatType = None,
-        metadata: dict = None,
+        sampling_frequency: Optional[float] = None,
+        start_time: Optional[float] = None,
+        metadata: Optional[dict] = None,
         channel_names: List[str] = None,
         verbose: bool = True,
     ):

--- a/src/neuroconv/datainterfaces/ophys/sbx/sbxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/sbx/sbxdatainterface.py
@@ -1,11 +1,11 @@
 from ..baseimagingextractorinterface import BaseImagingExtractorInterface
-from ....utils import FilePathType, FloatType
+from ....utils import FilePathType
 
 
 class SbxImagingInterface(BaseImagingExtractorInterface):
     """Data Interface for SbxImagingExtractor."""
 
-    def __init__(self, file_path: FilePathType, sampling_frequency: FloatType = None, verbose: bool = True):
+    def __init__(self, file_path: FilePathType, sampling_frequency: float = None, verbose: bool = True):
         super().__init__(file_path=file_path, sampling_frequency=sampling_frequency, verbose=verbose)
 
     def get_metadata(self):

--- a/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterface.py
+++ b/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterface.py
@@ -42,8 +42,9 @@ class ScanImageImagingInterface(BaseImagingExtractorInterface):
         file_path: str
             Path to tiff file.
         fallback_sampling_frequency: float, optional
-            The sampling frequency can usually be extracted from the scanimage metadata in
-            exif:ImageDescription:state.acq.frameRate. If not, use this.
+            The sampling frequency can usually be extracted from the scanimage metadata under
+            'exif:ImageDescription:state.acq.frameRate'.
+            If it is not specified in that location, use this argument instead.
         """
         self.image_metadata = extract_extra_metadata(file_path=file_path)
 
@@ -57,6 +58,7 @@ class ScanImageImagingInterface(BaseImagingExtractorInterface):
             assert fallback_sampling_frequency is not None, assert_msg
             sampling_frequency = fallback_sampling_frequency
 
+        self.keyword_aliases = dict(fallback_sampling_frequency="sampling_frequency")
         super().__init__(file_path=file_path, sampling_frequency=sampling_frequency, verbose=verbose)
 
     def get_metadata(self):

--- a/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterface.py
+++ b/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterface.py
@@ -58,7 +58,9 @@ class ScanImageImagingInterface(BaseImagingExtractorInterface):
             assert fallback_sampling_frequency is not None, assert_msg
             sampling_frequency = fallback_sampling_frequency
 
-        self.keyword_aliases = dict(fallback_sampling_frequency="sampling_frequency")
+        self.source_data_to_validate = dict(
+            file_path=file_path, fallback_sampling_frequency=sampling_frequency, verbose=verbose
+        )
         super().__init__(file_path=file_path, sampling_frequency=sampling_frequency, verbose=verbose)
 
     def get_metadata(self):

--- a/src/neuroconv/datainterfaces/ophys/suite2p/suite2pdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/suite2p/suite2pdatainterface.py
@@ -5,8 +5,6 @@ from ....utils import FolderPathType, IntType
 class Suite2pSegmentationInterface(BaseSegmentationExtractorInterface):
     """Data interface for Suite2pSegmentationExtractor."""
 
-    def __init__(
-        self, folder_path: FolderPathType, combined: bool = False, plane_no: IntType = 0, verbose: bool = True
-    ):
+    def __init__(self, folder_path: FolderPathType, combined: bool = False, plane_no: int = 0, verbose: bool = True):
         super().__init__(folder_path=folder_path, combined=combined, plane_no=plane_no)
         self.verbose = verbose

--- a/src/neuroconv/datainterfaces/ophys/suite2p/suite2pdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/suite2p/suite2pdatainterface.py
@@ -1,5 +1,5 @@
 from ..basesegmentationextractorinterface import BaseSegmentationExtractorInterface
-from ....utils import FolderPathType, IntType
+from ....utils import FolderPathType
 
 
 class Suite2pSegmentationInterface(BaseSegmentationExtractorInterface):

--- a/src/neuroconv/datainterfaces/ophys/tiff/tiffdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/tiff/tiffdatainterface.py
@@ -1,5 +1,5 @@
 from ..baseimagingextractorinterface import BaseImagingExtractorInterface
-from ....utils import FilePathType, FloatType
+from ....utils import FilePathType
 
 
 class TiffImagingInterface(BaseImagingExtractorInterface):
@@ -11,5 +11,5 @@ class TiffImagingInterface(BaseImagingExtractorInterface):
         source_schema["properties"]["file_path"]["description"] = "Path to Tiff file."
         return source_schema
 
-    def __init__(self, file_path: FilePathType, sampling_frequency: FloatType, verbose: bool = True):
+    def __init__(self, file_path: FilePathType, sampling_frequency: float, verbose: bool = True):
         super().__init__(file_path=file_path, sampling_frequency=sampling_frequency, verbose=verbose)

--- a/src/neuroconv/nwbconverter.py
+++ b/src/neuroconv/nwbconverter.py
@@ -64,7 +64,6 @@ class NWBConverter:
     def __init__(self, source_data: Dict[str, dict], verbose: bool = True):
         """Validate source_data against source_schema and initialize all data interfaces."""
         self.verbose = verbose
-        self._validate_source_data(source_data=source_data, verbose=self.verbose)
         self.data_interface_objects = {
             name: data_interface(**source_data[name])
             for name, data_interface in self.data_interface_classes.items()

--- a/src/neuroconv/tools/audio/audio.py
+++ b/src/neuroconv/tools/audio/audio.py
@@ -1,16 +1,16 @@
 from typing import Optional
 from warnings import warn
 
+import numpy as np
 from hdmf.backends.hdf5 import H5DataIO
 from ndx_sound import AcousticWaveformSeries
 from pynwb import NWBFile
 
 from neuroconv.tools.hdmf import SliceableDataChunkIterator
-from neuroconv.utils import ArrayType
 
 
 def add_acoustic_waveform_series(
-    acoustic_series: ArrayType,
+    acoustic_series: np.ndarray,
     nwbfile: NWBFile,
     rate: float,
     metadata: dict,

--- a/src/neuroconv/tools/data_transfers.py
+++ b/src/neuroconv/tools/data_transfers.py
@@ -17,7 +17,7 @@ from dandi.download import download as dandi_download
 from dandi.organize import organize as dandi_organize
 from dandi.upload import upload as dandi_upload
 
-from ..utils import FolderPathType, OptionalFolderPathType
+from ..utils import FolderPathType
 
 try:  # pragma: no cover
     import globus_cli
@@ -293,7 +293,7 @@ def estimate_s3_conversion_cost(
 def automatic_dandi_upload(
     dandiset_id: str,
     nwb_folder_path: FolderPathType,
-    dandiset_folder_path: OptionalFolderPathType = None,
+    dandiset_folder_path: Optional[FolderPathType] = None,
     version: Optional[str] = None,
     staging: bool = False,
     cleanup: bool = False,

--- a/src/neuroconv/tools/neo/neo.py
+++ b/src/neuroconv/tools/neo/neo.py
@@ -12,7 +12,7 @@ import pynwb
 from hdmf.backends.hdf5 import H5DataIO
 
 from ..nwb_helpers import add_device_from_metadata
-from ...utils import OptionalFilePathType
+from ...utils import FilePathType
 
 
 response_classes = dict(
@@ -432,7 +432,7 @@ def add_all_to_nwbfile(
 
 def write_neo_to_nwb(
     neo_reader: neo.io.baseio.BaseIO,
-    save_path: OptionalFilePathType = None,  # pragma: no cover
+    save_path: Optional[FilePathType] = None,  # pragma: no cover
     overwrite: bool = False,
     nwbfile=None,
     metadata: dict = None,

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -29,7 +29,7 @@ from hdmf.backends.hdf5.h5_utils import H5DataIO
 from .imagingextractordatachunkiterator import ImagingExtractorDataChunkIterator
 from ..hdmf import SliceableDataChunkIterator
 from ..nwb_helpers import get_default_nwbfile_metadata, make_or_load_nwbfile, get_module
-from ...utils import OptionalFilePathType, dict_deep_update, calculate_regular_series_rate
+from ...utils import FilePathType, dict_deep_update, calculate_regular_series_rate
 
 
 def get_default_ophys_metadata():
@@ -415,7 +415,7 @@ def _imaging_frames_to_hdmf_iterator(
 
 def write_imaging(
     imaging: ImagingExtractor,
-    nwbfile_path: OptionalFilePathType = None,
+    nwbfile_path: Optional[FilePathType] = None,
     nwbfile: Optional[NWBFile] = None,
     metadata: Optional[dict] = None,
     overwrite: bool = False,
@@ -909,7 +909,7 @@ def add_summary_images(
 
 def write_segmentation(
     segmentation_extractor: SegmentationExtractor,
-    nwbfile_path: OptionalFilePathType = None,
+    nwbfile_path: Optional[FilePathType] = None,
     nwbfile: Optional[NWBFile] = None,
     metadata: Optional[dict] = None,
     overwrite: bool = False,

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -20,7 +20,7 @@ import psutil
 
 from .spikeinterfacerecordingdatachunkiterator import SpikeInterfaceRecordingDataChunkIterator
 from ..nwb_helpers import get_module, make_or_load_nwbfile
-from ...utils import dict_deep_update, OptionalFilePathType, calculate_regular_series_rate
+from ...utils import dict_deep_update, FilePathType, calculate_regular_series_rate
 
 
 SpikeInterfaceRecording = Union[BaseRecording, RecordingExtractor]
@@ -907,7 +907,7 @@ def add_all_to_nwbfile(
 
 def write_recording(
     recording: SpikeInterfaceRecording,
-    nwbfile_path: OptionalFilePathType = None,
+    nwbfile_path: Optional[FilePathType] = None,
     nwbfile: Optional[pynwb.NWBFile] = None,
     metadata: Optional[dict] = None,
     overwrite: bool = False,
@@ -1378,7 +1378,7 @@ def _add_waveforms_to_units_table(
 
 def write_sorting(
     sorting: SpikeInterfaceSorting,
-    nwbfile_path: OptionalFilePathType = None,
+    nwbfile_path: Optional[FilePathType] = None,
     nwbfile: Optional[pynwb.NWBFile] = None,
     metadata: Optional[dict] = None,
     overwrite: bool = False,
@@ -1569,7 +1569,7 @@ def add_waveforms(
 
 def write_waveforms(
     waveform_extractor: WaveformExtractor,
-    nwbfile_path: OptionalFilePathType = None,
+    nwbfile_path: Optional[FilePathType] = None,
     nwbfile: Optional[pynwb.NWBFile] = None,
     metadata: Optional[dict] = None,
     overwrite: bool = False,

--- a/src/neuroconv/tools/yaml_conversion_specification/yaml_conversion_specification.py
+++ b/src/neuroconv/tools/yaml_conversion_specification/yaml_conversion_specification.py
@@ -12,7 +12,7 @@ from dandi.organize import create_unique_filenames_from_metadata
 from dandi.metadata import _get_pynwb_metadata
 
 from ...nwbconverter import NWBConverter
-from ...utils import dict_deep_update, load_dict_from_file, FilePathType, OptionalFolderPathType
+from ...utils import dict_deep_update, load_dict_from_file, FilePathType, FolderPathType
 
 
 @click.command()
@@ -51,11 +51,11 @@ def run_conversion_from_yaml_cli(
 
 def run_conversion_from_yaml(
     specification_file_path: FilePathType,
-    data_folder_path: OptionalFolderPathType = None,
-    output_folder_path: OptionalFolderPathType = None,
+    data_folder_path: Optional[FolderPathType] = None,
+    output_folder_path: Optional[FolderPathType] = None,
     overwrite: bool = False,
-    data_folder: OptionalFolderPathType = None,
-    output_folder: OptionalFolderPathType = None,
+    data_folder: Optional[FolderPathType] = None,
+    output_folder: Optional[FolderPathType] = None,
 ):
     """
     Run conversion to NWB given a yaml specification file.

--- a/src/neuroconv/utils/__init__.py
+++ b/src/neuroconv/utils/__init__.py
@@ -1,13 +1,4 @@
-from .types import (
-    FilePathType,
-    FolderPathType,
-    OptionalFilePathType,
-    OptionalFolderPathType,
-    ArrayType,
-    OptionalArrayType,
-    FloatType,
-    IntType,
-)
+from .types import FilePathType, FolderPathType
 from .dict import dict_deep_update, load_dict_from_file, append_replace_dict_in_list, exist_dict_in_list
 from .json_schema import (
     NWBMetaDataEncoder,

--- a/src/neuroconv/utils/__init__.py
+++ b/src/neuroconv/utils/__init__.py
@@ -18,6 +18,7 @@ from .json_schema import (
     unroot_schema,
     fill_defaults,
     get_metadata_schema_for_icephys,
+    get_pydantic_model_from_method_signature,
 )
 from .globbing import decompose_f_string, parse_f_string
 from .checks import calculate_regular_series_rate

--- a/src/neuroconv/utils/json_schema.py
+++ b/src/neuroconv/utils/json_schema.py
@@ -90,8 +90,11 @@ def get_pydantic_model_from_method_signature(function: callable, exclude: Option
                 fields=fields,
                 takes_args=False,
                 takes_kwargs=True,
-                config=dict(extra=Extra.allow),  # extras usually show up as fixed values passed into neo/SI
+                config=dict(
+                    extra=Extra.allow,  # extras usually show up as fixed values passed into neo/SI
+                ),
             )
+            self.model.__config__.arbitrary_types_allowed = True  # Does not propagate when set in higher configs
 
     return CustomValidatedFunction(function=function, exclude=exclude).model
 

--- a/src/neuroconv/utils/json_schema.py
+++ b/src/neuroconv/utils/json_schema.py
@@ -100,7 +100,7 @@ def get_pydantic_model_from_method_signature(function: callable, exclude: Option
     return CustomValidatedFunction(function=function, exclude=exclude).model
 
 
-def get_schema_from_pydantic_model(model: BaseModel) -> dict[str, Any]:
+def get_schema_from_pydantic_model(model: BaseModel) -> Dict[str, Any]:
     """
     Return the JSON schema of a Pydantic model.
 

--- a/src/neuroconv/utils/json_schema.py
+++ b/src/neuroconv/utils/json_schema.py
@@ -74,7 +74,11 @@ def get_pydantic_model_from_method_signature(function: callable, exclude: Option
     # whereas the model of this decorator class works more as a class method
     class CustomValidatedFunction(ValidatedFunction):
         def __init__(self, function: callable, exclude: Optional[List[str]] = None):
-            super().__init__(function=function, config=None)  # Sets various attributes other methods assume exist
+            config = dict(
+                arbitrary_types_allowed=True,  # Needed for NWBFile annotations and anything from Numpy
+            )
+
+            super().__init__(function=function, config=config)  # Sets various attributes other methods assume exist
 
             parameters: Dict[str, Parameter] = signature(function).parameters
             fields: Dict[str, Tuple[Any, Any]] = dict()
@@ -90,11 +94,8 @@ def get_pydantic_model_from_method_signature(function: callable, exclude: Option
                 fields=fields,
                 takes_args=False,
                 takes_kwargs=True,
-                config=dict(
-                    extra=Extra.allow,  # extras usually show up as fixed values passed into neo/SI
-                ),
+                config=config,
             )
-            self.model.__config__.arbitrary_types_allowed = True  # Does not propagate when set in higher configs
 
     return CustomValidatedFunction(function=function, exclude=exclude).model
 

--- a/src/neuroconv/utils/json_schema.py
+++ b/src/neuroconv/utils/json_schema.py
@@ -10,7 +10,8 @@ from inspect import Parameter, signature
 import pynwb
 from pynwb.device import Device
 from pynwb.icephys import IntracellularElectrode
-from pydantic import BaseModel, ValidatedFunction
+from pydantic import BaseModel
+from pydantic.decorator import ValidatedFunction
 from pydantic.schema import model_schema
 
 from .dict import dict_deep_update
@@ -82,7 +83,8 @@ def get_pydantic_model_from_method_signature(function: callable, exclude: Option
                 parameters = {k: v for k, v in parameters.items() if k not in exclude}
 
             for name, parameter in parameters.items():
-                fields[name] = parameter.annotation, ...
+                default = ... if parameter.default is Parameter.empty else parameter.default
+                fields[name] = parameter.annotation, default
 
             self.create_model(fields=fields, takes_args=False, takes_kwargs=True, config=None)
 

--- a/src/neuroconv/utils/json_schema.py
+++ b/src/neuroconv/utils/json_schema.py
@@ -10,7 +10,7 @@ from inspect import Parameter, signature
 import pynwb
 from pynwb.device import Device
 from pynwb.icephys import IntracellularElectrode
-from pydantic import BaseModel
+from pydantic import BaseModel, Extra
 from pydantic.decorator import ValidatedFunction
 from pydantic.schema import model_schema
 
@@ -86,7 +86,12 @@ def get_pydantic_model_from_method_signature(function: callable, exclude: Option
                 default = ... if parameter.default is Parameter.empty else parameter.default
                 fields[name] = parameter.annotation, default
 
-            self.create_model(fields=fields, takes_args=False, takes_kwargs=True, config=None)
+            self.create_model(
+                fields=fields,
+                takes_args=False,
+                takes_kwargs=True,
+                config=dict(extra=Extra.allow),  # extras usually show up as fixed values passed into neo/SI
+            )
 
     return CustomValidatedFunction(function=function, exclude=exclude).model
 

--- a/src/neuroconv/utils/types.py
+++ b/src/neuroconv/utils/types.py
@@ -4,12 +4,7 @@ from typing import Optional, Union
 from typing import TypeVar
 
 import numpy as np
+from pydantic import FilePath, DirectoryPath
 
-FilePathType = TypeVar("FilePathType", str, Path)
-FolderPathType = TypeVar("FolderPathType", str, Path)
-OptionalFilePathType = Optional[FilePathType]
-OptionalFolderPathType = Optional[FolderPathType]
-ArrayType = Union[list, np.ndarray]
-OptionalArrayType = Optional[ArrayType]
-FloatType = float
-IntType = Union[int, np.integer]
+FilePathType = FilePath
+FolderPathType = DirectoryPath

--- a/tests/test_minimal/test_converter.py
+++ b/tests/test_minimal/test_converter.py
@@ -23,6 +23,9 @@ def test_converter():
         nwbfile_path = str(test_dir / "extension_test.nwb")
 
         class NdxEventsInterface(BaseDataInterface):
+            def __init__(self):
+                super().__init__()
+
             def run_conversion(self, nwbfile: NWBFile, metadata: dict):
                 events = LabeledEvents(
                     name="LabeledEvents",
@@ -49,8 +52,8 @@ class TestNWBConverterAndPipeInitialization(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         class InterfaceA(BaseDataInterface):
-            def __init__(self, **source_data):
-                super().__init__(**source_data)
+            def __init__(self):
+                super().__init__()
 
             def run_conversion(self):
                 pass
@@ -58,8 +61,8 @@ class TestNWBConverterAndPipeInitialization(unittest.TestCase):
         cls.InterfaceA = InterfaceA
 
         class InterfaceB(BaseDataInterface):
-            def __init__(self, **source_data):
-                super().__init__(**source_data)
+            def __init__(self):
+                super().__init__()
 
             def run_conversion(self):
                 pass

--- a/tests/test_on_data/test_gin_ecephys.py
+++ b/tests/test_on_data/test_gin_ecephys.py
@@ -61,7 +61,7 @@ def custom_name_func(testcase_func, param_num, param):
         f"{testcase_func.__name__}_{param_num}_"
         f"{parameterized.to_safe_name(reduced_interface_name)}"
         f"_{param.kwargs.get('case_name', '')}"
-    )
+    ).rstrip("_")
 
 
 class TestEcephysNwbConversions(unittest.TestCase):
@@ -89,9 +89,13 @@ class TestEcephysNwbConversions(unittest.TestCase):
             data_interface_classes = dict(TestLFP=data_interface)
 
         converter = TestConverter(source_data=dict(TestLFP=interface_kwargs))
+
         for interface_kwarg in interface_kwargs:
             if interface_kwarg in ["file_path", "folder_path"]:
-                self.assertIn(member=interface_kwarg, container=converter.data_interface_objects["TestLFP"].source_data)
+                interface = converter.data_interface_objects["TestLFP"]
+                container = interface.source_data_to_validate or interface.source_data
+                self.assertIn(member=interface_kwarg, container=container)
+
         metadata = converter.get_metadata()
         metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
@@ -316,11 +320,13 @@ class TestEcephysNwbConversions(unittest.TestCase):
             data_interface_classes = dict(TestRecording=data_interface)
 
         converter = TestConverter(source_data=dict(TestRecording=interface_kwargs))
+
         for interface_kwarg in interface_kwargs:
             if interface_kwarg in ["file_path", "folder_path"]:
-                self.assertIn(
-                    member=interface_kwarg, container=converter.data_interface_objects["TestRecording"].source_data
-                )
+                interface = converter.data_interface_objects["TestRecording"]
+                container = interface.source_data_to_validate or interface.source_data
+                self.assertIn(member=interface_kwarg, container=container)
+
         metadata = converter.get_metadata()
         metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
@@ -427,11 +433,13 @@ class TestEcephysNwbConversions(unittest.TestCase):
             data_interface_classes = dict(TestSorting=data_interface)
 
         converter = TestConverter(source_data=dict(TestSorting=interface_kwargs))
+
         for interface_kwarg in interface_kwargs:
             if interface_kwarg in ["file_path", "folder_path"]:
-                self.assertIn(
-                    member=interface_kwarg, container=converter.data_interface_objects["TestSorting"].source_data
-                )
+                interface = converter.data_interface_objects["TestSorting"]
+                container = interface.source_data_to_validate or interface.source_data
+                self.assertIn(member=interface_kwarg, container=container)
+
         metadata = converter.get_metadata()
         metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)


### PR DESCRIPTION
fix #261

## Motivation

Showcase of how to use more rigorous Pydantic model validation instead of `jsonschema` validation.

Also moving it to the interface level, which will fix the current issue of interfaces not validating any schemas when used for stand-alone write to an NWB file.

This PR is only for `source`, subsequent PRs will extend to the other schemas.



## How to test the behavior?

Theoretically already tested but can add a few explicit tests to verify our understanding of the behavior going forward.


## Checklist

- [ ] Have you thoroughly read our [Developer Guide](https://neuroconv.readthedocs.io/en/main/developer_guide.html)?
- [ ] Have you ensured the PR description clearly describes the problem and solutions?
- [ ] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/neuroconv/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
- [ ] Did you update the [CHANGLOG.md](https://github.com/catalystneuro/neuroconv/blob/main/CHANGELOG.md) file on your branch to describe your changes?
