### PR TITLE
change get_conversion_options_schema from class method to object method

### DIFF
--- a/src/neuroconv/basedatainterface.py
+++ b/src/neuroconv/basedatainterface.py
@@ -17,13 +17,12 @@ class BaseDataInterface(ABC):
         """Infer the JSON schema for the source_data from the method signature (annotation typing)."""
         return get_schema_from_method_signature(cls.__init__, exclude=["source_data"])
 
-    @classmethod
-    def get_conversion_options_schema(cls):
-        """Infer the JSON schema for the conversion options from the method signature (annotation typing)."""
-        return get_schema_from_method_signature(cls.run_conversion, exclude=["nwbfile", "metadata"])
-
     def __init__(self, **source_data):
         self.source_data: dict = source_data
+
+    def get_conversion_options_schema(self):
+        """Infer the JSON schema for the conversion options from the method signature (annotation typing)."""
+        return get_schema_from_method_signature(self.run_conversion, exclude=["nwbfile", "metadata"])
 
     def get_metadata_schema(self):
         """Retrieve JSON schema for metadata."""

--- a/src/neuroconv/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -15,7 +15,7 @@ class BlackrockRecordingInterface(BaseRecordingExtractorInterface):
     @classmethod
     def get_source_schema(cls):
         source_schema = get_schema_from_method_signature(
-            class_method=cls.__init__, exclude=["block_index", "seg_index"]
+            method=cls.__init__, exclude=["block_index", "seg_index"]
         )
         source_schema["properties"]["file_path"]["description"] = "Path to Blackrock file."
         return source_schema
@@ -69,7 +69,7 @@ class BlackrockSortingInterface(BaseSortingExtractorInterface):
 
     @classmethod
     def get_source_schema(cls) -> dict:
-        metadata_schema = get_schema_from_method_signature(class_method=cls.__init__)
+        metadata_schema = get_schema_from_method_signature(method=cls.__init__)
         metadata_schema["additionalProperties"] = True
         metadata_schema["properties"]["file_path"].update(description="Path to Blackrock file.")
         return metadata_schema

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
@@ -17,7 +17,7 @@ class OpenEphysBinaryRecordingInterface(BaseRecordingExtractorInterface):
     def get_source_schema(cls) -> dict:
         """Compile input schema for the RecordingExtractor."""
         source_schema = get_schema_from_method_signature(
-            class_method=cls.__init__, exclude=["recording_id", "experiment_id", "stub_test"]
+            method=cls.__init__, exclude=["recording_id", "experiment_id", "stub_test"]
         )
         source_schema["properties"]["folder_path"][
             "description"
@@ -72,7 +72,7 @@ class OpenEphysSortingInterface(BaseSortingExtractorInterface):
     def get_source_schema(cls) -> dict:
         """Compile input schema for the SortingExtractor."""
         metadata_schema = get_schema_from_method_signature(
-            class_method=cls.__init__, exclude=["recording_id", "experiment_id"]
+            method=cls.__init__, exclude=["recording_id", "experiment_id"]
         )
         metadata_schema["properties"]["folder_path"].update(description="Path to directory containing OpenEphys files.")
         metadata_schema["additionalProperties"] = False

--- a/src/neuroconv/datainterfaces/ecephys/spike2/spike2datainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spike2/spike2datainterface.py
@@ -24,7 +24,7 @@ class Spike2RecordingInterface(BaseRecordingExtractorInterface):
 
     @classmethod
     def get_source_schema(cls) -> dict:
-        source_schema = get_schema_from_method_signature(class_method=cls.__init__, exclude=["smrx_channel_ids"])
+        source_schema = get_schema_from_method_signature(method=cls.__init__, exclude=["smrx_channel_ids"])
         source_schema.update(additionalProperties=True)
         source_schema["properties"]["file_path"].update(description="Path to CED data file.")
         return source_schema

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
@@ -36,7 +36,7 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
 
     @classmethod
     def get_source_schema(cls) -> dict:
-        source_schema = get_schema_from_method_signature(class_method=cls.__init__, exclude=["x_pitch", "y_pitch"])
+        source_schema = get_schema_from_method_signature(method=cls.__init__, exclude=["x_pitch", "y_pitch"])
         source_schema["properties"]["file_path"]["description"] = "Path to SpikeGLX ap.bin or lf.bin file."
         return source_schema
 

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
@@ -17,7 +17,7 @@ class SpikeGLXNIDQInterface(BaseRecordingExtractorInterface):
 
     @classmethod
     def get_source_schema(cls) -> dict:
-        source_schema = get_schema_from_method_signature(class_method=cls.__init__, exclude=["x_pitch", "y_pitch"])
+        source_schema = get_schema_from_method_signature(method=cls.__init__, exclude=["x_pitch", "y_pitch"])
         source_schema["properties"]["file_path"]["description"] = "Path to SpikeGLX .nidq file."
         return source_schema
 

--- a/src/neuroconv/datainterfaces/icephys/baseicephysinterface.py
+++ b/src/neuroconv/datainterfaces/icephys/baseicephysinterface.py
@@ -30,7 +30,7 @@ class BaseIcephysInterface(BaseExtractorInterface):
 
     @classmethod
     def get_source_schema(cls) -> dict:
-        source_schema = get_schema_from_method_signature(class_method=cls.__init__, exclude=[])
+        source_schema = get_schema_from_method_signature(method=cls.__init__, exclude=[])
         return source_schema
 
     def __init__(self, file_paths: list):

--- a/src/neuroconv/nwbconverter.py
+++ b/src/neuroconv/nwbconverter.py
@@ -44,8 +44,7 @@ class NWBConverter:
             source_schema["properties"].update({interface_name: unroot_schema(data_interface.get_source_schema())})
         return source_schema
 
-    @classmethod
-    def get_conversion_options_schema(cls):
+    def get_conversion_options_schema(self):
         """Compile conversion option schemas from each of the data interface classes."""
         conversion_options_schema = get_base_schema(
             root=True,
@@ -54,16 +53,15 @@ class NWBConverter:
             description="Schema for the conversion options",
             version="0.1.0",
         )
-        for interface_name, data_interface in cls.data_interface_classes.items():
+        for interface_name, data_interface in self.data_interface_objects.items():
             conversion_options_schema["properties"].update(
                 {interface_name: unroot_schema(data_interface.get_conversion_options_schema())}
             )
         return conversion_options_schema
 
-    @classmethod
-    def validate_source(cls, source_data: Dict[str, dict], verbose: bool = True):
+    def validate_source(self, source_data: Dict[str, dict], verbose: bool = True):
         """Validate source_data against Converter source_schema."""
-        cls._validate_source_data(source_data=source_data, verbose=verbose)
+        self._validate_source_data(source_data=source_data, verbose=verbose)
 
     def __init__(self, source_data: Dict[str, dict], verbose: bool = True):
         """Validate source_data against source_schema and initialize all data interfaces."""
@@ -200,7 +198,7 @@ class ConverterPipe(NWBConverter):
             description="Schema for the conversion options",
             version="0.1.0",
         )
