### PR TITLE
[WIP]: Simple neuroconv deployment

### DIFF
--- a/dockerfiles/dockerfile_neuroconv_with_rclone
+++ b/dockerfiles/dockerfile_neuroconv_with_rclone
@@ -1,0 +1,9 @@
+FROM rclone/rclone:latest
+RUN $CONFIG_STREAM > ./rclone.conf
+RUN $RCLONE_COMMANNDS
+
+FROM ghcr.io/catalystneuro/neuroconv:latest
+LABEL org.opencontainers.image.source=https://github.com/catalystneuro/neuroconv_with_rclone
+ENV YAML_FILE /usr/local/bin/this_image_yaml_conversion.yml
+RUN $YAML_STREAM > $YAML_FILE
+ENTRYPOINT neuroconv $YAML_FILE --upload-to-dandiset $DANDISET_ID

--- a/dockerfiles/dockerfile_neuroconv_with_rclone
+++ b/dockerfiles/dockerfile_neuroconv_with_rclone
@@ -1,9 +1,0 @@
-FROM rclone/rclone:latest
-RUN $CONFIG_STREAM > ./rclone.conf
-RUN $RCLONE_COMMANNDS
-
-FROM ghcr.io/catalystneuro/neuroconv:latest
-LABEL org.opencontainers.image.source=https://github.com/catalystneuro/neuroconv_with_rclone
-ENV YAML_FILE /usr/local/bin/this_image_yaml_conversion.yml
-RUN $YAML_STREAM > $YAML_FILE
-ENTRYPOINT neuroconv $YAML_FILE --upload-to-dandiset $DANDISET_ID

