### PR TITLE
Implement dynamic filters compression with config / strategy class 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming
 
+### Features
+* Implement compression strategy WIP [PR #281](https://github.com/catalystneuro/neuroconv/pull/281)
+
+
 ### Deprecation
 
 * All usages of `use_times` have been removed from spikeinterface tools and interfaces. The function `add_electrical_series` now determines whether the timestamps of the spikeinterface recording extractor are uniform or not and automatically stores the data according to best practices [PR #40](https://github.com/catalystneuro/neuroconv/pull/40)

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -4,6 +4,7 @@ jsonschema>=3.2.0
 PyYAML>=5.4
 scipy>=1.4.1
 h5py>=2.10.0
+hdf5plugin >= 4.0.1
 hdmf>=3.4.7
 pynwb>=1.4.0
 psutil>=5.8.0

--- a/src/neuroconv/datainterfaces/ecephys/baselfpextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baselfpextractorinterface.py
@@ -56,8 +56,6 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
             starting_time=starting_time,
             write_as="lfp",
             es_key="ElectricalSeriesLFP",
-            compression=compression,
-            compression_opts=compression_opts,
             iterator_type=iterator_type,
             iterator_opts=iterator_opts,
         )

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -186,8 +186,6 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
             write_as=write_as,
             write_electrical_series=write_electrical_series,
             es_key=es_key or self.es_key,
-            compression=compression,
-            compression_opts=compression_opts,
             iterator_type=iterator_type,
             iterator_opts=iterator_opts,
         )

--- a/src/neuroconv/tools/compression_strategies.py
+++ b/src/neuroconv/tools/compression_strategies.py
@@ -38,7 +38,8 @@ class HDF5CompressionStrategy(CompressionStategy):
         # Dynamic filters
         if self.method_name in self.dynamic_filters_names:
             hdf5plugin = get_package("hdf5plugin")
-            self.dynamic_filter = next(filter(lambda x: x.filter_name == self.method_name, hdf5plugin.get_filters()))
+            available_plugins = hdf5plugin.get_filters()
+            self.dynamic_filter = next(filter(lambda x: x.filter_name == self.method_name, available_plugins))
             self.method_name = self.dynamic_filter.filter_id
             self.allow_plugin_filters = True
             if self.compression_options is not None:

--- a/src/neuroconv/tools/compression_strategies.py
+++ b/src/neuroconv/tools/compression_strategies.py
@@ -37,31 +37,24 @@ class HDF5CompressionStrategy(CompressionStategy):
 
         # Dynamic filters
         if self.method_name in self.dynamic_filters_names:
+            self.allow_plugin_filters = True
             hdf5plugin = get_package("hdf5plugin")
             available_plugins = hdf5plugin.get_filters()
-            self.dynamic_filter = next(filter(lambda x: x.filter_name == self.method_name, available_plugins))
-            self.method_name = self.dynamic_filter.filter_id
-            self.allow_plugin_filters = True
-            if self.compression_options is not None:
-                raise ValueError("Compression options propagation is not yet supported for dynamic filters")
+            self.plugin = next(filter(lambda x: x.filter_name == self.method_name, available_plugins))
+            self.plugin_instance = self.plugin(**self.compression_options)
+            self.compression_kwargs = dict(self.plugin_instance)
 
-        # Zip
-        if self.method_name == "gzip":
-            if self.compression_options:
-                self.compression_options = self.compression_options.get("level", 4)
-                assert self.compression_options in range(10)  # This is checked by H5DataIO anyway, just as an example
+        else:
+            compression = self.method_name
+            compression_opts = self.compression_options
+            self.compression_kwargs = dict(compression=compression, compression_opts=compression_opts)
 
     def wrap_data_for_compression(self, data, h5dataio_kwargs: dict = None) -> H5DataIO:
 
         # In case some other parmaeters of H5DataIO are needed in the future
         h5dataio_kwargs = h5dataio_kwargs or dict()
 
-        h5dataio_kwargs.update(
-            data=data,
-            compression=self.method_name,
-            compression_opts=self.compression_options,
-            allow_plugin_filters=self.allow_plugin_filters,
-        )
+        h5dataio_kwargs.update(data=data, allow_plugin_filters=self.allow_plugin_filters, **self.compression_kwargs)
 
         return H5DataIO(**h5dataio_kwargs)
 