-        for interface_name, data_interface in self.data_interface_classes.items():
+        for interface_name, data_interface in self.data_interface_objects.items():
             conversion_options_schema["properties"].update(
                 {interface_name: unroot_schema(data_interface.get_conversion_options_schema())}
             )

--- a/src/neuroconv/tools/testing/mock_interfaces.py
+++ b/src/neuroconv/tools/testing/mock_interfaces.py
@@ -14,7 +14,7 @@ from ...utils import ArrayType, get_schema_from_method_signature
 class MockBehaviorEventInterface(BaseDataInterface):
     @classmethod
     def get_source_schema(cls) -> dict:
-        source_schema = get_schema_from_method_signature(class_method=cls.__init__, exclude=["event_times"])
+        source_schema = get_schema_from_method_signature(method=cls.__init__, exclude=["event_times"])
         source_schema["additionalProperties"] = True
         return source_schema
 
@@ -54,7 +54,7 @@ class MockSpikeGLXNIDQInterface(SpikeGLXNIDQInterface):
 
     @classmethod
     def get_source_schema(cls) -> dict:
-        source_schema = get_schema_from_method_signature(class_method=cls.__init__, exclude=["ttl_times"])
+        source_schema = get_schema_from_method_signature(method=cls.__init__, exclude=["ttl_times"])
         source_schema["additionalProperties"] = True
         return source_schema
 

--- a/src/neuroconv/utils/json_schema.py
+++ b/src/neuroconv/utils/json_schema.py
@@ -3,7 +3,7 @@ import collections.abc
 import inspect
 import json
 from datetime import datetime
-from typing import Literal
+from typing import Literal, Callable
 
 import numpy as np
 import pynwb
@@ -49,17 +49,19 @@ def get_base_schema(tag=None, root=False, id_=None, **kwargs) -> dict:
     return base_schema
 
 
-def get_schema_from_method_signature(class_method: classmethod, exclude: list = None) -> dict:
+def get_schema_from_method_signature(method: Callable, exclude: list = None) -> dict:
     """
     Take a class method and return a json-schema of the input args.
 
     Parameters
     ----------
-    class_method: function
+    method: function
     exclude: list, optional
+
     Returns
     -------
     dict
+
     """
     if exclude is None:
         exclude = ["self", "kwargs"]
@@ -78,7 +80,7 @@ def get_schema_from_method_signature(class_method: classmethod, exclude: list = 
         FolderPathType="string",
     )
     args_spec = dict()
-    for param_name, param in inspect.signature(class_method).parameters.items():
+    for param_name, param in inspect.signature(method).parameters.items():
         if param_name in exclude:
             continue
         args_spec[param_name] = dict()
@@ -118,7 +120,7 @@ def get_schema_from_method_signature(class_method: classmethod, exclude: list = 
                     input_schema["properties"].update({param_name: dict(format="directory")})
         else:
             raise NotImplementedError(
-                f"The annotation type of '{param}' in function '{class_method}' is not implemented! "
+                f"The annotation type of '{param}' in function '{method}' is not implemented! "
                 "Please request it to be added at github.com/catalystneuro/nwb-conversion-tools/issues "
                 "or create the json-schema for this method manually."
             )

--- a/tests/test_internals/test_schemas.py
+++ b/tests/test_internals/test_schemas.py
@@ -13,12 +13,6 @@ def test_interface_source_schema(data_interface):
     Draft7Validator.check_schema(schema=schema)
 
 
-@pytest.mark.parametrize("data_interface", interface_list)
-def test_interface_conversion_options_schema(data_interface):
-    schema = data_interface.get_conversion_options_schema()
-    Draft7Validator.check_schema(schema=schema)
-
-
 def test_yaml_specification_schema():
     schema = load_dict_from_file(
         file_path=Path(__file__).parent.parent.parent


### PR DESCRIPTION
fix #351 

change `NWBConverter.get_conversion_options_schema` and `BaseDataInterface.get_conversion_options_schema` from class method to object method

in `get_schema_from_method_signature`, change arg name from `class_method` to `method` and make it typehint `Callable`

move schema validation test to inside test_on_data, because now you have to instantiate the class before calling `get_conversion_schema`