--- a/docs/developer_guide/aws_batch_deployment.rst
+++ b/docs/developer_guide/aws_batch_deployment.rst
@@ -1,0 +1,168 @@
+One way of deploying items on AWS Batch is to manually setup the entire workflow through AWS web UI, and to manually submit each jobs in that manner.
+
+Deploying hundreds of jobs in this way would be cumbersome.
+
+Here are two other methods that allow simpler deployment by using `boto3`
+
+
+Semi-automated Deployment of NeuroConv on AWS Batch
+---------------------------------------------------
+
+Step 1: Transfer data to Elastic File System (EFS)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The nice thing about using EFS is that we are only ever billed for our literal amount of disk storage over time, and do not need to specify a particular fixed allocation or scaling stategy.
+
+It is also relatively easy to mount across multiple AWS Batch jobs simultaneously.
+
+Unfortunately, the one downside is that it's pricing per GB-month is significantly higher than either S3 or EBS.
+
+To easily transfer data from a Google Drive (or theoretically any backend supported by `rclone`), set the following environment variables for rclone credentials: `DRIVE_NAME`, `TOKEN`, `REFRESH_TOKEN`, and `EXPIRY`.
+
+.. note:
+
+    I eventually hope to just be able to read and pass these directly from a local `rclone.conf` file, but 
+
+.. note:
+
+    All path references must point to `/mnt/data/` as the base in order to persist across jobs.
+
+.. code:
+
+    import os
+    from datetime import datetime
+
+    from neuroconv.tools.data_transfers import submit_aws_batch_job
+
+    job_name = "<unique job name>"
+    docker_container = "ghcr.io/catalystneuro/rclone_auto_config:latest"
+    efs_name = "<your EFS volume name>"
+
+    log_datetime = str(datetime.now()).replace(" ", ":")  # no spaces in CLI
+    RCLONE_COMMAND = f"{os.environ['RCLONE_COMMAND']} -v --config /mnt/data/rclone.conf --log-file /mnt/data/submit-{log_datetime}.txt"
+
+    environment_variables = [
+        dict(name="DRIVE_NAME", value=os.environ["DRIVE_NAME"]),
+        dict(name="TOKEN", value=os.environ["TOKEN"]),
+        dict(name="REFRESH_TOKEN", value=os.environ["REFRESH_TOKEN"]),
+        dict(name="EXPIRY", value=os.environ["EXPIRY"]),
+        dict(name="RCLONE_COMMAND", value=RCLONE_COMMAND),
+    ]
+
+    submit_aws_batch_job(
+        job_name=job_name,
+        docker_container=docker_container,
+        efs_name=efs_name,
+        environment_variables=environment_variables,
+    )
+
+
+An example `RCLONE_COMMAND` for a drive named 'MyDrive' and the GIN testing data stored under `/ephy_testing_data/spikeglx/Noise4Sam_g0/` of that drive would be
+
+.. code:
+
+    RCLONE_COMMAND = f"sync MyDrive:/ephy_testing_data/spikeglx/Noise4Sam_g0 /mnt/data/Noise4Sam_g0"
+
+
+Step 2: Run the YAML Conversion Specificattion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Continuing the example above, if we have the YAML file `test_batch.yml`
+
+.. code:
+
+    metadata:
+      NWBFile:
+        lab: My Lab
+        institution: My Institution
+
+    conversion_options:
+      stub_test: True
+
+    data_interfaces:
+      ap: SpikeGLXRecordingInterface
+      lf: SpikeGLXRecordingInterface
+
+    experiments:
+      ymaze:
+        metadata:
+          NWBFile:
+            session_description: Testing batch deployment.
+
+        sessions:
+          - nwbfile_name: /mnt/data/test_batch_deployment.nwb
+            source_data:
+              ap:
+                file_path: /mnt/data/Noise4Sam_g0/Noise4Sam_g0_imec0/Noise4Sam_g0_t0.imec0.ap.bin
+              lf:
+                file_path: /mnt/data/Noise4Sam_g0/Noise4Sam_g0_imec0/Noise4Sam_g0_t0.imec0.lf.bin
+            metadata:
+              NWBFile:
+                session_id: test_batch_deployment
+              Subject:
+                subject_id: "1"
+                sex: F
+                age: P35D
+                species: Mus musculus
+
+then we can run the following stand-alone script to deploy the conversion after confirming Step 1 completed successfully.
+
+.. code:
+
+    from neuroconv.tools.data_transfers import submit_aws_batch_job
+
+    job_name = "<unique job name>"
+    docker_container = "ghcr.io/catalystneuro/neuroconv:dev_auto_yaml"
+    efs_name = "<name of EFS>"
+
+    yaml_file_path = "/path/to/test_batch.yml"
+
+    with open(file=yaml_file_path) as file:
+        YAML_STREAM = "".join(file.readlines()).replace('"', "'")
+
+    environment_variables = [dict(name="YAML_STREAM", value=YAML_STREAM)]
+
+    submit_aws_batch_job(
+        job_name=job_name,
+        docker_container=docker_container,
+        efs_name=efs_name,
+        environment_variables=environment_variables,
+    )
+
+
+Step 3: Ensure File Cleanup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO: write a dockerfile to perform this step with the API
+
+It's a good idea to confirm that you have access to your EFS from on-demand resources in case you ever need to go in and perform a manual cleanup operation.
+
+Boot up a EC2 t2.micro instance using AWS Linux 2 image with minimal resources.
+
+Create 2 new security groups, `EFS Target` (no policies set) and `EFS Mount` (set inbound policy to NFS with the `EFS Target` as the source).
+
+On the EC2 instance, change the security group to the `EFS Target`. On the EFS Network settings, add the `EFS Mount` group.
+
+Connect to the EC2 instance and run
+
+.. code:
+
+    mkdir ~/efs-mount-point  # or any other name you want; I do recommend keeping this in the home directory (~) for ease of access though
+    sudo mount -t nfs -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport fs-<efs number>.efs.us-east-2.amazonaws.com:/ ~/efs-mount-point  # Note that any operations performed on contents of the mounted volume must utilize sudo
+
+and it _should_ work, but this step is known to have various issues. If you did everything exactly as illustrated above, hopefully it should work. At least it did on 4/2/2023.
+
+You can now read, write, and importantly delete any contents on the EFS.
+
+Until the automated DANDI upload is implemented in YAML functionality, you will need to use this method to manually remove the NWB file.
+
+Even after, you should double check to ensure the `cleanup=True` flag to that function properly executed.
+
+
+
+Fully Automated Deployment of NeuroConv on AWS Batch
+----------------------------------------------------
+
+Coming soon...
+
+Approach is essentially the same as the semi-automated, I just submit all jobs at the same time with the jobs being dependent on the completion of one another.

