### PR TITLE
rmv author docstrings from all modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   [PR #322](https://github.com/catalystneuro/neuroconv/pull/322)
 * Moved instructions to build the documentation from README.md to ReadTheDocs. [PR #323](https://github.com/catalystneuro/neuroconv/pull/323)
 * Add `Spike2RecordingInterface` to conversion gallery. [PR #338](https://github.com/catalystneuro/neuroconv/pull/338)
+* Remove authors from module docstrings [PR #354](https://github.com/catalystneuro/neuroconv/pull/354)
 
 ### Pending deprecation
 * Change name from `CedRecordingInterface` to `Spike2RecordingInterface`. [PR #338](https://github.com/catalystneuro/neuroconv/pull/338)

--- a/src/neuroconv/basedatainterface.py
+++ b/src/neuroconv/basedatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker and Ben Dichter."""
 import uuid
 from abc import ABC, abstractmethod
 from typing import Optional

--- a/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Saksham Sharda, Cody Baker, Ben Dichter, Heberto Mayorquin."""
 from pathlib import Path
 from typing import Optional
 

--- a/src/neuroconv/datainterfaces/behavior/sleap/sleapdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/sleap/sleapdatainterface.py
@@ -1,4 +1,3 @@
-"""Author: Heberto Mayorquin."""
 from pathlib import Path
 from typing import Optional
 

--- a/src/neuroconv/datainterfaces/behavior/video/video_utils.py
+++ b/src/neuroconv/datainterfaces/behavior/video/video_utils.py
@@ -1,4 +1,3 @@
-"""Authors: Saksham Sharda, Cody Baker."""
 from typing import Iterable, Optional, Tuple
 
 import numpy as np

--- a/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Heberto Mayorquin, Saksham Sharda, Cody Baker and Ben Dichter."""
 import warnings
 from pathlib import Path
 from typing import List, Optional

--- a/src/neuroconv/datainterfaces/ecephys/alphaomega/alphaomegadatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/alphaomega/alphaomegadatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker."""
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ....utils.types import FolderPathType
 

--- a/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Heberto Mayorquin, Steffen Buergers."""
 from pynwb import NWBFile
 
 from .axona_utils import (

--- a/src/neuroconv/datainterfaces/ecephys/baselfpextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baselfpextractorinterface.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker and Ben Dichter."""
 from typing import Literal, Optional
 
 from pynwb import NWBFile

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker and Ben Dichter."""
 from typing import Literal, Optional
 
 import numpy as np

--- a/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker and Ben Dichter."""
 from typing import Optional
 
 import numpy as np

--- a/src/neuroconv/datainterfaces/ecephys/biocam/biocamdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/biocam/biocamdatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker."""
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ....utils.types import FilePathType
 

--- a/src/neuroconv/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Luiz Tauffer."""
 from pathlib import Path
 from typing import Optional
 

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker and Ben Dichter."""
 from pathlib import Path
 from warnings import warn
 

--- a/src/neuroconv/datainterfaces/ecephys/edf/edfdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/edf/edfdatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Heberto Mayorquin"""
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ....tools import get_package
 from ....utils.types import FilePathType

--- a/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Heberto Mayorquin, Cody Baker and Ben Dichter."""
 from pathlib import Path
 from warnings import warn
 

--- a/src/neuroconv/datainterfaces/ecephys/kilosort/kilosortdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/kilosort/kilosortdatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Heberto Mayorquin, Cody Baker."""
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
 from ....utils import FolderPathType
 

--- a/src/neuroconv/datainterfaces/ecephys/mcsraw/mcsrawdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/mcsraw/mcsrawdatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker."""
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ....utils.types import FilePathType
 

--- a/src/neuroconv/datainterfaces/ecephys/mearec/mearecdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/mearec/mearecdatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker."""
 import json
 
 from pynwb.ecephys import ElectricalSeries

--- a/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Heberto Mayorquin, Cody Baker, Ben Dichter and Julia Sprenger."""
 import json
 from typing import List
 

--- a/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Heberto Mayorquin, Cody Baker and Ben Dichter."""
 from pathlib import Path
 from typing import Optional
 from warnings import warn

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Heberto Mayorquin, Luiz Tauffer."""
 from typing import Optional
 from warnings import warn
 

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephyslegacydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephyslegacydatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Szonja Weigl, Cody Baker."""
 from typing import List, Optional
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface

--- a/src/neuroconv/datainterfaces/ecephys/phy/phydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/phy/phydatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Heberto Mayorquin, Cody Baker."""
 from typing import List, Optional
 from warnings import warn
 

--- a/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker."""
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
 from ....utils.types import FilePathType

--- a/src/neuroconv/datainterfaces/ecephys/spike2/spike2datainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spike2/spike2datainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Heberto Mayorquin, Luiz Tauffer."""
 from pathlib import Path
 from warnings import warn
 

--- a/src/neuroconv/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
@@ -1,4 +1,3 @@
-"""Authors: Heberto Mayorquin, Cody Baker."""
 from typing import Optional
 from warnings import warn
 

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker."""
 from pathlib import Path
 from typing import List
 

--- a/src/neuroconv/datainterfaces/ecephys/spikeinterface/sipickledatainterfaces.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeinterface/sipickledatainterfaces.py
@@ -1,4 +1,3 @@
-"""Authors: Alessio Buccino."""
 from warnings import warn
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface

--- a/src/neuroconv/datainterfaces/ecephys/tdt/tdtdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/tdt/tdtdatainterface.py
@@ -1,4 +1,3 @@
-"""Author: Heberto Mayorquin"""
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ....utils.types import FolderPathType
 

--- a/src/neuroconv/datainterfaces/icephys/abf/abfdatainterface.py
+++ b/src/neuroconv/datainterfaces/icephys/abf/abfdatainterface.py
@@ -1,4 +1,3 @@
-"""Author: Luiz Tauffer."""
 import json
 from datetime import datetime, timedelta
 from warnings import warn

--- a/src/neuroconv/datainterfaces/icephys/baseicephysinterface.py
+++ b/src/neuroconv/datainterfaces/icephys/baseicephysinterface.py
@@ -1,4 +1,3 @@
-"""Author: Luiz Tauffer."""
 from typing import Optional, Tuple
 from warnings import warn
 

--- a/src/neuroconv/nwbconverter.py
+++ b/src/neuroconv/nwbconverter.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker and Ben Dichter."""
 import json
 from collections import Counter
 from pathlib import Path

--- a/src/neuroconv/tools/neo/neo.py
+++ b/src/neuroconv/tools/neo/neo.py
@@ -1,4 +1,3 @@
-"""Author: Luiz Tauffer."""
 import distutils.version
 import uuid
 import warnings

--- a/src/neuroconv/tools/nwb_helpers.py
+++ b/src/neuroconv/tools/nwb_helpers.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker, Alessio Buccino."""
 import uuid
 from contextlib import contextmanager
 from datetime import datetime

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -1,4 +1,3 @@
-"""Authors: Heberto Mayorquin, Saksham Sharda, Alessio Buccino and Szonja Weigl."""
 from collections import defaultdict
 from copy import deepcopy
 from typing import Optional

--- a/src/neuroconv/tools/signal_processing.py
+++ b/src/neuroconv/tools/signal_processing.py
@@ -1,4 +1,3 @@
-"""Author: Cody Baker."""
 from typing import Optional
 
 import numpy as np

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -1,4 +1,3 @@
-"""Author: Heberto Mayorquin, Cody Baker."""
 import uuid
 import warnings
 from collections import defaultdict

--- a/src/neuroconv/tools/spikeinterface/spikeinterfacerecordingdatachunkiterator.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterfacerecordingdatachunkiterator.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker and Saksham Sharda."""
 from typing import Iterable, Optional, Tuple, Union
 from warnings import warn
 

--- a/src/neuroconv/tools/testing/mock_interfaces.py
+++ b/src/neuroconv/tools/testing/mock_interfaces.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker."""
 from typing import List, Optional
 
 import numpy as np

--- a/src/neuroconv/tools/testing/mock_ttl_signals.py
+++ b/src/neuroconv/tools/testing/mock_ttl_signals.py
@@ -1,4 +1,3 @@
-"""Author: Cody Baker."""
 from pathlib import Path
 from typing import Optional, Union
 

--- a/src/neuroconv/tools/text.py
+++ b/src/neuroconv/tools/text.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict
 
 import numpy as np
 import pandas as pd

--- a/src/neuroconv/tools/yaml_conversion_specification/yaml_conversion_specification.py
+++ b/src/neuroconv/tools/yaml_conversion_specification/yaml_conversion_specification.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker, Alessio Buccino."""
 import sys
 from importlib import import_module
 from pathlib import Path

--- a/src/neuroconv/utils/dict.py
+++ b/src/neuroconv/utils/dict.py
@@ -1,4 +1,3 @@
-"""Authors: Luiz Tauffer, Cody Baker, Saksham Sharda and Ben Dichter."""
 import collections.abc
 import json
 import warnings

--- a/src/neuroconv/utils/globbing.py
+++ b/src/neuroconv/utils/globbing.py
@@ -1,4 +1,3 @@
-"""Authors: Cody Baker."""
 import re
 from typing import List
 from warnings import warn

--- a/src/neuroconv/utils/json_schema.py
+++ b/src/neuroconv/utils/json_schema.py
@@ -1,4 +1,3 @@
-"""Authors: Luiz Tauffer, Cody Baker, Saksham Sharda and Ben Dichter."""
 import collections.abc
 import inspect
 import json

--- a/src/neuroconv/utils/types.py
+++ b/src/neuroconv/utils/types.py
@@ -1,4 +1,3 @@
-"""Authors: Luiz Tauffer, Cody Baker, Saksham Sharda and Ben Dichter."""
 from pathlib import Path
 from typing import Optional, TypeVar, Union
 

--- a/tests/test_behavior/test_audio_interface.py
+++ b/tests/test_behavior/test_audio_interface.py
@@ -11,7 +11,6 @@ from dateutil.tz import gettz
 from hdmf.testing import TestCase
 from numpy.testing import assert_array_equal
 from pynwb import NWBHDF5IO
-from pynwb.testing import remove_test_file
 from scipy.io.wavfile import read, write
 
 from neuroconv import NWBConverter


### PR DESCRIPTION
I'd like to remove author docstrings from modules. 

First, a much more detailed summary of contributions can be achieved through Git Blame, which can be accessed conveniently using the GitHub interface. This feature details the author, commit, and time of each line of code.

Second, I don't like the way these comments render in the API docs.

I think the main downside of this would be personal. I don't want anyone to think I am erasing the records of their contributions, I just think this is a sub-optimal way to record and communicate authorship.

