### PR TITLE
[Sync VIg] Add base interface for pre-aligned data

### DIFF
--- a/src/neuroconv/__init__.py
+++ b/src/neuroconv/__init__.py
@@ -1,2 +1,3 @@
+from .basedatainterface import BaseDataInterface, TemporallyAlignedDataInterface
 from .nwbconverter import ConverterPipe, NWBConverter
 from .tools.yaml_conversion_specification import run_conversion_from_yaml

--- a/src/neuroconv/basedatainterface.py
+++ b/src/neuroconv/basedatainterface.py
@@ -152,3 +152,16 @@ class BaseDataInterface(ABC):
             The default is False (append mode).
         """
         raise NotImplementedError("The run_conversion method for this DataInterface has not been defined!")
+
+
+class TemporallyAlignedDataInterface(BaseDataInterface):
+    """When the data stream of an interface is already temporally aligned, the various alignment methods may be ignored."""
+
+    def get_original_timestamps(self):
+        pass
+
+    def get_timestamps(self):
+        pass
+
+    def align_timestamps(self):
+        pass

--- a/tests/test_minimal/test_converter.py
+++ b/tests/test_minimal/test_converter.py
@@ -7,8 +7,12 @@ from tempfile import mkdtemp
 import numpy as np
 from pynwb import NWBFile
 
-from neuroconv import ConverterPipe, NWBConverter
-from neuroconv.basedatainterface import BaseDataInterface
+from neuroconv import (
+    BaseDataInterface,
+    ConverterPipe,
+    NWBConverter,
+    TemporallyAlignedDataInterface,
+)
 
 try:
     from ndx_events import LabeledEvents
@@ -80,18 +84,9 @@ class TestNWBConverterAndPipeInitialization(unittest.TestCase):
 
         cls.InterfaceA = InterfaceA
 
-        class InterfaceB(BaseDataInterface):
+        class InterfaceB(TemporallyAlignedDataInterface):
             def __init__(self, **source_data):
                 super().__init__(**source_data)
-
-            def get_original_timestamps(self):
-                pass
-
-            def get_timestamps(self):
-                pass
-
-            def align_timestamps(self):
-                pass
 
             def run_conversion(self):
                 pass


### PR DESCRIPTION
It might become annoying to override the 3 abstract methods for temporal alignment when creating a custom data interface for pre-aligned data (not uncommon for behavior streams)

I still believe it should be a core requirement of the fundamental `BaseDataInterface`, however. It's such an essential feature of a proper NWB conversion, everyone should be made aware of it one way or another

But this PR introduces a second class for convenience that acts as the equivalent confirmation from the developer creating the new interface that the timing information is already aligned