### PR TITLE
drop `NotImplementedError` in `OpenEphysRecordingInterface` for legacy format

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysdatainterface.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Optional
 
 from .openephysbinarydatainterface import OpenEphysBinaryRecordingInterface
+from .openephyslegacydatainterface import OpenEphysLegacyRecordingInterface
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ....utils import FolderPathType
 
@@ -36,7 +37,11 @@ class OpenEphysRecordingInterface(BaseRecordingExtractorInterface):
 
         folder_path = Path(folder_path)
         if any(folder_path.rglob("*.continuous")):
-            raise NotImplementedError("OpenEphysLegacyRecordingInterface had not been implemented yet.")
+            return OpenEphysLegacyRecordingInterface(
+                folder_path=folder_path,
+                stream_name=stream_name,
+                verbose=verbose,
+            )
 
         elif any(folder_path.rglob("*.dat")):
             return OpenEphysBinaryRecordingInterface(

--- a/tests/test_on_data/test_gin_ecephys/test_openephys.py
+++ b/tests/test_on_data/test_gin_ecephys/test_openephys.py
@@ -1,20 +1,26 @@
 from hdmf.testing import TestCase
 
-from neuroconv.datainterfaces import OpenEphysRecordingInterface
-from neuroconv.datainterfaces.ecephys.openephys.openephysbinarydatainterface import (
+from neuroconv.datainterfaces import (
     OpenEphysBinaryRecordingInterface,
+    OpenEphysLegacyRecordingInterface,
+    OpenEphysRecordingInterface,
 )
 
 from ..setup_paths import ECEPHY_DATA_PATH
 
 
 class TestOpenOpenEphysRecordingInterfaceRedirects(TestCase):
-    def test_legacy_format_raises_NotImplementedError(self):
+    def test_legacy_format(self):
         folder_path = ECEPHY_DATA_PATH / "openephys" / "OpenEphys_SampleData_1"
 
-        exc_msg = "OpenEphysLegacyRecordingInterface had not been implemented yet."
-        with self.assertRaisesWith(NotImplementedError, exc_msg=exc_msg):
-            OpenEphysRecordingInterface(folder_path=folder_path)
+        interface = OpenEphysRecordingInterface(folder_path=folder_path)
+        self.assertIsInstance(interface, OpenEphysLegacyRecordingInterface)
+
+    def test_propagate_stream_name(self):
+        folder_path = ECEPHY_DATA_PATH / "openephys" / "OpenEphys_SampleData_1"
+        exc_msg = "The selected stream 'AUX' is not in the available streams '['Signals CH']'!"
+        with self.assertRaisesWith(AssertionError, exc_msg=exc_msg):
+            OpenEphysRecordingInterface(folder_path=folder_path, stream_name="AUX")
 
     def test_binary_format(self):
         folder_path = ECEPHY_DATA_PATH / "openephysbinary" / "v0.4.4.1_with_video_tracking"


### PR DESCRIPTION
Now that #295 is merged, drop `NotImplementedError` for .continuous files and redirect to `OpenEphysLegacyRecordingInterface`.