### PR TITLE
Update code coverage action version

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -136,7 +136,7 @@ jobs:
         run: pytest -rsx -n auto --dist loadscope --cov=./ --cov-report xml:./codecov.xml
       - name: Upload full coverage to Codecov
         if: ${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' }}
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./codecov.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### Testing
 * Re-organized the `test_gin_ecephys` file by splitting into each sub-modality. [PR #282](https://github.com/catalystneuro/neuroconv/pull/282)
-
+* Update github action for code coverage. [PR #307](https://github.com/catalystneuro/neuroconv/pull/307)
 
 
 # v0.2.3


### PR DESCRIPTION
Working on spikeinterface  I realized that the version that we have here is going to be depreacted (actually it says that it should be deprecated already!):

https://github.com/codecov/codecov-action