### PR TITLE
Disable DANDI test temporarily (again)

### DIFF
--- a/tests/test_minimal/test_tools/test_dandi_transfer_tools.py
+++ b/tests/test_minimal/test_tools/test_dandi_transfer_tools.py
@@ -21,10 +21,10 @@ HAVE_DANDI_KEY = DANDI_API_KEY is not None and DANDI_API_KEY != ""  # can be "" 
 
 
 @pytest.mark.skip(reason="DANDI Server problems on 3/9/23")
-#@pytest.mark.skipif(
+# @pytest.mark.skipif(
 #    not HAVE_DANDI_KEY,
 #    reason="You must set your DANDI_API_KEY to run this test!",
-#)
+# )
 class TestAutomaticDANDIUpload(TestCase):
     def setUp(self):
         self.tmpdir = Path(mkdtemp())

--- a/tests/test_minimal/test_tools/test_dandi_transfer_tools.py
+++ b/tests/test_minimal/test_tools/test_dandi_transfer_tools.py
@@ -20,10 +20,11 @@ DANDI_API_KEY = os.getenv("DANDI_API_KEY")
 HAVE_DANDI_KEY = DANDI_API_KEY is not None and DANDI_API_KEY != ""  # can be "" from external forks
 
 
-@pytest.mark.skipif(
-    not HAVE_DANDI_KEY,
-    reason="You must set your DANDI_API_KEY to run this test!",
-)
+@pytest.mark.skip(reason="DANDI Server problems on 3/9/23")
+#@pytest.mark.skipif(
+#    not HAVE_DANDI_KEY,
+#    reason="You must set your DANDI_API_KEY to run this test!",
+#)
 class TestAutomaticDANDIUpload(TestCase):
     def setUp(self):
         self.tmpdir = Path(mkdtemp())


### PR DESCRIPTION
CI breaking again due to failure on DANDI server

Good to catch so we can warn them and get a fix ASAP

But for years this test has run without hardly ever causing issues, wonder what's been going on lately