### PR TITLE
simplify blackrockdatainterface.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Testing
 * The tests for `automatic_dandi_upload` now follow up-to-date DANDI validation rules for file name conventions. [PR #310](https://github.com/catalystneuro/neuroconv/pull/310)
 
+### Fixes
+* BlackrockRecordingInterface now writes all ElectricalSeries to "acquisition" unless changed using the `write_as` flag in `run_conversion`. [PR #315](https://github.com/catalystneuro/neuroconv/pull/315)
+
 
 # v0.2.4
 


### PR DESCRIPTION
## Motivation

This PR deletes some automated BlackRock behavior that put certain ns files in processing rather than acquisition. I don't think the automated decision making was necessarily right and the user can use the "write_as" arg to control that manually.

## Checklist

- [x] Have you thoroughly read our [Developer Guide](https://neuroconv.readthedocs.io/en/main/developer_guide.html)?
- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/catalystneuro/neuroconv/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XXX` where `XXX` is the issue number?
- [x] Did you update the [CHANGLOG.md](https://github.com/catalystneuro/neuroconv/blob/main/CHANGELOG.md) file on your branch to describe your changes?
