### PR TITLE
Set upper numpy bound for Python < 3.11

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,5 +1,5 @@
-numpy>=1.21.0;python_version<'3.8'
-numpy>=1.22.0;python_version>='3.8'
+numpy>=1.22.0,<1.24;python_version<'3.11'
+numpy>=1.22.0;python_version>='3.11'
 jsonschema>=3.2.0
 PyYAML>=5.4
 scipy>=1.4.1


### PR DESCRIPTION
Testing a fix that was just revealed by failing tests on #428; zero clue why it happened this way, the [daily tests ran perfectly find 6 hours earlier](https://github.com/catalystneuro/neuroconv/actions/runs/4863353553/jobs/8670942626), and the only major difference I can spot between the two CI installations is the numpy version was 1 patch lower in the dailies.