### PR TITLE
Use Pydocstyle to automatically check for Numpy docstring compliance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,8 @@ repos:
     hooks:
     -   id: black
         exclude: ^docs/
+-   repo: https://github.com/PyCQA/pydocstyle
+    rev: 5.11.4
+    hooks:
+    -   id: pydocstyle
+        exclude: ^docs/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: black
         exclude: ^docs/
 -   repo: https://github.com/PyCQA/pydocstyle
-    rev: 5.11.4
+    rev: 6.2.1
     hooks:
     -   id: pydocstyle
         exclude: ^docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ extend-exclude = '''
   | dist
 )/
 '''
+[tool.pydocstyle]
+convention = "numpy"
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra --doctest-glob='*.rst'"


### PR DESCRIPTION
## Motivation

Testing this out to see how well it checks our docstrings for Numpy compliance. Probably doesn't get too specific about sub-standards like how to specify default values.

## Checklist

- [X] Have you thoroughly read our [Developer Guide](https://neuroconv.readthedocs.io/en/main/developer_guide.html)?
- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/neuroconv/pulls) for the same change?
- [X] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
- [X] Did you update the [CHANGLOG.md](https://github.com/catalystneuro/neuroconv/blob/main/CHANGELOG.md) file on your branch to describe your changes?
