### PR TITLE
expand iterator_opts in docstrings to include all args

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -176,9 +176,20 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
                 buffer_gb : float, default: 1.0
                     In units of GB. Recommended to be as much free RAM as available. Automatically calculates suitable
                     buffer shape.
+                buffer_shape : tuple, optional
+                    Manual specification of buffer shape to return on each iteration.
+                    Must be a multiple of chunk_shape along each axis.
+                    Cannot be set if `buffer_gb` is specified.
                 chunk_mb : float. default: 1.0
                     Should be below 1 MB. Automatically calculates suitable chunk shape.
-            If manual specification of buffer_shape and chunk_shape are desired, these may be specified as well.
+                chunk_shape : tuple, optional
+                    Manual specification of the internal chunk shape for the HDF5 dataset.
+                    Cannot be set if `chunk_mb` is also specified.
+                display_progress : bool, default: False
+                    Display a progress bar with iteration rate and estimated completion time.
+                progress_bar_options : dict, optional
+                    Dictionary of keyword arguments to be passed directly to tqdm.
+                    See https://github.com/tqdm/tqdm#parameters for options.
         """
         from ...tools.spikeinterface import write_recording
 

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -809,13 +809,24 @@ def write_recording(
         None: write the TimeSeries with no memory chunking.
     iterator_opts: dict, optional
         Dictionary of options for the RecordingExtractorDataChunkIterator (iterator_type='v2').
-        Valid options are
+        Valid options are:
             buffer_gb : float, default: 1.0
-                In units of GB. Recommended to be as much free RAM as available). Automatically calculates suitable
+                In units of GB. Recommended to be as much free RAM as available. Automatically calculates suitable
                 buffer shape.
-            chunk_mb : float, default: 1.0
+            buffer_shape : tuple, optional
+                Manual specification of buffer shape to return on each iteration.
+                Must be a multiple of chunk_shape along each axis.
+                Cannot be set if `buffer_gb` is specified.
+            chunk_mb : float. default: 1.0
                 Should be below 1 MB. Automatically calculates suitable chunk shape.
-        If manual specification of buffer_shape and chunk_shape are desired, these may be specified as well.
+            chunk_shape : tuple, optional
+                Manual specification of the internal chunk shape for the HDF5 dataset.
+                Cannot be set if `chunk_mb` is also specified.
+            display_progress : bool, default: False
+                Display a progress bar with iteration rate and estimated completion time.
+            progress_bar_options : dict, optional
+                Dictionary of keyword arguments to be passed directly to tqdm.
+                See https://github.com/tqdm/tqdm#parameters for options.
     """
     if nwbfile is not None:
         assert isinstance(nwbfile, pynwb.NWBFile), "'nwbfile' should be of type pynwb.NWBFile"


### PR DESCRIPTION
I was using `RecordingInterface.run_conversion` and it was not clear to me from the docstring how to turn on a progress bar. This expands the docstring in two places to make this explicit.