### PR TITLE
[YAML]: allow a global conversion_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * The `OpenEphysRecordingInterface` is now a wrapper for `OpenEphysBinaryRecordingInterface`. [PR #294](https://github.com/catalystneuro/neuroconv/pull/294)
 * Swapped the backend for `CellExplorerSortingInterface` from `spikeextactors` to `spikeinterface`. [PR #267](https://github.com/catalystneuro/neuroconv/pull/267)
 * In the conversion YAML, `DataInterface` classes must now be specified as a dictionary instead of a list. [PR #311](https://github.com/catalystneuro/neuroconv/pull/311)
+* In the conversion YAML, conversion_options can be specified on the global level. [PR #312](https://github.com/catalystneuro/neuroconv/pull/312)
 
 ### Testing
 * The tests for `automatic_dandi_upload` now follow up-to-date DANDI validation rules for file name conventions. [PR #310](https://github.com/catalystneuro/neuroconv/pull/310)

--- a/src/neuroconv/schemas/yaml_conversion_specification_schema.json
+++ b/src/neuroconv/schemas/yaml_conversion_specification_schema.json
@@ -9,6 +9,7 @@
   "additionalProperties": false,
   "properties": {
     "metadata": {"$ref": "./metadata_schema.json#"},
+    "conversion_options": {"type": "object"},
     "data_interfaces": {
       "type": "object",
       "additionalProperties": {"type": "string"}
@@ -25,7 +26,6 @@
             "items": {
               "title": "Single-session specification",
               "type": "object",
-              "required": ["source_data"],
               "properties": {
                 "metadata": {"$ref": "./metadata_schema.json#"},
                 "nwbfile_name": {"type": "string"},

--- a/src/neuroconv/schemas/yaml_conversion_specification_schema.json
+++ b/src/neuroconv/schemas/yaml_conversion_specification_schema.json
@@ -26,6 +26,7 @@
             "items": {
               "title": "Single-session specification",
               "type": "object",
+              "required": ["source_data"],
               "properties": {
                 "metadata": {"$ref": "./metadata_schema.json#"},
                 "nwbfile_name": {"type": "string"},

--- a/src/neuroconv/tools/yaml_conversion_specification/yaml_conversion_specification.py
+++ b/src/neuroconv/tools/yaml_conversion_specification/yaml_conversion_specification.py
@@ -91,9 +91,7 @@ def run_conversion_from_yaml(
     global_conversion_options = specification.get("conversion_options", dict())
     data_interfaces_spec = specification.get("data_interfaces")
     data_interfaces_module = import_module(name=".datainterfaces", package="neuroconv")
-    data_interface_classes = {
-        key: getattr(data_interfaces_module, name) for key, name in data_interfaces_spec.items()
-    }
+    data_interface_classes = {key: getattr(data_interfaces_module, name) for key, name in data_interfaces_spec.items()}
 
     CustomNWBConverter = type(
         "CustomNWBConverter", (NWBConverter,), dict(data_interface_classes=data_interface_classes)

--- a/tests/test_on_data/conversion_specifications/GIN_conversion_specification.yml
+++ b/tests/test_on_data/conversion_specifications/GIN_conversion_specification.yml
@@ -3,6 +3,9 @@ metadata:
     lab: My Lab
     institution: My Institution
 
+conversion_options:
+  stub_test: True
+
 data_interfaces:
   ap: SpikeGLXRecordingInterface
   lf: SpikeGLXLFPInterface
@@ -19,9 +22,6 @@ experiments:
         source_data:
           ap:
             file_path: spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0/Noise4Sam_g0_t0.imec0.ap.bin
-        conversion_options:
-          ap:
-            stub_test: True  # Required for all SpikeGLX here. File on GIN is still huge
         metadata:
           NWBFile:
             session_start_time: "2020-10-09T21:19:09+00:00"
@@ -33,9 +33,6 @@ experiments:
             session_start_time: "2020-10-10T21:19:09+00:00"
           Subject:
             subject_id: "002"
-        conversion_options:
-          lf:
-            stub_test: True  # Required for all SpikeGLX here. File on GIN is still huge
         source_data:
           lf:
             file_path: spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0/Noise4Sam_g0_t0.imec0.lf.bin
@@ -53,6 +50,3 @@ experiments:
             session_start_time: "2020-10-11T21:19:09+00:00"
           Subject:
             subject_id: Subject Name
-        conversion_options:
-          lf:
-            stub_test: True  # Required for all SpikeGLX here. File on GIN is still huge

--- a/tests/test_on_data/conversion_specifications/GIN_conversion_specification_missing_nwbfile_names.yml
+++ b/tests/test_on_data/conversion_specifications/GIN_conversion_specification_missing_nwbfile_names.yml
@@ -2,6 +2,10 @@ metadata:
   NWBFile:
     lab: My Lab
     institution: My Institution
+
+conversion_options:
+  stub_test: True
+
 data_interfaces:
   ap: SpikeGLXRecordingInterface
   lf: SpikeGLXLFPInterface
@@ -16,9 +20,6 @@ experiments:
       - source_data:
           ap:
             file_path: spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0/Noise4Sam_g0_t0.imec0.ap.bin
-        conversion_options:
-          ap:
-            stub_test: True  # Required for all SpikeGLX here. File on GIN is still huge
         metadata:
           NWBFile:
             session_start_time: "2020-10-09T21:19:09+00:00"
@@ -30,9 +31,6 @@ experiments:
             session_start_time: "2020-10-10T21:19:09+00:00"
           Subject:
             subject_id: MyMouse002
-        conversion_options:
-          lf:
-            stub_test: True  # Required for all SpikeGLX here. File on GIN is still huge
         source_data:
           lf:
             file_path: spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0/Noise4Sam_g0_t0.imec0.lf.bin
@@ -49,6 +47,3 @@ experiments:
             session_start_time: "2020-10-11T21:19:09+00:00"
           Subject:
             subject_id: Subject Name
-        conversion_options:
-          lf:
-            stub_test: True  # Required for all SpikeGLX here. File on GIN is still huge

--- a/tests/test_on_data/conversion_specifications/GIN_conversion_specification_no_nwbfile_name_or_other_metadata.yml
+++ b/tests/test_on_data/conversion_specifications/GIN_conversion_specification_no_nwbfile_name_or_other_metadata.yml
@@ -6,8 +6,6 @@ data_interfaces:
 
 experiments:
   ymaze:
-    source_data:
-      ap: "spikeglx/Noise4{subject}_g0/Noise4{subject}_g0_imec0/Noise4{subject}_g0_t0.imec0.ap.bin"
     sessions:
       - source_data:
           ap:

--- a/tests/test_on_data/conversion_specifications/GIN_conversion_specification_no_nwbfile_name_or_other_metadata.yml
+++ b/tests/test_on_data/conversion_specifications/GIN_conversion_specification_no_nwbfile_name_or_other_metadata.yml
@@ -1,15 +1,17 @@
+conversion_options:
+  stub_test: True
+
 data_interfaces:
   ap: SpikeGLXRecordingInterface
 
 experiments:
   ymaze:
+    source_data:
+      ap: "spikeglx/Noise4{subject}_g0/Noise4{subject}_g0_imec0/Noise4{subject}_g0_t0.imec0.ap.bin"
     sessions:
       - source_data:
           ap:
             file_path: spikeglx/Noise4Sam_g0/Noise4Sam_g0_imec0/Noise4Sam_g0_t0.imec0.ap.bin
-        conversion_options:
-          ap:
-            stub_test: True  # Required for all SpikeGLX here. File on GIN is still huge
         metadata:
           NWBFile:
             session_description: Testing assertions.


### PR DESCRIPTION
## Motivation

Generally, if you want a conversion to be a stub_test, you want this for every session and every data interface, so I've added an option of global conversion options where this can be specified. Any conversion option specified here propagates to all sessions and data interfaces. You can still specify conversion_options on a session and interface level if you want to

## Checklist

- [x] Have you thoroughly read our [Developer Guide](https://neuroconv.readthedocs.io/en/main/developer_guide.html)?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/neuroconv/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
- [x] Did you update the [CHANGLOG.md](https://github.com/catalystneuro/neuroconv/blob/main/CHANGELOG.md) file on your branch to describe your changes?
