### PR TITLE
Add `get_source_schema` classmethod to `OpenEphysRecordingInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Fixes
 * `BlackrockRecordingInterface` now writes all ElectricalSeries to "acquisition" unless changed using the `write_as` flag in `run_conversion`. [PR #315](https://github.com/catalystneuro/neuroconv/pull/315)
 * Excluding Python versions 3.8 and 3.9 for the `EdfRecordingInterface` on M1 macs due to installation problems. [PR #319](https://github.com/catalystneuro/neuroconv/pull/319)
+* Add `get_source_schema` classmethod to `OpenEphysRecordingInterface`. [PR #372](https://github.com/catalystneuro/neuroconv/pull/372)
 
 ### Documentation and tutorial enhancements
 * The instructions to build the documentation were moved to ReadTheDocs. [PR #323](https://github.com/catalystneuro/neuroconv/pull/323)

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysdatainterface.py
@@ -12,6 +12,13 @@ class OpenEphysRecordingInterface(BaseRecordingExtractorInterface):
 
     ExtractorName = "OpenEphysBinaryRecordingExtractor"
 
+    @classmethod
+    def get_source_schema(cls):
+        """Compile input schema for the RecordingExtractor."""
+        source_schema = super().get_source_schema()
+        source_schema.update(required=["folder_path"], additionalProperties=True)
+        return source_schema
+
     def __new__(
         cls,
         folder_path: FolderPathType,


### PR DESCRIPTION
I noticed when using `OpenEphysRecordingInterface` from an `NWBConverter` with `source_data` specified as `folder_path`, I got a source data validation error that additional properties are not allowed (`folder_path` was unexpected).