--- a/src/neuroconv/tools/data_transfers.py
+++ b/src/neuroconv/tools/data_transfers.py
@@ -378,6 +378,7 @@ def automatic_dandi_upload(
 def submit_aws_batch_job(
     job_name: str,
     docker_container: str,
+    environment_variables: List[Dict[str, str]],
     status_tracker_table_name: str = "neuroconv_batch_status_tracker",
     iam_role_name: str = "neuroconv_batch_role",
     compute_environment_name: str = "neuroconv_batch_environment",
@@ -501,22 +502,7 @@ def submit_aws_batch_job(
             jobQueue=job_queue_name,
             jobDefinition=job_definition,
             jobName=job_name,
-            containerOverrides=dict(
-                environment=[  # These are environment variables
-                    dict(  # The burden is on the calling script to update the table status to finished
-                        name="STATUS_TRACKER_TABLE_NAME",
-                        value=status_tracker_table_name,
-                    ),
-                    dict(  # For rclone transfers
-                        name="RCLONE_CREDENTIALS",
-                        value=os.environ["RCLONE_CREDENTIALS"],
-                    ),
-                    dict(  # For rclone transfers
-                        name="DANDI_API_KEY",
-                        value=os.environ["DANDI_API_KEY"],
-                    ),
-                ]
-            ),
+            containerOverrides=dict(environment=environment_variables),  # TODO - auto inject status tracker?
         )
         table.put_item(Item=dict(id=uuid4(), job_name=job_name, submitted_on=datetime.now(), status="submitted"))
     else:

--- a/src/neuroconv/tools/yaml_conversion_specification/__init__.py
+++ b/src/neuroconv/tools/yaml_conversion_specification/__init__.py
@@ -1,1 +1,1 @@
-from .yaml_conversion_specification import run_conversion_from_yaml, deploy_conversion_from_yaml
+from .yaml_conversion_specification import run_conversion_from_yaml, deploy_conversion_from_yaml_and_upload_to_dandi

--- a/src/neuroconv/tools/yaml_conversion_specification/__init__.py
+++ b/src/neuroconv/tools/yaml_conversion_specification/__init__.py
@@ -1,1 +1,1 @@
-from .yaml_conversion_specification import run_conversion_from_yaml
+from .yaml_conversion_specification import run_conversion_from_yaml, deploy_conversion_from_yaml

--- a/src/neuroconv/tools/yaml_conversion_specification/yaml_conversion_specification.py
+++ b/src/neuroconv/tools/yaml_conversion_specification/yaml_conversion_specification.py
@@ -1,13 +1,17 @@
 import sys
+import os
 from importlib import import_module
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Literal
+from uuid import uuid4
 
 import click
 from dandi.metadata import _get_pynwb_metadata
 from dandi.organize import create_unique_filenames_from_metadata
 from jsonschema import RefResolver, validate
+from pydantic import FilePath
 
+from ..data_transfers import submit_aws_batch_job, automatic_dandi_upload
 from ...nwbconverter import NWBConverter
 from ...utils import FilePathType, FolderPathType, dict_deep_update, load_dict_from_file
 
@@ -25,11 +29,17 @@ from ...utils import FilePathType, FolderPathType, dict_deep_update, load_dict_f
     help="Path to folder where you want to save the output NWBFile.",
     type=click.Path(writable=True),
 )
+@click.option(
+    "--upload-to-dandiset",
+    help="Do you want to upload the result to DANDI? Specify the dandiset ID if so. "
+    "Also ensure you have your DANDI_API_KEY set as an environment variable.",
+)
 @click.option("--overwrite", help="Overwrite an existing NWBFile at the location.", is_flag=True)
 def run_conversion_from_yaml_cli(
     specification_file_path: str,
     data_folder_path: Optional[str] = None,
     output_folder_path: Optional[str] = None,
+    upload_to_dandiset: Optional[str] = None,
     overwrite: bool = False,
 ):
     """
@@ -42,6 +52,7 @@ def run_conversion_from_yaml_cli(
         specification_file_path=specification_file_path,
         data_folder_path=data_folder_path,
         output_folder_path=output_folder_path,
+        upload_to_dandiset=upload_to_dandiset,
         overwrite=overwrite,
     )
 
@@ -50,6 +61,7 @@ def run_conversion_from_yaml(
     specification_file_path: FilePathType,
     data_folder_path: Optional[FolderPathType] = None,
     output_folder_path: Optional[FolderPathType] = None,
+    upload_to_dandiset: Optional[str] = None,
     overwrite: bool = False,
 ):
     """
@@ -69,6 +81,13 @@ def run_conversion_from_yaml(
         If True, replaces any existing NWBFile at the nwbfile_path location, if save_to_file is True.
         If False, appends the existing NWBFile at the nwbfile_path location, if save_to_file is True.
     """
+    # This check is technically a part of the automatic dandi upload, but good to check as early as possible
+    # to avoid wasting time.
+    if upload_to_dandiset:
+        assert os.getenv("DANDI_API_KEY"), (
+            "Unable to find environment variable 'DANDI_API_KEY'. "
+            "Please retrieve your token from DANDI and set this environment variable."
+        )
 
     if data_folder_path is None:
         data_folder_path = Path(specification_file_path).parent
@@ -140,3 +159,36 @@ def run_conversion_from_yaml(
                     dandi_filename != ".nwb"
                 ), f"Not enough metadata available to assign name to {str(named_dandi_metadata['path'])}!"
                 named_dandi_metadata["path"].rename(str(output_folder_path / dandi_filename))
+
+    if upload_to_dandiset:
+        staging = int(upload_to_dandiset) < 100000  # temporary heuristic
+        automatic_dandi_upload(dandiset_id=upload_to_dandiset, nwb_folder_path=output_folder_path, staging=staging)
+
+
+def deploy_conversion_from_yaml_and_upload_to_dandi(  # the 'and upload to DANDI' part should ultimately be embedded in the YAML syntax
+    specification_file_path: FilePath,
+    dandiset_id: str,
+    transfer_method: Literal["rclone"],
+    transfer_commands: str,
+    transfer_config_file_path: FilePath,
+):
+    job_name = Path(specification_file_path).stem + uuid4()
+    with open(file=specification_file_path) as file:
+        yaml_as_string = "".join(file.readlines())  # Loaded as raw string, not as dict
+
+    if transfer_method == "rclone":
+        docker_container = "ghcr.io/catalystneuro/neuroconv:with_rclone"
+        with open(file=transfer_config_file_path) as file:
+            config_as_string = "".join(file.readlines())  # TODO - check newlines are OK cross-platform
+        environment_variables = [
+            dict(name="CONFIG_STREAM", value=config_as_string),
+            dict(name="RCLONE_COMMANDS", value=transfer_commands),
+            dict(name="YAML_STREAM", value=yaml_as_string),
+            dict(name="DANDI_API_KEY", value=os.envion["DANDI_API_KEY"]),
+            dict(name="DANDISET_ID", value=dandiset_id),
+        ]
+    else:
+        raise NotImplementedError(f"The transfer method {transfer_method} is not yet supported!")
+    submit_aws_batch_job(
+        job_name=job_name, docker_container=docker_container, environment_variables=environment_variables
+    )  # TODO - setup something here with status tracker table - might have to be on YAML level

--- a/src/neuroconv/tools/yaml_conversion_specification/yaml_conversion_specification.py
+++ b/src/neuroconv/tools/yaml_conversion_specification/yaml_conversion_specification.py
@@ -167,12 +167,13 @@ def run_conversion_from_yaml(
 
 def deploy_conversion_from_yaml_and_upload_to_dandi(  # the 'and upload to DANDI' part should ultimately be embedded in the YAML syntax
     specification_file_path: FilePath,
+    efs_name: str,
     dandiset_id: str,
     transfer_method: Literal["rclone"],
     transfer_commands: str,
     transfer_config_file_path: FilePath,
 ):
-    job_name = Path(specification_file_path).stem + uuid4()
+    job_name = Path(specification_file_path).stem + "-" + str(uuid4())
     with open(file=specification_file_path) as file:
         yaml_as_string = "".join(file.readlines())  # Loaded as raw string, not as dict
 
@@ -184,11 +185,14 @@ def deploy_conversion_from_yaml_and_upload_to_dandi(  # the 'and upload to DANDI
             dict(name="CONFIG_STREAM", value=config_as_string),
             dict(name="RCLONE_COMMANDS", value=transfer_commands),
             dict(name="YAML_STREAM", value=yaml_as_string),
-            dict(name="DANDI_API_KEY", value=os.envion["DANDI_API_KEY"]),
+            dict(name="DANDI_API_KEY", value=os.environ["DANDI_API_KEY"]),
             dict(name="DANDISET_ID", value=dandiset_id),
         ]
     else:
         raise NotImplementedError(f"The transfer method {transfer_method} is not yet supported!")
     submit_aws_batch_job(
-        job_name=job_name, docker_container=docker_container, environment_variables=environment_variables
+        job_name=job_name,
+        docker_container=docker_container,
+        efs_name=efs_name,
+        environment_variables=environment_variables,
     )  # TODO - setup something here with status tracker table - might have to be on YAML level


### PR DESCRIPTION
Introduces the one-line helper function `deploy_conversion_from_yaml_and_upload_to_dandi` to perform the entire cloud deployment stack, along with necessary changes to the batch submission utility introduced in the base of this PR.

Note the one-liner isn't working yet, but I attached detailed instructions for running the utility function in separate stand-alone scripts which is still much easier than doing the entire thing manually.