### PR TITLE
Align recording extractor properties between Neuroscope raw and LFP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * Added the `BaseTemporalAlignmentInterface` to serve as the new base class for all new temporal alignment methods. [PR #442](https://github.com/catalystneuro/neuroconv/pull/442)
 * Added direct imports for all base classes from the outer level; you may now call `from neuroconv import BaseDataInterface, BaseTemporalAlignmentInterface, BaseExtractorInterface`. [PR #442](https://github.com/catalystneuro/neuroconv/pull/442)
 * Added basic temporal alignment methods to the AudioInterface. `align_starting_time` is split into `align_starting_times` (list of times, one per audio file) and `align_global_starting_time` (shift all by a scalar amount). `align_by_interpolation` and other timestamp-based approaches is not yet implemented for this interface. [PR #402](https://github.com/catalystneuro/neuroconv/pull/402)
+* Changed the order of recording properties extraction in `NeuroscopeRecordingInterface` and `NeuroScopeLFPInterface` to make them consistent with each other [PR #466](https://github.com/catalystneuro/neuroconv/pull/466)
 
 ### Testing
 * The tests for `automatic_dandi_upload` now follow up-to-date DANDI validation rules for file name conventions. [PR #310](https://github.com/catalystneuro/neuroconv/pull/310)

--- a/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -111,11 +111,12 @@ class NeuroScopeRecordingInterface(BaseRecordingExtractorInterface):
         super().__init__(file_path=file_path, verbose=verbose, es_key=es_key)
         self.source_data["xml_file_path"] = xml_file_path
 
-        self.recording_extractor = subset_shank_channels(
-            recording_extractor=self.recording_extractor, xml_file_path=xml_file_path
-        )
         add_recording_extractor_properties(
             recording_extractor=self.recording_extractor, xml_file_path=xml_file_path, gain=gain
+        )
+
+        self.recording_extractor = subset_shank_channels(
+            recording_extractor=self.recording_extractor, xml_file_path=xml_file_path
         )
 
     def get_metadata(self) -> dict:
@@ -176,12 +177,12 @@ class NeuroScopeLFPInterface(BaseLFPExtractorInterface):
         super().__init__(file_path=file_path)
         self.source_data["xml_file_path"] = xml_file_path
 
-        self.recording_extractor = subset_shank_channels(
-            recording_extractor=self.recording_extractor, xml_file_path=xml_file_path
-        )
-
         add_recording_extractor_properties(
             recording_extractor=self.recording_extractor, xml_file_path=xml_file_path, gain=gain
+        )
+
+        self.recording_extractor = subset_shank_channels(
+            recording_extractor=self.recording_extractor, xml_file_path=xml_file_path
         )
 
     def get_metadata(self) -> dict:

--- a/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -176,11 +176,12 @@ class NeuroScopeLFPInterface(BaseLFPExtractorInterface):
         super().__init__(file_path=file_path)
         self.source_data["xml_file_path"] = xml_file_path
 
-        add_recording_extractor_properties(
-            recording_extractor=self.recording_extractor, xml_file_path=xml_file_path, gain=gain
-        )
         self.recording_extractor = subset_shank_channels(
             recording_extractor=self.recording_extractor, xml_file_path=xml_file_path
+        )
+
+        add_recording_extractor_properties(
+            recording_extractor=self.recording_extractor, xml_file_path=xml_file_path, gain=gain
         )
 
     def get_metadata(self) -> dict:


### PR DESCRIPTION
There are two functions that extract proeprties for the recording extractor on Neuroscope.

1. `subset_shank_channels` which takes a subset of the channels that are anatomically relevant according to the docstring.
2. `add_recording_extractor_properties` which uses the properties of the XML to add other properties such as shank electrode number and group memebership.

The problem right now is that they are in different order in `NeuroScopeLFPInterface` and in `NeuroScopeRecordingInterface` which leads to them having inconsistent properties when both of them are added in a conversion.

This PR fixes this by having them perform exactly the same operation.