### PR TITLE
Add stream control to OpenEphysBinary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,7 @@
 * Added a `TemporallyAlignedDataInterface` definition for convenience when creating a custom interface for pre-aligned data. [PR #434](https://github.com/catalystneuro/neuroconv/pull/434)
 * Added `write_as`, `units_name`, `units_description` to `BaseSortingExtractorInterface` `run_conversion` method to be able to modify them in conversion options. [PR #438](https://github.com/catalystneuro/neuroconv/pull/438)
 * Added basic temporal alignment methods to the VideoInterface. These are `align_starting_time` is split into `align_starting_times` (list of times, one per video file) and `align_global_starting_time` (shift all by a scalar amount). `align_by_interpolation` is not yet implemented for this interface. [PR #283](https://github.com/catalystneuro/neuroconv/pull/283)
-* Added stream control for the `OpenEphysBinaryRecordingInterface`.
-
+* Added stream control for the `OpenEphysBinaryRecordingInterface`. [PR #445](https://github.com/catalystneuro/neuroconv/pull/445)
 
 ### Testing
 * The tests for `automatic_dandi_upload` now follow up-to-date DANDI validation rules for file name conventions. [PR #310](https://github.com/catalystneuro/neuroconv/pull/310)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 * Added a `TemporallyAlignedDataInterface` definition for convenience when creating a custom interface for pre-aligned data. [PR #434](https://github.com/catalystneuro/neuroconv/pull/434)
 * Added `write_as`, `units_name`, `units_description` to `BaseSortingExtractorInterface` `run_conversion` method to be able to modify them in conversion options. [PR #438](https://github.com/catalystneuro/neuroconv/pull/438)
 * Added basic temporal alignment methods to the VideoInterface. These are `align_starting_time` is split into `align_starting_times` (list of times, one per video file) and `align_global_starting_time` (shift all by a scalar amount). `align_by_interpolation` is not yet implemented for this interface. [PR #283](https://github.com/catalystneuro/neuroconv/pull/283)
+* Added stream control for the `OpenEphysBinaryRecordingInterface`.
+
 
 ### Testing
 * The tests for `automatic_dandi_upload` now follow up-to-date DANDI validation rules for file name conventions. [PR #310](https://github.com/catalystneuro/neuroconv/pull/310)

--- a/docs/conversion_examples_gallery/recording/openephys.rst
+++ b/docs/conversion_examples_gallery/recording/openephys.rst
@@ -19,12 +19,9 @@ Convert OpenEphys data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys
     >>>
     >>> folder_path = f"{ECEPHY_DATA_PATH}/openephysbinary/v0.4.4.1_with_video_tracking"
     >>> # Change the folder_path to the appropriate location in your system
-    >>> interface = OpenEphysRecordingInterface(folder_path=folder_path, verbose=False)
+    >>> interface = OpenEphysRecordingInterface(folder_path=folder_path)
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
-    Loading Open-Ephys: reading settings...
-    Decoding data from  binary  format
-    Reading oebin file
     >>> # session_start_time is required for conversion. If it cannot be inferred
     >>> # automatically from the source files you must supply one.
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=tz.gettz("US/Pacific"))
@@ -33,3 +30,4 @@ Convert OpenEphys data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./saved_file.nwb"
     >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)
+    NWB file saved at ...

--- a/src/neuroconv/datainterfaces/__init__.py
+++ b/src/neuroconv/datainterfaces/__init__.py
@@ -34,12 +34,12 @@ from .ecephys.neuroscope.neuroscopedatainterface import (
 )
 from .ecephys.openephys.openephysbinarydatainterface import (
     OpenEphysBinaryRecordingInterface,
-    OpenEphysSortingInterface,
 )
 from .ecephys.openephys.openephysdatainterface import OpenEphysRecordingInterface
 from .ecephys.openephys.openephyslegacydatainterface import (
     OpenEphysLegacyRecordingInterface,
 )
+from .ecephys.openephys.openephyssortingdatainterface import OpenEphysSortingInterface
 from .ecephys.phy.phydatainterface import PhySortingInterface
 from .ecephys.plexon.plexondatainterface import (
     PlexonRecordingInterface,

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
@@ -73,7 +73,7 @@ class OpenEphysBinaryRecordingInterface(BaseRecordingExtractorInterface):
         except Exception as error:
             # Type of error might depend on pyopenephys version and/or platform
             error_case_1 = (
-                type(error) == ValueError
+                type(error) == Exception
                 and str(error) == "Only 'binary' and 'openephys' format are supported by pyopenephys"
             )
             error_case_2 = type(error) == OSError and "Unique settings file not found in" in str(error)

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
@@ -71,9 +71,13 @@ class OpenEphysBinaryRecordingInterface(BaseRecordingExtractorInterface):
         try:
             _open_with_pyopenephys(folder_path=folder_path)
         except Exception as error:
-            if (
-                str(error) == "Only 'binary' and 'openephys' format are supported by pyopenephys"
-            ):  # Raise a more informative error instead.
+            # Type of error might depend on pyopenephys version and/or platform
+            error_case_1 = (
+                type(error) == ValueError
+                and str(error) == "Only 'binary' and 'openephys' format are supported by pyopenephys"
+            )
+            error_case_2 = type(error) == OSError and "Unique settings file not found in" in str(error)
+            if error_case_1 or error_case_2:  # Raise a more informative error instead.
                 raise ValueError(
                     "Unable to identify the OpenEphys folder structure! Please check that your `folder_path` contains sub-folders of the "
                     "following form: 'experiment<index>' -> 'recording<index>' -> 'continuous'."

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
@@ -87,7 +87,7 @@ class OpenEphysBinaryRecordingInterface(BaseRecordingExtractorInterface):
                 "More than one stream is detected! Please specify which stream you wish to load with the `stream_name` argument. "
                 "To see what streams are available, call `OpenEphysRecordingInterface.get_stream_names(folder_path=...)`."
             )
-        if len(available_streams) > 1 and stream_name not in available_streams:
+        if stream_name is not None and stream_name not in available_streams:
             raise ValueError(
                 f"The selected stream '{stream_name}' is not in the available streams '{available_streams}'!"
             )

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysdatainterface.py
@@ -15,7 +15,7 @@ class OpenEphysRecordingInterface(BaseRecordingExtractorInterface):
     def __new__(
         cls,
         folder_path: FolderPathType,
-        stream_name: Optional[str] = "Signals CH",
+        stream_name: Optional[str] = None,
         verbose: bool = True,
     ):
         """
@@ -27,7 +27,7 @@ class OpenEphysRecordingInterface(BaseRecordingExtractorInterface):
         ----------
         folder_path : FolderPathType
             Path to OpenEphys directory (.continuous or .dat files).
-        stream_name : str, default: "Signals CH"
+        stream_name : str, optional
             The name of the recording stream.
             When the recording stream is not specified the channel stream is chosen if available.
             When channel stream is not available the name of the stream must be specified.
@@ -37,17 +37,10 @@ class OpenEphysRecordingInterface(BaseRecordingExtractorInterface):
 
         folder_path = Path(folder_path)
         if any(folder_path.rglob("*.continuous")):
-            return OpenEphysLegacyRecordingInterface(
-                folder_path=folder_path,
-                stream_name=stream_name,
-                verbose=verbose,
-            )
+            return OpenEphysLegacyRecordingInterface(folder_path=folder_path, stream_name=stream_name, verbose=verbose)
 
         elif any(folder_path.rglob("*.dat")):
-            return OpenEphysBinaryRecordingInterface(
-                folder_path=folder_path,
-                verbose=verbose,
-            )
+            return OpenEphysBinaryRecordingInterface(folder_path=folder_path, stream_name=stream_name, verbose=verbose)
 
         else:
             raise AssertionError("The Open Ephys data must be in 'legacy' (.continuous) or in 'binary' (.dat) format.")

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephyslegacydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephyslegacydatainterface.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from dateutil.parser import parse
 
@@ -9,6 +9,13 @@ from ....utils import FolderPathType
 class OpenEphysLegacyRecordingInterface(BaseRecordingExtractorInterface):
     """Primary data interface for converting legacy Open Ephys data (.continuous files).
     Uses :py:class:`~spikeinterface.extractors.OpenEphysLegacyRecordingExtractor`."""
+
+    @classmethod
+    def get_stream_names(cls, folder_path: FolderPathType) -> List[str]:
+        from spikeinterface.extractors import OpenEphysLegacyRecordingExtractor
+
+        stream_names, _ = OpenEphysLegacyRecordingExtractor.get_streams(folder_path=folder_path)
+        return stream_names
 
     @classmethod
     def get_source_schema(cls):
@@ -23,7 +30,7 @@ class OpenEphysLegacyRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         folder_path: FolderPathType,
-        stream_name: str = "Signals CH",
+        stream_name: Optional[str] = None,
         verbose: bool = True,
     ):
         """
@@ -34,28 +41,17 @@ class OpenEphysLegacyRecordingInterface(BaseRecordingExtractorInterface):
         ----------
         folder_path : FolderPathType
             Path to OpenEphys directory.
-        stream_name : str, default: "Signals CH"
+        stream_name : str, optional
             The name of the recording stream.
         verbose : bool, default: True
         """
-
         available_streams = self.get_stream_names(folder_path=folder_path)
-        assert (
-            stream_name in available_streams
-        ), f"The selected stream '{stream_name}' is not in the available streams '{available_streams}'!"
+        if len(available_streams) > 1 and stream_name not in available_streams:
+            raise ValueError(
+                f"The selected stream '{stream_name}' is not in the available streams '{available_streams}'!"
+            )
 
-        super().__init__(
-            folder_path=folder_path,
-            stream_name=stream_name,
-            verbose=verbose,
-        )
-
-    @classmethod
-    def get_stream_names(cls, folder_path: FolderPathType) -> List[str]:
-        from spikeinterface.extractors import OpenEphysLegacyRecordingExtractor
-
-        stream_names, _ = OpenEphysLegacyRecordingExtractor.get_streams(folder_path=folder_path)
-        return stream_names
+        super().__init__(folder_path=folder_path, stream_name=stream_name, verbose=verbose)
 
     def get_metadata(self):
         metadata = super().get_metadata()

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephyslegacydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephyslegacydatainterface.py
@@ -46,7 +46,12 @@ class OpenEphysLegacyRecordingInterface(BaseRecordingExtractorInterface):
         verbose : bool, default: True
         """
         available_streams = self.get_stream_names(folder_path=folder_path)
-        if len(available_streams) > 1 and stream_name not in available_streams:
+        if len(available_streams) > 1 and stream_name is None:
+            raise ValueError(
+                "More than one stream is detected! Please specify which stream you wish to load with the `stream_name` argument. "
+                "To see what streams are available, call `OpenEphysRecordingInterface.get_stream_names(folder_path=...)`."
+            )
+        if stream_name is not None and stream_name not in available_streams:
             raise ValueError(
                 f"The selected stream '{stream_name}' is not in the available streams '{available_streams}'!"
             )

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephyssortingdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephyssortingdatainterface.py
@@ -1,0 +1,27 @@
+from contextlib import redirect_stdout
+from io import StringIO
+from typing import List, Optional
+
+from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
+from ..basesortingextractorinterface import BaseSortingExtractorInterface
+from ....utils import FolderPathType, get_schema_from_method_signature
+
+
+class OpenEphysSortingInterface(BaseSortingExtractorInterface):
+    """Primary data interface class for converting OpenEphys spiking data."""
+
+    @classmethod
+    def get_source_schema(cls) -> dict:
+        """Compile input schema for the SortingExtractor."""
+        metadata_schema = get_schema_from_method_signature(
+            method=cls.__init__, exclude=["recording_id", "experiment_id"]
+        )
+        metadata_schema["properties"]["folder_path"].update(description="Path to directory containing OpenEphys files.")
+        metadata_schema["additionalProperties"] = False
+        return metadata_schema
+
+    def __init__(self, folder_path: FolderPathType, experiment_id: int = 0, recording_id: int = 0):
+        from spikeextractors import OpenEphysSortingExtractor
+
+        self.Extractor = OpenEphysSortingExtractor
+        super().__init__(folder_path=str(folder_path), experiment_id=experiment_id, recording_id=recording_id)

--- a/tests/test_on_data/test_gin_ecephys/test_openephys.py
+++ b/tests/test_on_data/test_gin_ecephys/test_openephys.py
@@ -19,7 +19,7 @@ class TestOpenEphysRecordingInterfaceRedirects(TestCase):
     def test_propagate_stream_name(self):
         folder_path = ECEPHY_DATA_PATH / "openephys" / "OpenEphys_SampleData_1"
         exc_msg = "The selected stream 'AUX' is not in the available streams '['Signals CH']'!"
-        with self.assertRaisesWith(AssertionError, exc_msg=exc_msg):
+        with self.assertRaisesWith(ValueError, exc_msg=exc_msg):
             OpenEphysRecordingInterface(folder_path=folder_path, stream_name="AUX")
 
     def test_binary_format(self):

--- a/tests/test_on_data/test_gin_ecephys/test_openephyslegacy.py
+++ b/tests/test_on_data/test_gin_ecephys/test_openephyslegacy.py
@@ -16,12 +16,12 @@ class TestOpenEphysLegacyConversions(TestCase):
 
     def test_openephyslegacy_streams(self):
         stream_names = self.interface.get_stream_names(folder_path=self.folder_path)
-        self.assertEqual(stream_names, ["Signals CH"])
-        self.assertEqual(self.interface.source_data["stream_name"], "Signals CH")
+        self.assertCountEqual(first=stream_names, second=["Signals CH"])
+        assert self.interface.source_data["stream_name"] is None
 
     def test_openephyslegacy_raises(self):
         with self.assertRaisesWith(
-            AssertionError,
+            ValueError,
             "The selected stream 'AUX' is not in the available streams '['Signals CH']'!",
         ):
             OpenEphysLegacyRecordingInterface(folder_path=self.folder_path, stream_name="AUX")


### PR DESCRIPTION
fix #426 

The multi-stream `OpenEphysConverter` will be added in a follow-up as this is more than enough for a single PR

While I was poking around in these interfaces for the first time in a while, I made some other changes.

- Enhanced the tests a bit (the folder structure one was because of a new issue if you're not careful about the path in the new testing data)
- Suppressed the annoying print statements from `pyopenephys` during metadata collection
- Moved the sorting interface since I'm not sure why it was still in the recording interface file