### PR TITLE
Changlog CI trigger on source changes only

### DIFF
--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -15,6 +15,7 @@ jobs:
 
   detect-changelog-updates:
     needs: assess-file-changes
+    if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' }}
     name: Auto-detecting CHANGELOG.md updates
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Since we essentially only ask for changelog updates when source code is changed, might as well prevent it from triggering otherwise?