--- a/src/neuroconv/tools/compression_strategies.py
+++ b/src/neuroconv/tools/compression_strategies.py
@@ -1,0 +1,67 @@
+from abc import ABC, abstractmethod
+
+from hdmf.backends.hdf5.h5_utils import H5DataIO
+
+from .importing import get_package
+
+# Instances would be HDF5 or Zarr
+class CompressionStategy(ABC):
+    @abstractmethod
+    def validate_and_format(self):
+        pass
+
+    @abstractmethod
+    def wrap_data_for_compression(self):
+        pass
+
+    # @staticmethod
+    # @abstractmethod
+    # def available_methods():
+    #     pass
+    # Maybe? Can be a instance property
+
+
+class HDF5CompressionStrategy(CompressionStategy):
+
+    dynamic_filters_names = ["blosc", "bshuf", "bzip2", "fcidecomp", "lz4", "sz", "zfp", "zstd"]
+
+    def __init__(self, method_name: str, compression_options: dict = None):
+        self.method_name = method_name
+        self.compression_options = compression_options
+        self.allow_plugin_filters = False
+
+        self.validate_and_format()
+
+    def validate_and_format(self):
+
+        # Dynamic filters
+        if self.method_name in self.dynamic_filters_names:
+            hdf5plugin = get_package("hdf5plugin")
+            self.dynamic_filter = next(filter(lambda x: x.filter_name == "bzip2", hdf5plugin.get_filters()))
+            self.method_name = self.dynamic_filter.filter_id
+            self.allow_plugin_filters = True
+            if self.compression_options is not None:
+                raise ValueError("Compression options propagation is not yet supported for dynamic filters")
+
+        # Zip
+        if self.method_name == "gzip":
+            if self.compression_options:
+                self.compression_options = self.compression_options.get("level", 4)
+                assert self.compression_options in range(10)  # This is checked by H5DataIO anyway, just as an example
+
+    def wrap_data_for_compression(self, data, h5dataio_kwargs: dict = None) -> H5DataIO:
+
+        # In case some other parmaeters of H5DataIO are needed in the future
+        h5dataio_kwargs = h5dataio_kwargs or dict()
+
+        h5dataio_kwargs.update(
+            data=data,
+            compression=self.method_name,
+            compression_opts=self.compression_options,
+            allow_plugin_filters=self.allow_plugin_filters,
+        )
+
+        return H5DataIO(**h5dataio_kwargs)
+
+
+# Another option is to make a class for each compression method but this seems to much

--- a/src/neuroconv/tools/compression_strategies.py
+++ b/src/neuroconv/tools/compression_strategies.py
@@ -21,6 +21,7 @@ class CompressionStategy(ABC):
     # Maybe? Can be a instance property
 
 
+# We could also have ZarrCompressionStrategy(CompressionStategy): # for implementing wrapping with ZarrDataIO
 class HDF5CompressionStrategy(CompressionStategy):
 
     dynamic_filters_names = ["blosc", "bshuf", "bzip2", "fcidecomp", "lz4", "sz", "zfp", "zstd"]

--- a/src/neuroconv/tools/compression_strategies.py
+++ b/src/neuroconv/tools/compression_strategies.py
@@ -38,7 +38,7 @@ class HDF5CompressionStrategy(CompressionStategy):
         # Dynamic filters
         if self.method_name in self.dynamic_filters_names:
             hdf5plugin = get_package("hdf5plugin")
-            self.dynamic_filter = next(filter(lambda x: x.filter_name == "bzip2", hdf5plugin.get_filters()))
+            self.dynamic_filter = next(filter(lambda x: x.filter_name == self.method_name, hdf5plugin.get_filters()))
             self.method_name = self.dynamic_filter.filter_id
             self.allow_plugin_filters = True
             if self.compression_options is not None:

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -159,7 +159,7 @@ class TestAddElectricalSeriesHDF5Compression(unittest.TestCase):
     def test_gzip_compression(self):
 
         method_name = "gzip"
-        compression_options = dict(level=8)
+        compression_options = 8
         compression_zip = HDF5CompressionStrategy(method_name="gzip", compression_options=compression_options)
 
         add_electrical_series(
@@ -173,12 +173,15 @@ class TestAddElectricalSeriesHDF5Compression(unittest.TestCase):
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
         compression_parameters = electrical_series.data.get_io_params()
         assert compression_parameters["compression"] == method_name
-        assert compression_parameters["compression_opts"] == compression_options["level"]
+        assert compression_parameters["compression_opts"] == compression_options
 
     def test_dynamic_filter_bzip(self):
 
         method_name = "bzip2"
-        compression_dynamic_filter = HDF5CompressionStrategy(method_name=method_name)
+        compression_options = dict(blocksize=9)
+        compression_dynamic_filter = HDF5CompressionStrategy(
+            method_name=method_name, compression_options=compression_options
+        )
 
         add_electrical_series(
             recording=self.test_recording_extractor,
@@ -190,7 +193,7 @@ class TestAddElectricalSeriesHDF5Compression(unittest.TestCase):
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
         compression_parameters = electrical_series.data.get_io_params()
-        assert compression_parameters["compression"] == compression_dynamic_filter.dynamic_filter.filter_id
+        assert compression_parameters["compression"] == compression_dynamic_filter.plugin_instance.filter_id
 
 
 class TestAddElectricalSeriesSavingTimestampsVsRates(unittest.TestCase):


### PR DESCRIPTION
This a specific implementation of an idea that is discussed in #280. Instead of using `compression` and `compression_opts` to specify the compression configuration / strategy we use a full fledge class, `HDF5CompressionStrategy`, which is in charge of two things:

1) Validating the conversion options.
2) Wrapping the data object into the appropiate instance of `H5DataIO` so this process can be encapsulated in our pipelines.

To showcase an advantage of this method I have added dynamic filter support and some tests. In line with the defaults of `H5DataIO`,  gzip is used when no `compresion_strategy` is provided.  

