### PR TITLE
Swap CI to concurrency

### DIFF
--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -8,6 +8,7 @@ concurrency:  # Cancel previous workflows on the same pull request
   cancel-in-progress: true
 
 jobs:
+
   assess-file-changes:
     uses: catalystneuro/neuroconv/.github/workflows/assess-file-changes.yml@main
 

--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -3,13 +3,11 @@ name: Deploy tests
 on:
   pull_request:
 
-jobs:
-  cancel-previous-runs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+concurrency:  # Cancel previous workflows on the same pull request
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   assess-file-changes:
     uses: catalystneuro/neuroconv/.github/workflows/assess-file-changes.yml@main
 


### PR DESCRIPTION
Copycatting @h-mayorquin to replace a functionality that used to be an external workflow but now can be done internal to all GitHub actions

Testing it out here