### PR TITLE
[Sync VIIc] Final alignment cleanup and name changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
   Changed `get_default_ophys_metadata()` to add `Device` and `ImagingPlane` metadata which are both used by imaging and segmentation.
   Added `photon_series_type` to `get_nwb_imaging_metadata()` to fill metadata for `OnePhotonSeries` or `TwoPhotonSeries`. [PR #462](https://github.com/catalystneuro/neuroconv/pull/462)
 * Split `align_timestamps` and `align_starting_times` into `align_segment_timestamps` and `align_segment_starting_times` for API consistency for multi-segment `RecordingInterface`s. [PR #463](https://github.com/catalystneuro/neuroconv/pull/463)
+* Rename `align_timestamps` and `align_segmentt_timestamps` into `set_aligned_timestamps` and `set_aligned_segment_timestamps` to more clearly indicate their usage and behavior. [PR #470](https://github.com/catalystneuro/neuroconv/pull/470)
 
 ### Testing
 * The tests for `automatic_dandi_upload` now follow up-to-date DANDI validation rules for file name conventions. [PR #310](https://github.com/catalystneuro/neuroconv/pull/310)

--- a/src/neuroconv/basetemporalalignmentinterface.py
+++ b/src/neuroconv/basetemporalalignmentinterface.py
@@ -40,7 +40,7 @@ class BaseTemporalAlignmentInterface(BaseDataInterface):
         )
 
     @abstractmethod
-    def align_timestamps(self, aligned_timestamps: np.ndarray):
+    def set_aligned_timestamps(self, aligned_timestamps: np.ndarray):
         """
         Replace all timestamps for this interface with those aligned to the common session start time.
 
@@ -66,7 +66,7 @@ class BaseTemporalAlignmentInterface(BaseDataInterface):
         starting_time : float
             The starting time for all temporal data in this interface.
         """
-        self.align_timestamps(aligned_timestamps=self.get_timestamps() + starting_time)
+        self.set_aligned_timestamps(aligned_timestamps=self.get_timestamps() + starting_time)
 
     def align_by_interpolation(self, unaligned_timestamps: np.ndarray, aligned_timestamps: np.ndarray):
         """
@@ -89,6 +89,6 @@ class BaseTemporalAlignmentInterface(BaseDataInterface):
         aligned_timestamps : numpy.ndarray
             The timestamps aligned to the primary time basis.
         """
-        self.align_timestamps(
+        self.set_aligned_timestamps(
             aligned_timestamps=np.interp(x=self.get_timestamps(), xp=unaligned_timestamps, fp=aligned_timestamps)
         )

--- a/src/neuroconv/basetemporalalignmentinterface.py
+++ b/src/neuroconv/basetemporalalignmentinterface.py
@@ -55,7 +55,7 @@ class BaseTemporalAlignmentInterface(BaseDataInterface):
             "The protocol for synchronizing the timestamps of this interface has not been specified!"
         )
 
-    def align_starting_time(self, starting_time: float):
+    def set_aligned_starting_time(self, aligned_starting_time: float):
         """
         Align the starting time for this interface relative to the common session start time.
 
@@ -63,10 +63,10 @@ class BaseTemporalAlignmentInterface(BaseDataInterface):
 
         Parameters
         ----------
-        starting_time : float
+        aligned_starting_time : float
             The starting time for all temporal data in this interface.
         """
-        self.set_aligned_timestamps(aligned_timestamps=self.get_timestamps() + starting_time)
+        self.set_aligned_timestamps(aligned_timestamps=self.get_timestamps() + aligned_starting_time)
 
     def align_by_interpolation(self, unaligned_timestamps: np.ndarray, aligned_timestamps: np.ndarray):
         """

--- a/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
@@ -98,7 +98,7 @@ class AudioInterface(BaseTemporalAlignmentInterface):
     def set_aligned_timestamps(self, aligned_timestamps: List[np.ndarray]):
         raise NotImplementedError("The AudioInterface does not yet support timestamps.")
 
-    def align_starting_time(self, starting_time: float):
+    def set_aligned_starting_time(self, aligned_starting_time: float):
         """
         Align all starting times for all audio files in this interface relative to the common session start time.
 
@@ -106,23 +106,23 @@ class AudioInterface(BaseTemporalAlignmentInterface):
 
         Parameters
         ----------
-        starting_time : float
+        aligned_starting_time : float
             The common starting time for all temporal data in this interface.
             Applies to all segments if there are multiple file paths used by the interface.
         """
         if self._segment_starting_times is None and self._number_of_audio_files == 1:
-            self._segment_starting_times = [starting_time]
+            self._segment_starting_times = [aligned_starting_time]
         elif self._segment_starting_times is not None and self._number_of_audio_files > 1:
             self._segment_starting_times = [
-                segment_starting_time + starting_time for segment_starting_time in self._segment_starting_times
+                segment_starting_time + aligned_starting_time for segment_starting_time in self._segment_starting_times
             ]
         else:
             raise ValueError(
                 "There are no segment starting times to shift by a common value! "
-                "Please set them using 'align_segment_starting_times'."
+                "Please set them using 'set_aligned_segment_starting_times'."
             )
 
-    def align_segment_starting_times(self, segment_starting_times: List[float]):
+    def set_aligned_segment_starting_times(self, aligned_segment_starting_times: List[float]):
         """
         Align the individual starting time for each audio file in this interface relative to the common session start time.
 
@@ -130,19 +130,19 @@ class AudioInterface(BaseTemporalAlignmentInterface):
 
         Parameters
         ----------
-        segment_starting_times : list of floats
+        aligned_segment_starting_times : list of floats
             The relative starting times of each audio file (segment).
         """
-        segment_starting_times_length = len(segment_starting_times)
-        assert isinstance(segment_starting_times, list) and all(
-            [isinstance(x, float) for x in segment_starting_times]
-        ), "Argument 'segment_starting_times' must be a list of floats."
-        assert segment_starting_times_length == self._number_of_audio_files, (
-            f"The number of entries in 'segment_starting_times' ({segment_starting_times_length}) must be equal to the number of "
-            f"audio file paths ({self._number_of_audio_files})."
+        aligned_segment_starting_times_length = len(aligned_segment_starting_times)
+        assert isinstance(aligned_segment_starting_times, list) and all(
+            [isinstance(x, float) for x in aligned_segment_starting_times]
+        ), "Argument 'aligned_segment_starting_times' must be a list of floats."
+        assert aligned_segment_starting_times_length == self._number_of_audio_files, (
+            f"The number of entries in 'aligned_segment_starting_times' ({aligned_segment_starting_times_length}) "
+            f"must be equal to the number of audio file paths ({self._number_of_audio_files})."
         )
 
-        self._segment_starting_times = segment_starting_times
+        self._segment_starting_times = aligned_segment_starting_times
 
     def align_by_interpolation(self, unaligned_timestamps: np.ndarray, aligned_timestamps: np.ndarray):
         raise NotImplementedError("The AudioInterface does not yet support timestamps.")
@@ -200,7 +200,7 @@ class AudioInterface(BaseTemporalAlignmentInterface):
         if self._number_of_audio_files > 1 and self._segment_starting_times is None:
             raise ValueError(
                 "If you have multiple audio files, then you must specify each starting time by calling "
-                "'.align_segment_starting_times(segment_starting_times=...)'!"
+                "'.set_aligned_segment_starting_times(...)'!"
             )
         starting_times = self._segment_starting_times or [0.0]
 

--- a/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
@@ -95,7 +95,7 @@ class AudioInterface(BaseTemporalAlignmentInterface):
     def get_timestamps(self) -> Optional[np.ndarray]:
         raise NotImplementedError("The AudioInterface does not yet support timestamps.")
 
-    def align_timestamps(self, aligned_timestamps: List[np.ndarray]):
+    def set_aligned_timestamps(self, aligned_timestamps: List[np.ndarray]):
         raise NotImplementedError("The AudioInterface does not yet support timestamps.")
 
     def align_starting_time(self, starting_time: float):

--- a/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
@@ -96,7 +96,7 @@ class DeepLabCutInterface(BaseTemporalAlignmentInterface):
             "Unable to retrieve timestamps for this interface! Define the `get_timestamps` method for this interface."
         )
 
-    def align_timestamps(self, aligned_timestamps: np.ndarray):
+    def set_aligned_timestamps(self, aligned_timestamps: np.ndarray):
         raise NotImplementedError(
             "The protocol for synchronizing the timestamps of this interface has not been specified!"
         )

--- a/src/neuroconv/datainterfaces/behavior/sleap/sleapdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/sleap/sleapdatainterface.py
@@ -55,7 +55,7 @@ class SLEAPInterface(BaseTemporalAlignmentInterface):
         timestamps = self._timestamps if self._timestamps is not None else self.get_original_timestamps()
         return timestamps
 
-    def align_timestamps(self, aligned_timestamps: np.ndarray):
+    def set_aligned_timestamps(self, aligned_timestamps: np.ndarray):
         self._timestamps = aligned_timestamps
 
     def run_conversion(

--- a/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
@@ -141,7 +141,7 @@ class VideoInterface(BaseDataInterface):
         """
         return self._timestamps or self.get_original_timestamps(stub_test=stub_test)
 
-    def align_timestamps(self, aligned_timestamps: List[np.ndarray]):
+    def set_aligned_timestamps(self, aligned_timestamps: List[np.ndarray]):
         """
         Replace all timestamps for this interface with those aligned to the common session start time.
 
@@ -175,7 +175,7 @@ class VideoInterface(BaseDataInterface):
             To limit that scan to a small number of frames, set `stub_test=True`.
         """
         if self._timestamps is not None:
-            self.align_timestamps(
+            self.set_aligned_timestamps(
                 aligned_timestamps=[
                     timestamps + starting_time for timestamps in self.get_timestamps(stub_test=stub_test)
                 ]
@@ -210,7 +210,7 @@ class VideoInterface(BaseDataInterface):
             "number of video files ({self._number_of_files})!"
         )
         if self._timestamps is not None:
-            self.align_timestamps(
+            self.set_aligned_timestamps(
                 aligned_timestamps=[
                     timestamps + segment_starting_time
                     for timestamps, segment_starting_time in zip(

--- a/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
@@ -175,11 +175,10 @@ class VideoInterface(BaseDataInterface):
             To limit that scan to a small number of frames, set `stub_test=True`.
         """
         if self._timestamps is not None:
-            self.set_aligned_timestamps(
-                aligned_timestamps=[
-                    timestamps + aligned_starting_time for timestamps in self.get_timestamps(stub_test=stub_test)
-                ]
-            )
+            aligned_timestamps = [
+                timestamps + aligned_starting_time for timestamps in self.get_timestamps(stub_test=stub_test)
+            ]
+            self.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
         elif self._segment_starting_times is not None:
             self._segment_starting_times = [
                 segment_starting_time + aligned_starting_time for segment_starting_time in self._segment_starting_times

--- a/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
@@ -157,7 +157,7 @@ class VideoInterface(BaseDataInterface):
         ), "If setting both timestamps and starting times, please set the timestamps first so they can be shifted by the starting times."
         self._timestamps = aligned_timestamps
 
-    def align_starting_time(self, starting_time: float, stub_test: bool = False):
+    def set_aligned_starting_time(self, aligned_starting_time: float, stub_test: bool = False):
         """
         Align all starting times for all videos in this interface relative to the common session start time.
 
@@ -165,7 +165,7 @@ class VideoInterface(BaseDataInterface):
 
         Parameters
         ----------
-        starting_time : float
+        aligned_starting_time : float
             The common starting time for all segments of temporal data in this interface.
         stub_test : bool, default: False
             If timestamps have not been set to this interface, it will attempt to retrieve them
@@ -177,17 +177,17 @@ class VideoInterface(BaseDataInterface):
         if self._timestamps is not None:
             self.set_aligned_timestamps(
                 aligned_timestamps=[
-                    timestamps + starting_time for timestamps in self.get_timestamps(stub_test=stub_test)
+                    timestamps + aligned_starting_time for timestamps in self.get_timestamps(stub_test=stub_test)
                 ]
             )
         elif self._segment_starting_times is not None:
             self._segment_starting_times = [
-                starting_time + starting_time for starting_time in self._segment_starting_times
+                segment_starting_time + aligned_starting_time for segment_starting_time in self._segment_starting_times
             ]
         else:
             raise ValueError("There are no timestamps or starting times set to shift by a common value!")
 
-    def align_segment_starting_times(self, segment_starting_times: List[float], stub_test: bool = False):
+    def set_aligned_segment_starting_times(self, aligned_segment_starting_times: List[float], stub_test: bool = False):
         """
         Align the individual starting time for each video (segment) in this interface relative to the common session start time.
 
@@ -204,9 +204,9 @@ class VideoInterface(BaseDataInterface):
 
             To limit that scan to a small number of frames, set `stub_test=True`.
         """
-        segment_starting_times_length = len(segment_starting_times)
-        assert segment_starting_times_length == self._number_of_files, (
-            f"The length of the 'segment_starting_times' list ({segment_starting_times_length}) does not match the "
+        aligned_segment_starting_times_length = len(aligned_segment_starting_times)
+        assert aligned_segment_starting_times_length == self._number_of_files, (
+            f"The length of the 'aligned_segment_starting_times' list ({aligned_segment_starting_times_length}) does not match the "
             "number of video files ({self._number_of_files})!"
         )
         if self._timestamps is not None:
@@ -214,12 +214,12 @@ class VideoInterface(BaseDataInterface):
                 aligned_timestamps=[
                     timestamps + segment_starting_time
                     for timestamps, segment_starting_time in zip(
-                        self.get_timestamps(stub_test=stub_test), segment_starting_times
+                        self.get_timestamps(stub_test=stub_test), aligned_segment_starting_times
                     )
                 ]
             )
         else:
-            self._segment_starting_times = segment_starting_times
+            self._segment_starting_times = aligned_segment_starting_times
 
     def align_by_interpolation(self, unaligned_timestamps: np.ndarray, aligned_timestamps: np.ndarray):
         raise NotImplementedError("The `align_by_interpolation` method has not been developed for this interface yet.")

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -193,17 +193,17 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
                 times=aligned_segment_timestamps[segment_index], segment_index=segment_index
             )
 
-    def align_starting_time(self, starting_time: float):
+    def set_aligned_starting_time(self, aligned_starting_time: float):
         if self._number_of_segments == 1:
-            self.set_aligned_timestamps(aligned_timestamps=self.get_timestamps() + starting_time)
+            self.set_aligned_timestamps(aligned_timestamps=self.get_timestamps() + aligned_starting_time)
         else:
             self.set_aligned_segment_timestamps(
                 aligned_segment_timestamps=[
-                    segment_timestamps + starting_time for segment_timestamps in self.get_timestamps()
+                    segment_timestamps + aligned_starting_time for segment_timestamps in self.get_timestamps()
                 ]
             )
 
-    def align_segment_starting_times(self, segment_starting_times: List[float]):
+    def set_aligned_segment_starting_times(self, aligned_segment_starting_times: List[float]):
         """
         Align the starting time for each segment in this interface relative to the common session start time.
 
@@ -211,19 +211,22 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
 
         Parameters
         ----------
-        segment_starting_times : list of floats
+        aligned_segment_starting_times : list of floats
             The starting time for each segment of data in this interface.
         """
-        assert (
-            len(segment_starting_times) == self._number_of_segments
-        ), f"The length of the starting_times ({len(segment_starting_times)}) does not match the number of segments ({self._number_of_segments})!"
+        assert len(aligned_segment_starting_times) == self._number_of_segments, (
+            f"The length of the starting_times ({len(aligned_segment_starting_times)}) does not match the "
+            "number of segments ({self._number_of_segments})!"
+        )
 
         if self._number_of_segments == 1:
-            self.align_starting_time(starting_time=segment_starting_times[0])
+            self.set_aligned_starting_time(aligned_starting_time=aligned_segment_starting_times[0])
         else:
             aligned_segment_timestamps = [
-                segment_timestamps + segment_starting_time
-                for segment_timestamps, segment_starting_time in zip(self.get_timestamps(), segment_starting_times)
+                segment_timestamps + aligned_segment_starting_time
+                for segment_timestamps, aligned_segment_starting_time in zip(
+                    self.get_timestamps(), aligned_segment_starting_times
+                )
             ]
             self.set_aligned_segment_timestamps(aligned_segment_timestamps=aligned_segment_timestamps)
 

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -170,7 +170,7 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
 
         self.recording_extractor.set_times(times=aligned_timestamps)
 
-    def align_segment_timestamps(self, aligned_segment_timestamps: List[np.ndarray]):
+    def set_aligned_segment_timestamps(self, aligned_segment_timestamps: List[np.ndarray]):
         """
         Replace all timestamps for all segments in this interface with those aligned to the common session start time.
 
@@ -197,7 +197,7 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
         if self._number_of_segments == 1:
             self.set_aligned_timestamps(aligned_timestamps=self.get_timestamps() + starting_time)
         else:
-            self.align_segment_timestamps(
+            self.set_aligned_segment_timestamps(
                 aligned_segment_timestamps=[
                     segment_timestamps + starting_time for segment_timestamps in self.get_timestamps()
                 ]
@@ -225,7 +225,7 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
                 segment_timestamps + segment_starting_time
                 for segment_timestamps, segment_starting_time in zip(self.get_timestamps(), segment_starting_times)
             ]
-            self.align_segment_timestamps(aligned_segment_timestamps=aligned_segment_timestamps)
+            self.set_aligned_segment_timestamps(aligned_segment_timestamps=aligned_segment_timestamps)
 
     def align_by_interpolation(
         self,

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -163,7 +163,7 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
                 for segment_index in range(self._number_of_segments)
             ]
 
-    def align_timestamps(self, aligned_timestamps: np.ndarray):
+    def set_aligned_timestamps(self, aligned_timestamps: np.ndarray):
         assert (
             self._number_of_segments == 1
         ), "This recording has multiple segments; please use 'align_segment_timestamps' instead."
@@ -186,7 +186,7 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
         ), "Recording has multiple segment! Please pass a list of timestamps to align each segment."
         assert (
             len(aligned_segment_timestamps) == self._number_of_segments
-        ), f"The number of timestamp vectors ({len(aligned_timestamps)}) does not match the number of segments ({self._number_of_segments})!"
+        ), f"The number of timestamp vectors ({len(aligned_segment_timestamps)}) does not match the number of segments ({self._number_of_segments})!"
 
         for segment_index in range(self._number_of_segments):
             self.recording_extractor.set_times(
@@ -195,7 +195,7 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
 
     def align_starting_time(self, starting_time: float):
         if self._number_of_segments == 1:
-            self.align_timestamps(aligned_timestamps=self.get_timestamps() + starting_time)
+            self.set_aligned_timestamps(aligned_timestamps=self.get_timestamps() + starting_time)
         else:
             self.align_segment_timestamps(
                 aligned_segment_timestamps=[
@@ -216,7 +216,7 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
         """
         assert (
             len(segment_starting_times) == self._number_of_segments
-        ), f"The length of the starting_times ({len(starting_times)}) does not match the number of segments ({self._number_of_segments})!"
+        ), f"The length of the starting_times ({len(segment_starting_times)}) does not match the number of segments ({self._number_of_segments})!"
 
         if self._number_of_segments == 1:
             self.align_starting_time(starting_time=segment_starting_times[0])
@@ -233,7 +233,7 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
         aligned_timestamps: np.ndarray,
     ):
         if self._number_of_segments == 1:
-            self.align_timestamps(
+            self.set_aligned_timestamps(
                 aligned_timestamps=np.interp(x=self.get_timestamps(), xp=unaligned_timestamps, fp=aligned_timestamps)
             )
         else:

--- a/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
@@ -166,21 +166,21 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
                 times=aligned_segment_timestamps[segment_index], segment_index=segment_index
             )
 
-    def align_starting_time(self, starting_time: float):
+    def set_aligned_starting_time(self, aligned_starting_time: float):
         if self.sorting_extractor.has_recording():
             if self._number_of_segments == 1:
-                self.set_aligned_timestamps(aligned_timestamps=self.get_timestamps() + starting_time)
+                self.set_aligned_timestamps(aligned_timestamps=self.get_timestamps() + aligned_starting_time)
             else:
                 self.set_aligned_segment_timestamps(
                     aligned_timestamps=[
-                        segment_timestamps + starting_time for segment_timestamps in self.get_timestamps()
+                        segment_timestamps + aligned_starting_time for segment_timestamps in self.get_timestamps()
                     ]
                 )
         else:
             for sorting_segment in self.sorting_extractor._sorting_segments:
-                sorting_segment._t_start += starting_time
+                sorting_segment._t_start += aligned_starting_time
 
-    def align_segment_starting_times(self, segment_starting_times: List[float]):
+    def set_aligned_segment_starting_times(self, aligned_segment_starting_times: List[float]):
         """
         Align the starting time for each segment in this interface relative to the common session start time.
 
@@ -188,25 +188,30 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
 
         Parameters
         ----------
-        segment_starting_times : list of floats
+        aligned_segment_starting_times : list of floats
             The starting time for each segment of data in this interface.
         """
-        assert (
-            len(segment_starting_times) == self._number_of_segments
-        ), f"The length of the starting_times ({len(segment_starting_times)}) does not match the number of segments ({self._number_of_segments})!"
+        assert len(aligned_segment_starting_times) == self._number_of_segments, (
+            f"The length of the starting_times ({len(aligned_segment_starting_times)}) does not match the number "
+            f"of segments ({self._number_of_segments})!"
+        )
 
         if self.sorting_extractor.has_recording():
             if self._number_of_segments == 1:
-                self.set_aligned_timestamps(aligned_timestamps=self.get_timestamps() + segment_starting_times[0])
+                self.set_aligned_starting_time(aligned_starting_time=aligned_segment_starting_times[0])
             else:
                 aligned_segment_timestamps = [
-                    segment_timestamps + segment_starting_time
-                    for segment_timestamps, segment_starting_time in zip(self.get_timestamps(), segment_starting_times)
+                    segment_timestamps + aligned_segment_starting_time
+                    for segment_timestamps, aligned_segment_starting_time in zip(
+                        self.get_timestamps(), aligned_segment_starting_times
+                    )
                 ]
                 self.set_aligned_segment_timestamps(aligned_segment_timestamps=aligned_segment_timestamps)
         else:
-            for sorting_segment, starting_time in zip(self.sorting_extractor._sorting_segments, segment_starting_times):
-                sorting_segment._t_start = starting_time
+            for sorting_segment, aligned_segment_starting_time in zip(
+                self.sorting_extractor._sorting_segments, aligned_segment_starting_times
+            ):
+                sorting_segment._t_start = aligned_segment_starting_time
 
     def subset_sorting(self):
         max_min_spike_time = max(

--- a/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
@@ -96,7 +96,7 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
                 for segment_index in range(self._number_of_segments)
             ]
 
-    def align_timestamps(self, aligned_timestamps: np.ndarray):
+    def set_aligned_timestamps(self, aligned_timestamps: np.ndarray):
         """
         Replace all timestamps for the attached interface with those aligned to the common session start time.
 
@@ -120,7 +120,7 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
             )
         assert (
             self._number_of_segments == 1
-        ), "This recording has multiple segments; please use 'align_segment_timestamps' instead."
+        ), "This recording has multiple segments; please use 'set_aligned_segment_timestamps' instead."
 
         if self._number_of_segments == 1:
             self.sorting_extractor._recording.set_times(times=aligned_timestamps)
@@ -137,12 +137,12 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
                     times=aligned_timestamps[segment_index], segment_index=segment_index
                 )
 
-    def align_segment_timestamps(self, aligned_segment_timestamps: List[np.ndarray]):
+    def set_aligned_segment_timestamps(self, aligned_segment_timestamps: List[np.ndarray]):
         """
         Replace all timestamps for all segments in this interface with those aligned to the common session start time.
 
         Must be in units seconds relative to the common 'session_start_time'.
-        Must have a multi-segment RecordingInterface attached; call `.register_recording(recording_interface=...)` to accomplish this.
+        Must have a multi-segment RecordingInterface attached by calling `.register_recording(recording_interface=...)`.
 
         Parameters
         ----------
@@ -159,7 +159,7 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
         ), "Recording has multiple segment! Please pass a list of timestamps to align each segment."
         assert (
             len(aligned_segment_timestamps) == self._number_of_segments
-        ), f"The number of timestamp vectors ({len(aligned_timestamps)}) does not match the number of segments ({self._number_of_segments})!"
+        ), f"The number of timestamp vectors ({len(aligned_segment_timestamps)}) does not match the number of segments ({self._number_of_segments})!"
 
         for segment_index in range(self._number_of_segments):
             self.sorting_extractor._recording.set_times(
@@ -169,9 +169,9 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
     def align_starting_time(self, starting_time: float):
         if self.sorting_extractor.has_recording():
             if self._number_of_segments == 1:
-                self.align_timestamps(aligned_timestamps=self.get_timestamps() + starting_time)
+                self.set_aligned_timestamps(aligned_timestamps=self.get_timestamps() + starting_time)
             else:
-                self.align_segment_timestamps(
+                self.set_aligned_segment_timestamps(
                     aligned_timestamps=[
                         segment_timestamps + starting_time for segment_timestamps in self.get_timestamps()
                     ]
@@ -193,17 +193,17 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
         """
         assert (
             len(segment_starting_times) == self._number_of_segments
-        ), f"The length of the starting_times ({len(starting_times)}) does not match the number of segments ({self._number_of_segments})!"
+        ), f"The length of the starting_times ({len(segment_starting_times)}) does not match the number of segments ({self._number_of_segments})!"
 
         if self.sorting_extractor.has_recording():
             if self._number_of_segments == 1:
-                self.align_timestamps(aligned_timestamps=self.get_timestamps() + segment_starting_times[0])
+                self.set_aligned_timestamps(aligned_timestamps=self.get_timestamps() + segment_starting_times[0])
             else:
                 aligned_segment_timestamps = [
                     segment_timestamps + segment_starting_time
                     for segment_timestamps, segment_starting_time in zip(self.get_timestamps(), segment_starting_times)
                 ]
-                self.align_segment_timestamps(aligned_segment_timestamps=aligned_segment_timestamps)
+                self.set_aligned_segment_timestamps(aligned_segment_timestamps=aligned_segment_timestamps)
         else:
             for sorting_segment, starting_time in zip(self.sorting_extractor._sorting_segments, segment_starting_times):
                 sorting_segment._t_start = starting_time

--- a/src/neuroconv/datainterfaces/icephys/abf/abfdatainterface.py
+++ b/src/neuroconv/datainterfaces/icephys/abf/abfdatainterface.py
@@ -144,7 +144,7 @@ class AbfInterface(BaseIcephysInterface):
 
         return metadata
 
-    def align_starting_time(self, aligned_starting_time: float):
+    def set_aligned_starting_time(self, aligned_starting_time: float):
         for reader in self.readers_list:
             number_of_segments = reader.header["nb_segment"][0]
             for segment_index in range(number_of_segments):

--- a/src/neuroconv/datainterfaces/icephys/abf/abfdatainterface.py
+++ b/src/neuroconv/datainterfaces/icephys/abf/abfdatainterface.py
@@ -144,13 +144,15 @@ class AbfInterface(BaseIcephysInterface):
 
         return metadata
 
-    def align_starting_time(self, starting_time: float):
+    def align_starting_time(self, aligned_starting_time: float):
         for reader in self.readers_list:
             number_of_segments = reader.header["nb_segment"][0]
             for segment_index in range(number_of_segments):
-                reader._t_starts[segment_index] += starting_time
+                reader._t_starts[segment_index] += aligned_starting_time
 
-    def align_segment_starting_times(self, segment_starting_times: List[List[float]], stub_test: bool = False):
+    def set_aligned_segment_starting_times(
+        self, aligned_segment_starting_times: List[List[float]], stub_test: bool = False
+    ):
         """
         Align the individual starting time for each video in this interface relative to the common session start time.
 
@@ -158,21 +160,23 @@ class AbfInterface(BaseIcephysInterface):
 
         Parameters
         ----------
-        segment_starting_times : list of list of floats
+        aligned_segment_starting_times : list of list of floats
             The relative starting times of each video.
             Outer list is over file paths (readers).
             Inner list is over segments of each recording.
         """
-        number_of_files_from_starting_times = len(segment_starting_times)
+        number_of_files_from_starting_times = len(aligned_segment_starting_times)
         assert number_of_files_from_starting_times == len(self.readers_list), (
             f"The length of the outer list of 'starting_times' ({number_of_files_from_starting_times}) "
             "does not match the number of files ({len(self.readers_list)})!"
         )
 
-        for file_index, (reader, segment_starting_times) in enumerate(zip(self.readers_list, segment_starting_times)):
+        for file_index, (reader, aligned_segment_starting_times_by_file) in enumerate(
+            zip(self.readers_list, aligned_segment_starting_times)
+        ):
             number_of_segments = reader.header["nb_segment"][0]
             assert number_of_segments == len(
-                segment_starting_times
+                aligned_segment_starting_times_by_file
             ), f"The length of starting times index {file_index} does not match the number of segments of that reader!"
 
-            reader._t_starts = segment_starting_times
+            reader._t_starts = aligned_segment_starting_times_by_file

--- a/src/neuroconv/datainterfaces/icephys/abf/abfdatainterface.py
+++ b/src/neuroconv/datainterfaces/icephys/abf/abfdatainterface.py
@@ -145,49 +145,34 @@ class AbfInterface(BaseIcephysInterface):
         return metadata
 
     def align_starting_time(self, starting_time: float):
-        raise NotImplementedError(
-            "The AbfInterface operates on a list of file paths; to reduce ambiguity, please choose "
-            "between `align_global_starting_time` (shift starting time of each video by the same value) "
-            "and `align_starting_times` (specify a list of values to use in shifting the starting time for each video)."
-        )
-
-    def align_global_starting_time(self, global_starting_time: float):
-        """
-        Align all starting times for all videos in this interface relative to the common session start time.
-        Must be in units seconds relative to the common 'session_start_time'.
-
-        Parameters
-        ----------
-        global_starting_time : float
-            The starting time for all temporal data in this interface.
-        """
         for reader in self.readers_list:
             number_of_segments = reader.header["nb_segment"][0]
             for segment_index in range(number_of_segments):
-                reader._t_starts[segment_index] += global_starting_time
+                reader._t_starts[segment_index] += starting_time
 
-    def align_starting_times(self, starting_times: List[List[float]], stub_test: bool = False):
+    def align_segment_starting_times(self, segment_starting_times: List[List[float]], stub_test: bool = False):
         """
         Align the individual starting time for each video in this interface relative to the common session start time.
+
         Must be in units seconds relative to the common 'session_start_time'.
 
         Parameters
         ----------
-        starting_times : list of list of floats
+        segment_starting_times : list of list of floats
             The relative starting times of each video.
             Outer list is over file paths (readers).
             Inner list is over segments of each recording.
         """
-        number_of_files_from_starting_times = len(starting_times)
+        number_of_files_from_starting_times = len(segment_starting_times)
         assert number_of_files_from_starting_times == len(self.readers_list), (
             f"The length of the outer list of 'starting_times' ({number_of_files_from_starting_times}) "
             "does not match the number of files ({len(self.readers_list)})!"
         )
 
-        for file_index, (reader, starting_times_per_segment) in enumerate(zip(self.readers_list, starting_times)):
+        for file_index, (reader, segment_starting_times) in enumerate(zip(self.readers_list, segment_starting_times)):
             number_of_segments = reader.header["nb_segment"][0]
             assert number_of_segments == len(
-                starting_times_per_segment
+                segment_starting_times
             ), f"The length of starting times index {file_index} does not match the number of segments of that reader!"
 
-            reader._t_starts = starting_times_per_segment
+            reader._t_starts = segment_starting_times

--- a/src/neuroconv/datainterfaces/icephys/baseicephysinterface.py
+++ b/src/neuroconv/datainterfaces/icephys/baseicephysinterface.py
@@ -73,14 +73,14 @@ class BaseIcephysInterface(BaseExtractorInterface):
     def get_timestamps(self) -> np.ndarray:
         raise NotImplementedError("Icephys interfaces do not yet support timestamps.")
 
-    def align_timestamps(self, aligned_timestamps: np.ndarray):
-        raise NotImplementedError("Icephys interfaces do not yet support timestamps.")
-
-    def align_by_interpolation(self, unaligned_timestamps: np.ndarray, aligned_timestamps: np.ndarray):
+    def set_aligned_timestamps(self, aligned_timestamps: np.ndarray):
         raise NotImplementedError("Icephys interfaces do not yet support timestamps.")
 
     def align_starting_time(self, starting_time: float):
         raise NotImplementedError("This icephys interface has not specified the method for aligning starting time.")
+
+    def align_by_interpolation(self, unaligned_timestamps: np.ndarray, aligned_timestamps: np.ndarray):
+        raise NotImplementedError("Icephys interfaces do not yet support timestamps.")
 
     def run_conversion(
         self,

--- a/src/neuroconv/datainterfaces/icephys/baseicephysinterface.py
+++ b/src/neuroconv/datainterfaces/icephys/baseicephysinterface.py
@@ -76,7 +76,7 @@ class BaseIcephysInterface(BaseExtractorInterface):
     def set_aligned_timestamps(self, aligned_timestamps: np.ndarray):
         raise NotImplementedError("Icephys interfaces do not yet support timestamps.")
 
-    def align_starting_time(self, starting_time: float):
+    def set_aligned_starting_time(self, aligned_starting_time: float):
         raise NotImplementedError("This icephys interface has not specified the method for aligning starting time.")
 
     def align_by_interpolation(self, unaligned_timestamps: np.ndarray, aligned_timestamps: np.ndarray):

--- a/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
@@ -80,7 +80,7 @@ class BaseImagingExtractorInterface(BaseExtractorInterface):
     def get_timestamps(self) -> np.ndarray:
         return self.imaging_extractor.frame_to_time(frames=np.arange(stop=self.imaging_extractor.get_num_frames()))
 
-    def align_timestamps(self, aligned_timestamps: np.ndarray):
+    def set_aligned_timestamps(self, aligned_timestamps: np.ndarray):
         self.imaging_extractor.set_times(times=aligned_timestamps)
 
     def run_conversion(

--- a/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
@@ -73,7 +73,7 @@ class BaseSegmentationExtractorInterface(BaseExtractorInterface):
             frames=np.arange(stop=self.segmentation_extractor.get_num_frames())
         )
 
-    def align_timestamps(self, aligned_timestamps: np.ndarray):
+    def set_aligned_timestamps(self, aligned_timestamps: np.ndarray):
         self.segmentation_extractor.set_times(times=aligned_timestamps)
 
     def run_conversion(

--- a/src/neuroconv/datainterfaces/text/timeintervalsinterface.py
+++ b/src/neuroconv/datainterfaces/text/timeintervalsinterface.py
@@ -63,11 +63,11 @@ class TimeIntervalsInterface(BaseDataInterface):
 
         return self.dataframe[column].values
 
-    def align_starting_time(self, starting_time: float):
+    def set_aligned_starting_time(self, aligned_starting_time: float):
         timing_columns = [column for column in self.dataframe.columns if column.endswith("_time")]
 
         for column in timing_columns:
-            self.dataframe[column] += starting_time
+            self.dataframe[column] += aligned_starting_time
 
     def set_aligned_timestamps(
         self, aligned_timestamps: np.ndarray, column: str, interpolate_other_columns: bool = False

--- a/src/neuroconv/datainterfaces/text/timeintervalsinterface.py
+++ b/src/neuroconv/datainterfaces/text/timeintervalsinterface.py
@@ -69,7 +69,9 @@ class TimeIntervalsInterface(BaseDataInterface):
         for column in timing_columns:
             self.dataframe[column] += starting_time
 
-    def align_timestamps(self, aligned_timestamps: np.ndarray, column: str, interpolate_other_columns: bool = False):
+    def set_aligned_timestamps(
+        self, aligned_timestamps: np.ndarray, column: str, interpolate_other_columns: bool = False
+    ):
         if not column.endswith("_time"):
             raise ValueError("Timing columns on a TimeIntervals table need to end with '_time'!")
 
@@ -101,7 +103,7 @@ class TimeIntervalsInterface(BaseDataInterface):
         ), "All current timestamps except for the last must be strictly within the unaligned mapping."
         # Assume timing column is ascending otherwise
 
-        self.align_timestamps(
+        self.set_aligned_timestamps(
             aligned_timestamps=np.interp(
                 x=current_timestamps,
                 xp=unaligned_timestamps,

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -552,6 +552,6 @@ class SortingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
                 self.check_nwbfile_temporal_alignment()
 
 
-class AudioInterfaceTestMixin(DataInterfaceTestMixin):
+class AudioInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
     def check_read_nwb(self, nwbfile_path: str):
         pass  # asserted in the testing suite; could be refactored in future PR

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -323,7 +323,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
                 ]
                 self.interface.set_aligned_timestamps(aligned_timestamps=all_aligned_segment_timestamps)
 
-    def check_interface_align_segment_timestamps(self):
+    def check_interface_set_aligned_segment_timestamps(self):
         self.setUpFreshInterface()
 
         random_number_generator = np.random.default_rng(seed=0)
@@ -333,7 +333,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
             all_aligned_segment_timestamps = [
                 unaligned_timestamps + 1.23 + random_number_generator.random(size=unaligned_timestamps.shape)
             ]
-            self.interface.align_segment_timestamps(aligned_segment_timestamps=all_aligned_segment_timestamps)
+            self.interface.set_aligned_segment_timestamps(aligned_segment_timestamps=all_aligned_segment_timestamps)
 
             retrieved_aligned_timestamps = self.interface.get_timestamps()
             assert_array_equal(x=retrieved_aligned_timestamps, y=all_aligned_segment_timestamps[0])
@@ -343,7 +343,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
                 unaligned_timestamps + 1.23 + random_number_generator.random(size=unaligned_timestamps.shape)
                 for unaligned_timestamps in all_unaligned_timestamps
             ]
-            self.interface.align_segment_timestamps(aligned_segment_timestamps=all_aligned_segment_timestamps)
+            self.interface.set_aligned_segment_timestamps(aligned_segment_timestamps=all_aligned_segment_timestamps)
 
             all_retrieved_aligned_timestamps = self.interface.get_timestamps()
             for retrieved_aligned_timestamps, aligned_segment_timestamps in zip(
@@ -438,7 +438,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
                 self.check_interface_get_original_timestamps()
                 self.check_interface_get_timestamps()
                 self.check_interface_set_aligned_timestamps()
-                self.check_interface_align_segment_timestamps()
+                self.check_interface_set_aligned_segment_timestamps()
                 self.check_shift_timestamps_by_start_time()
                 self.check_shift_segment_timestamps_by_starting_times()
                 self.check_interface_original_timestamps_inmutability()
@@ -473,7 +473,7 @@ class SortingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
             )
             check_sortings_equal(SX1=sorting_renamed, SX2=nwb_sorting)
 
-    def check_interface_align_segment_timestamps(self):
+    def check_interface_set_aligned_segment_timestamps(self):
         self.setUpFreshInterface()
 
         if self.interface.sorting_extractor.has_recording():
@@ -484,7 +484,7 @@ class SortingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
                 all_aligned_segment_timestamps = [
                     unaligned_timestamps + 1.23 + random_number_generator.random(size=unaligned_timestamps.shape)
                 ]
-                self.interface.align_segment_timestamps(aligned_segment_timestamps=all_aligned_segment_timestamps)
+                self.interface.set_aligned_segment_timestamps(aligned_segment_timestamps=all_aligned_segment_timestamps)
 
                 retrieved_aligned_timestamps = self.interface.get_timestamps()
                 assert_array_equal(x=retrieved_aligned_timestamps, y=all_aligned_segment_timestamps[0])
@@ -494,7 +494,7 @@ class SortingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
                     unaligned_timestamps + 1.23 + random_number_generator.random(size=unaligned_timestamps.shape)
                     for unaligned_timestamps in all_unaligned_timestamps
                 ]
-                self.interface.align_segment_timestamps(aligned_segment_timestamps=all_aligned_segment_timestamps)
+                self.interface.set_aligned_segment_timestamps(aligned_segment_timestamps=all_aligned_segment_timestamps)
 
                 all_retrieved_aligned_timestamps = self.interface.get_timestamps()
                 for retrieved_aligned_timestamps, aligned_segment_timestamps in zip(
@@ -544,7 +544,7 @@ class SortingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
                 # Skip get_original_timestamps() checks since unsupported
                 self.check_interface_get_timestamps()
                 self.check_interface_set_aligned_timestamps()
-                self.check_interface_align_segment_timestamps()
+                self.check_interface_set_aligned_segment_timestamps()
                 self.check_shift_timestamps_by_start_time()
                 self.check_shift_segment_timestamps_by_starting_times()
 

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -555,6 +555,9 @@ class AudioInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
     def check_read_nwb(self, nwbfile_path: str):
         pass  # asserted in the testing suite; could be refactored in future PR
 
+    def test_interface_alignment(self):
+        pass  # Currently asserted in the testing suite
+
 
 class DeepLabCutInterfaceMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
     def check_interface_get_original_timestamps(self):

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -176,11 +176,11 @@ class TemporalAlignmentMixin:
         self.setUpFreshInterface()
         unaligned_timestamps = self.interface.get_timestamps()
 
-        starting_time = 1.23
-        self.interface.align_starting_time(starting_time=starting_time)
+        aligned_starting_time = 1.23
+        self.interface.set_aligned_starting_time(aligned_starting_time=aligned_starting_time)
 
         aligned_timestamps = self.interface.get_timestamps()
-        expected_timestamps = unaligned_timestamps + starting_time
+        expected_timestamps = unaligned_timestamps + aligned_starting_time
         assert_array_equal(x=aligned_timestamps, y=expected_timestamps)
 
     def check_interface_original_timestamps_inmutability(self):
@@ -236,8 +236,8 @@ class ImagingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
 
         interface = self.data_interface_cls(**self.test_kwargs)
 
-        starting_time = 1.23
-        interface.align_starting_time(starting_time=starting_time)
+        aligned_starting_time = 1.23
+        interface.set_aligned_starting_time(aligned_starting_time=aligned_starting_time)
 
         metadata = interface.get_metadata()
         metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
@@ -246,7 +246,7 @@ class ImagingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
         with NWBHDF5IO(path=nwbfile_path) as io:
             nwbfile = io.read()
 
-            assert nwbfile.acquisition["TwoPhotonSeries"].starting_time == starting_time
+            assert nwbfile.acquisition["TwoPhotonSeries"].starting_time == aligned_starting_time
 
 
 class SegmentationExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
@@ -355,17 +355,17 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
         self.setUpFreshInterface()
         all_unaligned_timestamps = self.interface.get_timestamps()
 
-        starting_time = 1.23
-        self.interface.align_starting_time(starting_time=starting_time)
+        aligned_starting_time = 1.23
+        self.interface.set_aligned_starting_time(aligned_starting_time=aligned_starting_time)
 
         if self.interface._number_of_segments == 1:
             retrieved_aligned_timestamps = self.interface.get_timestamps()
-            expected_timestamps = all_unaligned_timestamps + starting_time
+            expected_timestamps = all_unaligned_timestamps + aligned_starting_time
             assert_array_equal(x=retrieved_aligned_timestamps, y=expected_timestamps)
         else:
             all_retrieved_aligned_timestamps = self.interface.get_timestamps()
             all_expected_timestamps = [
-                unaligned_timestamps + starting_time for unaligned_timestamps in all_unaligned_timestamps
+                unaligned_timestamps + aligned_starting_time for unaligned_timestamps in all_unaligned_timestamps
             ]
             for retrieved_aligned_timestamps, expected_timestamps in zip(
                 all_retrieved_aligned_timestamps, all_expected_timestamps
@@ -375,24 +375,28 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
     def check_shift_segment_timestamps_by_starting_times(self):
         self.setUpFreshInterface()
 
-        segment_starting_times = list(np.arange(float(self.interface._number_of_segments)) + 1.23)
+        aligned_segment_starting_times = list(np.arange(float(self.interface._number_of_segments)) + 1.23)
         if self.interface._number_of_segments == 1:
             unaligned_timestamps = self.interface.get_timestamps()
 
-            self.interface.align_segment_starting_times(segment_starting_times=segment_starting_times)
+            self.interface.set_aligned_segment_starting_times(
+                aligned_segment_starting_times=aligned_segment_starting_times
+            )
 
             retrieved_aligned_timestamps = self.interface.get_timestamps()
-            expected_aligned_timestamps = unaligned_timestamps + segment_starting_times[0]
+            expected_aligned_timestamps = unaligned_timestamps + aligned_segment_starting_times[0]
             assert_array_equal(x=retrieved_aligned_timestamps, y=expected_aligned_timestamps)
         else:
             all_unaligned_timestamps = self.interface.get_timestamps()
 
-            self.interface.align_segment_starting_times(segment_starting_times=segment_starting_times)
+            self.interface.set_aligned_segment_starting_times(
+                aligned_segment_starting_times=aligned_segment_starting_times
+            )
 
             all_retrieved_aligned_timestamps = self.interface.get_timestamps()
             all_expected_aligned_timestamps = [
                 timestamps + segment_starting_time
-                for timestamps, segment_starting_time in zip(all_unaligned_timestamps, segment_starting_times)
+                for timestamps, segment_starting_time in zip(all_unaligned_timestamps, aligned_segment_starting_times)
             ]
             for retrieved_aligned_timestamps, expected_aligned_timestamps in zip(
                 all_retrieved_aligned_timestamps, all_expected_aligned_timestamps
@@ -505,24 +509,30 @@ class SortingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
     def check_shift_segment_timestamps_by_starting_times(self):
         self.setUpFreshInterface()
 
-        segment_starting_times = list(np.arange(float(self.interface._number_of_segments)) + 1.23)
+        aligned_segment_starting_times = list(np.arange(float(self.interface._number_of_segments)) + 1.23)
         if self.interface._number_of_segments == 1:
             unaligned_timestamps = self.interface.get_timestamps()
 
-            self.interface.align_segment_starting_times(segment_starting_times=segment_starting_times)
+            self.interface.set_aligned_segment_starting_times(
+                aligned_segment_starting_times=aligned_segment_starting_times
+            )
 
             retrieved_aligned_timestamps = self.interface.get_timestamps()
-            expected_aligned_timestamps = unaligned_timestamps + segment_starting_times[0]
+            expected_aligned_timestamps = unaligned_timestamps + aligned_segment_starting_times[0]
             assert_array_equal(x=retrieved_aligned_timestamps, y=expected_aligned_timestamps)
         else:
             all_unaligned_timestamps = self.interface.get_timestamps()
 
-            self.interface.align_segment_starting_times(segment_starting_times=segment_starting_times)
+            self.interface.set_aligned_segment_starting_times(
+                aligned_segment_starting_times=aligned_segment_starting_times
+            )
 
             all_retrieved_aligned_timestamps = self.interface.get_timestamps()
             all_expected_aligned_timestamps = [
                 segment_timestamps + segment_starting_time
-                for segment_timestamps, segment_starting_time in zip(all_unaligned_timestamps, segment_starting_times)
+                for segment_timestamps, segment_starting_time in zip(
+                    all_unaligned_timestamps, aligned_segment_starting_times
+                )
             ]
             for retrieved_aligned_timestamps, expected_aligned_timestamps in zip(
                 all_retrieved_aligned_timestamps, all_expected_aligned_timestamps
@@ -602,29 +612,29 @@ class VideoInterfaceMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
     def check_shift_timestamps_by_start_time(self):
         self.setUpFreshInterface()
 
-        starting_time = 1.23
+        aligned_starting_time = 1.23
         self.interface.set_aligned_timestamps(aligned_timestamps=self.interface.get_original_timestamps())
-        self.interface.align_starting_time(starting_time=starting_time)
+        self.interface.set_aligned_starting_time(aligned_starting_time=aligned_starting_time)
         all_aligned_timestamps = self.interface.get_timestamps()
 
         unaligned_timestamps = self.interface.get_original_timestamps()
-        all_expected_timestamps = [timestamps + starting_time for timestamps in unaligned_timestamps]
+        all_expected_timestamps = [timestamps + aligned_starting_time for timestamps in unaligned_timestamps]
         [
             assert_array_equal(x=aligned_timestamps, y=expected_timestamps)
             for aligned_timestamps, expected_timestamps in zip(all_aligned_timestamps, all_expected_timestamps)
         ]
 
-    def check_align_segment_starting_times(self):
+    def check_set_aligned_segment_starting_times(self):
         self.setUpFreshInterface()
 
-        segment_starting_times = [1.23 * file_path_index for file_path_index in range(len(self.test_kwargs))]
-        self.interface.align_segment_starting_times(segment_starting_times=segment_starting_times)
+        aligned_segment_starting_times = [1.23 * file_path_index for file_path_index in range(len(self.test_kwargs))]
+        self.interface.set_aligned_segment_starting_times(aligned_segment_starting_times=aligned_segment_starting_times)
         all_aligned_timestamps = self.interface.get_timestamps()
 
         unaligned_timestamps = self.interface.get_original_timestamps()
         all_expected_timestamps = [
             timestamps + segment_starting_time
-            for timestamps, segment_starting_time in zip(unaligned_timestamps, segment_starting_times)
+            for timestamps, segment_starting_time in zip(unaligned_timestamps, aligned_segment_starting_times)
         ]
         for aligned_timestamps, expected_timestamps in zip(all_aligned_timestamps, all_expected_timestamps):
             assert_array_equal(x=aligned_timestamps, y=expected_timestamps)
@@ -663,6 +673,6 @@ class VideoInterfaceMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
                 self.check_interface_set_aligned_timestamps()
                 self.check_shift_timestamps_by_start_time()
                 self.check_interface_original_timestamps_inmutability()
-                self.check_align_segment_starting_times()
+                self.check_set_aligned_segment_starting_times()
 
                 self.check_nwbfile_temporal_alignment()

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -158,7 +158,7 @@ class TemporalAlignmentMixin:
 
         assert len(timestamps) != 0
 
-    def check_interface_align_timestamps(self):
+    def check_interface_set_aligned_timestamps(self):
         """Ensure that internal mechanisms for the timestamps getter/setter work as expected."""
         self.setUpFreshInterface()
         unaligned_timestamps = self.interface.get_timestamps()
@@ -167,7 +167,7 @@ class TemporalAlignmentMixin:
         aligned_timestamps = (
             unaligned_timestamps + 1.23 + random_number_generator.random(size=unaligned_timestamps.shape)
         )
-        self.interface.align_timestamps(aligned_timestamps=aligned_timestamps)
+        self.interface.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
 
         retrieved_aligned_timestamps = self.interface.get_timestamps()
         assert_array_equal(x=retrieved_aligned_timestamps, y=aligned_timestamps)
@@ -190,7 +190,7 @@ class TemporalAlignmentMixin:
         pre_alignment_original_timestamps = self.interface.get_original_timestamps()
 
         aligned_timestamps = pre_alignment_original_timestamps + 1.23
-        self.interface.align_timestamps(aligned_timestamps=aligned_timestamps)
+        self.interface.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
 
         post_alignment_original_timestamps = self.interface.get_original_timestamps()
         assert_array_equal(x=post_alignment_original_timestamps, y=pre_alignment_original_timestamps)
@@ -210,7 +210,7 @@ class TemporalAlignmentMixin:
 
                 self.check_interface_get_original_timestamps()
                 self.check_interface_get_timestamps()
-                self.check_interface_align_timestamps()
+                self.check_interface_set_aligned_timestamps()
                 self.check_shift_timestamps_by_start_time()
                 self.check_interface_original_timestamps_inmutability()
 
@@ -294,7 +294,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
                 if recording.has_scaled_traces() and nwb_recording.has_scaled_traces():
                     check_recordings_equal(RX1=recording, RX2=nwb_recording, return_scaled=True)
 
-    def check_interface_align_timestamps(self):
+    def check_interface_set_aligned_timestamps(self):
         self.setUpFreshInterface()
 
         random_number_generator = np.random.default_rng(seed=0)
@@ -304,7 +304,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
             aligned_timestamps = (
                 unaligned_timestamps + 1.23 + random_number_generator.random(size=unaligned_timestamps.shape)
             )
-            self.interface.align_timestamps(aligned_timestamps=aligned_timestamps)
+            self.interface.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
 
             retrieved_aligned_timestamps = self.interface.get_timestamps()
             assert_array_equal(x=retrieved_aligned_timestamps, y=aligned_timestamps)
@@ -322,7 +322,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
                     unaligned_timestamps + 1.23 + random_number_generator.random(size=unaligned_timestamps.shape)
                     for unaligned_timestamps in all_unaligned_timestamps
                 ]
-                self.interface.align_timestamps(aligned_timestamps=all_aligned_segment_timestamps)
+                self.interface.set_aligned_timestamps(aligned_timestamps=all_aligned_segment_timestamps)
 
     def check_interface_align_segment_timestamps(self):
         self.setUpFreshInterface()
@@ -408,7 +408,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
             pre_alignment_original_timestamps = self.interface.get_original_timestamps()
 
             aligned_timestamps = pre_alignment_original_timestamps + 1.23
-            self.interface.align_timestamps(aligned_timestamps=aligned_timestamps)
+            self.interface.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
 
             post_alignment_original_timestamps = self.interface.get_original_timestamps()
             assert_array_equal(x=post_alignment_original_timestamps, y=pre_alignment_original_timestamps)
@@ -425,7 +425,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
                 all_aligned_timestamps = [
                     unaligned_timestamps + 1.23 for unaligned_timestamps in all_pre_alignement_timestamps
                 ]
-                self.interface.align_timestamps(aligned_timestamps=all_aligned_timestamps)
+                self.interface.set_aligned_timestamps(aligned_timestamps=all_aligned_timestamps)
 
     def test_interface_alignment(self):
         interface_kwargs = self.interface_kwargs
@@ -438,7 +438,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
 
                 self.check_interface_get_original_timestamps()
                 self.check_interface_get_timestamps()
-                self.check_interface_align_timestamps()
+                self.check_interface_set_aligned_timestamps()
                 self.check_interface_align_segment_timestamps()
                 self.check_shift_timestamps_by_start_time()
                 self.check_shift_segment_timestamps_by_starting_times()
@@ -544,7 +544,7 @@ class SortingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
 
                 # Skip get_original_timestamps() checks since unsupported
                 self.check_interface_get_timestamps()
-                self.check_interface_align_timestamps()
+                self.check_interface_set_aligned_timestamps()
                 self.check_interface_align_segment_timestamps()
                 self.check_shift_timestamps_by_start_time()
                 self.check_shift_segment_timestamps_by_starting_times()

--- a/src/neuroconv/tools/testing/mock_interfaces.py
+++ b/src/neuroconv/tools/testing/mock_interfaces.py
@@ -41,7 +41,7 @@ class MockBehaviorEventInterface(BaseTemporalAlignmentInterface):
     def get_timestamps(self) -> np.ndarray:
         return self.event_times
 
-    def align_timestamps(self, aligned_timestamps: np.ndarray):
+    def set_aligned_timestamps(self, aligned_timestamps: np.ndarray):
         self.event_times = aligned_timestamps
 
     def run_conversion(self, nwbfile: NWBFile, metadata: dict):

--- a/tests/test_behavior/test_audio_interface.py
+++ b/tests/test_behavior/test_audio_interface.py
@@ -45,7 +45,7 @@ class TestAudioInterface(AudioInterfaceTestMixin, TestCase):
         cls.num_frames = 10000
         cls.num_audio_files = 3
         cls.sampling_rate = 500
-        cls.segment_starting_times = [0.0, 20.0, 40.0]
+        cls.aligned_segment_starting_times = [0.0, 20.0, 40.0]
 
         cls.test_dir = Path(mkdtemp())
         cls.file_paths = create_audio_files(
@@ -77,7 +77,9 @@ class TestAudioInterface(AudioInterfaceTestMixin, TestCase):
         source_data = dict(Audio=dict(file_paths=self.file_paths))
         self.nwb_converter = AudioTestNWBConverter(source_data)
         self.interface = self.nwb_converter.data_interface_objects["Audio"]
-        self.interface.align_segment_starting_times(segment_starting_times=self.segment_starting_times)
+        self.interface.set_aligned_segment_starting_times(
+            aligned_segment_starting_times=self.aligned_segment_starting_times
+        )
 
     def test_unsupported_format(self):
         exc_msg = "The currently supported file format for audio is WAV file. Some of the provided files does not match this format: ['.test']."
@@ -158,35 +160,37 @@ On instance['Audio']['write_as']:
 
     def test_segment_starting_times_are_floats(self):
         with self.assertRaisesWith(
-            exc_type=AssertionError, exc_msg="Argument 'segment_starting_times' must be a list of floats."
+            exc_type=AssertionError, exc_msg="Argument 'aligned_segment_starting_times' must be a list of floats."
         ):
-            self.interface.align_segment_starting_times(segment_starting_times=[0, 1, 2])
+            self.interface.set_aligned_segment_starting_times(aligned_segment_starting_times=[0, 1, 2])
 
     def test_segment_starting_times_length_mismatch(self):
         with self.assertRaisesWith(
             exc_type=AssertionError,
-            exc_msg="The number of entries in 'segment_starting_times' (4) must be equal to the number of audio file paths (3).",
+            exc_msg="The number of entries in 'aligned_segment_starting_times' (4) must be equal to the number of audio file paths (3).",
         ):
-            self.interface.align_segment_starting_times(segment_starting_times=[0.0, 1.0, 2.0, 4.0])
+            self.interface.set_aligned_segment_starting_times(aligned_segment_starting_times=[0.0, 1.0, 2.0, 4.0])
 
-    def test_align_segment_starting_times(self):
+    def test_set_aligned_segment_starting_times(self):
         fresh_interface = AudioInterface(file_paths=self.file_paths[:2])
 
-        segment_starting_times = [0.0, 1.0]
-        fresh_interface.align_segment_starting_times(segment_starting_times=segment_starting_times)
+        aligned_segment_starting_times = [0.0, 1.0]
+        fresh_interface.set_aligned_segment_starting_times(
+            aligned_segment_starting_times=aligned_segment_starting_times
+        )
 
-        assert_array_equal(x=self.interface._segment_starting_times, y=self.segment_starting_times)
+        assert_array_equal(x=self.interface._segment_starting_times, y=self.aligned_segment_starting_times)
 
-    def test_align_starting_time(self):
+    def test_set_aligned_starting_time(self):
         fresh_interface = AudioInterface(file_paths=self.file_paths[:2])
 
-        starting_time = 1.23
+        aligned_starting_time = 1.23
         relative_starting_times = [0.0, 1.0]
-        fresh_interface.align_segment_starting_times(segment_starting_times=relative_starting_times)
-        fresh_interface.align_starting_time(starting_time=starting_time)
+        fresh_interface.set_aligned_segment_starting_times(aligned_segment_starting_times=relative_starting_times)
+        fresh_interface.set_aligned_starting_time(aligned_starting_time=aligned_starting_time)
 
         expecting_starting_times = [
-            relative_starting_time + starting_time for relative_starting_time in relative_starting_times
+            relative_starting_time + aligned_starting_time for relative_starting_time in relative_starting_times
         ]
         assert_array_equal(x=fresh_interface._segment_starting_times, y=expecting_starting_times)
 
@@ -205,6 +209,8 @@ On instance['Audio']['write_as']:
             for audio_ind, audio_metadata in enumerate(metadata["Behavior"]["Audio"]):
                 audio_interface_name = audio_metadata["name"]
                 assert audio_interface_name in container
-                self.assertEqual(self.segment_starting_times[audio_ind], container[audio_interface_name].starting_time)
+                self.assertEqual(
+                    self.aligned_segment_starting_times[audio_ind], container[audio_interface_name].starting_time
+                )
                 self.assertEqual(self.sampling_rate, container[audio_interface_name].rate)
                 assert_array_equal(audio_test_data[audio_ind], container[audio_interface_name].data)

--- a/tests/test_behavior/test_video_interface.py
+++ b/tests/test_behavior/test_video_interface.py
@@ -29,7 +29,7 @@ class TestVideoInterface(TestCase):
         self.metadata = self.nwb_converter.get_metadata()
         self.metadata["NWBFile"].update(session_start_time=datetime.now(tz=gettz(name="US/Pacific")))
         self.nwbfile_path = self.test_dir / "video_test.nwb"
-        self.segment_starting_times = [0.0, 50.0]
+        self.aligned_segment_starting_times = [0.0, 50.0]
 
     def tearDown(self) -> None:
         shutil.rmtree(self.test_dir)
@@ -100,7 +100,7 @@ class TestExternalVideoInterface(TestVideoInterface):
         timestamps = [np.array([2.2, 2.4, 2.6]), np.array([3.2, 3.4, 3.6])]
         interface = self.nwb_converter.data_interface_objects["Video"]
         interface.set_aligned_timestamps(aligned_timestamps=timestamps)
-        interface.align_segment_starting_times(segment_starting_times=self.segment_starting_times)
+        interface.set_aligned_segment_starting_times(aligned_segment_starting_times=self.aligned_segment_starting_times)
 
         conversion_options = dict(Video=dict(external_mode=True, starting_frames=[0, 4]))
         self.nwb_converter.run_conversion(
@@ -116,10 +116,10 @@ class TestExternalVideoInterface(TestVideoInterface):
             self.assertListEqual(list1=list(module["Video: test1"].external_file[:]), list2=self.video_files)
 
     def test_video_irregular_timestamps(self):
-        timestamps = [np.array([1.0, 2.0, 4.0]), np.array([5.0, 6.0, 7.0])]
+        aligned_timestamps = [np.array([1.0, 2.0, 4.0]), np.array([5.0, 6.0, 7.0])]
         interface = self.nwb_converter.data_interface_objects["Video"]
-        interface.set_aligned_timestamps(aligned_timestamps=timestamps)
-        interface.align_segment_starting_times(segment_starting_times=self.segment_starting_times)
+        interface.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
+        interface.set_aligned_segment_starting_times(aligned_segment_starting_times=self.aligned_segment_starting_times)
 
         conversion_options = dict(Video=dict(external_mode=True, starting_frames=[0, 4]))
         self.nwb_converter.run_conversion(
@@ -221,10 +221,12 @@ class TestInternalVideoInterface(TestVideoInterface):
                 assert mod[video_interface_name].data.chunks is not None  # TODO retrieve storage_layout of hdf5 dataset
 
     def test_video_stub(self):
-        timestamps = [np.array([1, 2, 4, 5, 6, 7, 8, 9, 10, 11])]
+        aligned_timestamps = [np.array([1, 2, 4, 5, 6, 7, 8, 9, 10, 11])]
         interface = self.nwb_converter.data_interface_objects["Video"]
-        interface.set_aligned_timestamps(aligned_timestamps=timestamps)
-        interface.align_segment_starting_times(segment_starting_times=[self.segment_starting_times[0]])
+        interface.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
+        interface.set_aligned_segment_starting_times(
+            aligned_segment_starting_times=[self.aligned_segment_starting_times[0]]
+        )
 
         conversion_options = dict(Video=dict(external_mode=False, stub_test=True))
         self.nwb_converter.run_conversion(

--- a/tests/test_behavior/test_video_interface.py
+++ b/tests/test_behavior/test_video_interface.py
@@ -99,7 +99,7 @@ class TestExternalVideoInterface(TestVideoInterface):
     def test_video_external_mode(self):
         timestamps = [np.array([2.2, 2.4, 2.6]), np.array([3.2, 3.4, 3.6])]
         interface = self.nwb_converter.data_interface_objects["Video"]
-        interface.align_timestamps(aligned_timestamps=timestamps)
+        interface.set_aligned_timestamps(aligned_timestamps=timestamps)
         interface.align_segment_starting_times(segment_starting_times=self.segment_starting_times)
 
         conversion_options = dict(Video=dict(external_mode=True, starting_frames=[0, 4]))
@@ -118,7 +118,7 @@ class TestExternalVideoInterface(TestVideoInterface):
     def test_video_irregular_timestamps(self):
         timestamps = [np.array([1.0, 2.0, 4.0]), np.array([5.0, 6.0, 7.0])]
         interface = self.nwb_converter.data_interface_objects["Video"]
-        interface.align_timestamps(aligned_timestamps=timestamps)
+        interface.set_aligned_timestamps(aligned_timestamps=timestamps)
         interface.align_segment_starting_times(segment_starting_times=self.segment_starting_times)
 
         conversion_options = dict(Video=dict(external_mode=True, starting_frames=[0, 4]))
@@ -137,7 +137,7 @@ class TestExternalVideoInterface(TestVideoInterface):
     def test_starting_frames_type_error(self):
         timestamps = [np.array([2.2, 2.4, 2.6]), np.array([3.2, 3.4, 3.6])]
         interface = self.nwb_converter.data_interface_objects["Video"]
-        interface.align_timestamps(aligned_timestamps=timestamps)
+        interface.set_aligned_timestamps(aligned_timestamps=timestamps)
 
         conversion_opts = dict(Video=dict(external_mode=True))
         metadata = self.metadata
@@ -156,7 +156,7 @@ class TestExternalVideoInterface(TestVideoInterface):
     def test_starting_frames_value_error(self):
         timestamps = [np.array([2.2, 2.4, 2.6]), np.array([3.2, 3.4, 3.6])]
         interface = self.nwb_converter.data_interface_objects["Video"]
-        interface.align_timestamps(aligned_timestamps=timestamps)
+        interface.set_aligned_timestamps(aligned_timestamps=timestamps)
 
         conversion_opts = dict(Video=dict(external_mode=True, starting_frames=[0]))
         metadata = self.metadata
@@ -223,7 +223,7 @@ class TestInternalVideoInterface(TestVideoInterface):
     def test_video_stub(self):
         timestamps = [np.array([1, 2, 4, 5, 6, 7, 8, 9, 10, 11])]
         interface = self.nwb_converter.data_interface_objects["Video"]
-        interface.align_timestamps(aligned_timestamps=timestamps)
+        interface.set_aligned_timestamps(aligned_timestamps=timestamps)
         interface.align_segment_starting_times(segment_starting_times=[self.segment_starting_times[0]])
 
         conversion_options = dict(Video=dict(external_mode=False, stub_test=True))

--- a/tests/test_minimal/test_converter.py
+++ b/tests/test_minimal/test_converter.py
@@ -27,18 +27,18 @@ def test_converter():
         test_dir = Path(mkdtemp())
         nwbfile_path = str(test_dir / "extension_test.nwb")
 
-        class NdxEventsInterface(BaseDataInterface):
+        class NdxEventsInterface(BaseTemporalAlignmentInterface):
             def __init__(self):
-                self.timestamps = np.array([0.0, 0.5, 0.6, 2.0, 2.05, 3.0, 3.5, 3.6, 4.0])
+                self._timestamps = np.array([0.0, 0.5, 0.6, 2.0, 2.05, 3.0, 3.5, 3.6, 4.0])
                 self.original_timestamps = np.array(self.timestamps)
 
             def get_original_timestamps(self) -> np.ndarray:
                 return self.original_timestamps
 
             def get_timestamps(self) -> np.ndarray:
-                return self.timestamps
+                return self._timestamps
 
-            def align_timestamps(self, aligned_timestamps: np.ndarray):
+            def set_aligned_timestamps(self, aligned_timestamps: np.ndarray):
                 self.timestamps = aligned_timestamps
 
             def run_conversion(self, nwbfile: NWBFile, metadata: dict):
@@ -76,7 +76,7 @@ class TestNWBConverterAndPipeInitialization(unittest.TestCase):
             def get_timestamps(self):
                 pass
 
-            def align_timestamps(self):
+            def set_aligned_timestamps(self):
                 pass
 
             def run_conversion(self):

--- a/tests/test_minimal/test_converter.py
+++ b/tests/test_minimal/test_converter.py
@@ -30,16 +30,16 @@ def test_converter():
         class NdxEventsInterface(BaseTemporalAlignmentInterface):
             def __init__(self):
                 self._timestamps = np.array([0.0, 0.5, 0.6, 2.0, 2.05, 3.0, 3.5, 3.6, 4.0])
-                self.original_timestamps = np.array(self.timestamps)
+                self._original_timestamps = np.array(self._timestamps)
 
             def get_original_timestamps(self) -> np.ndarray:
-                return self.original_timestamps
+                return self._original_timestamps
 
             def get_timestamps(self) -> np.ndarray:
                 return self._timestamps
 
             def set_aligned_timestamps(self, aligned_timestamps: np.ndarray):
-                self.timestamps = aligned_timestamps
+                self._timestamps = aligned_timestamps
 
             def run_conversion(self, nwbfile: NWBFile, metadata: dict):
                 events = LabeledEvents(

--- a/tests/test_on_data/test_behavior_interfaces.py
+++ b/tests/test_on_data/test_behavior_interfaces.py
@@ -1,15 +1,13 @@
 import unittest
-from datetime import datetime
-from pathlib import Path
 
-import numpy as np
-from numpy.testing import assert_array_equal
 from pynwb import NWBHDF5IO
 
 from neuroconv.datainterfaces import DeepLabCutInterface, SLEAPInterface, VideoInterface
 from neuroconv.tools.testing.data_interface_mixins import (
+    DeepLabCutInterfaceMixin,
     DataInterfaceTestMixin,
     TemporalAlignmentMixin,
+    VideoInterfaceMixin,
 )
 
 try:
@@ -18,7 +16,19 @@ except ImportError:
     from setup_paths import BEHAVIOR_DATA_PATH, OUTPUT_PATH
 
 
-class TestDeepLabCutInterface(DataInterfaceTestMixin, TemporalAlignmentMixin, unittest.TestCase):
+class TestVideoInterface(VideoInterfaceMixin, unittest.TestCase):
+    data_interface_cls = VideoInterface
+    interface_kwargs = [
+        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_avi.avi")]),
+        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_flv.flv")]),
+        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_mov.mov")]),
+        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_mp4.mp4")]),
+        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_wmv.wmv")]),
+    ]
+    save_directory = OUTPUT_PATH
+
+
+class TestDeepLabCutInterface(DeepLabCutInterfaceMixin, unittest.TestCase):
     data_interface_cls = DeepLabCutInterface
     interface_kwargs = dict(
         file_path=str(BEHAVIOR_DATA_PATH / "DLC" / "m3v1mp4DLC_resnet50_openfieldAug20shuffle1_30000.h5"),
@@ -27,30 +37,7 @@ class TestDeepLabCutInterface(DataInterfaceTestMixin, TemporalAlignmentMixin, un
     )
     save_directory = OUTPUT_PATH
 
-    def run_conversion(self, nwbfile_path: str):
-        metadata = self.interface.get_metadata()
-        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
-        self.interface.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
-
-    def check_interface_get_original_timestamps(self):
-        pass  # TODO in separate PR
-
-    def check_interface_get_timestamps(self):
-        pass  # TODO in separate PR
-
-    def check_interface_align_timestamps(self):
-        pass  # TODO in separate PR
-
-    def check_shift_timestamps_by_start_time(self):
-        pass  # TODO in separate PR
-
-    def check_interface_original_timestamps_inmutability(self):
-        pass  # TODO in separate PR
-
-    def check_nwbfile_temporal_alignment(self):
-        pass  # TODO in separate PR
-
-    def check_read_nwb(self, nwbfile_path: str):
+    def check_read_nwb(self, nwbfile_path: str):  # This is currently structured to be file-specific
         with NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True) as io:
             nwbfile = io.read()
             assert "behavior" in nwbfile.processing
@@ -67,105 +54,6 @@ class TestDeepLabCutInterface(DataInterfaceTestMixin, TemporalAlignmentMixin, un
             assert all(expected_pose_estimation_series_are_in_nwb_file)
 
 
-class TestVideoInterface(DataInterfaceTestMixin, TemporalAlignmentMixin, unittest.TestCase):
-    data_interface_cls = VideoInterface
-    interface_kwargs = [
-        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_avi.avi")]),
-        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_flv.flv")]),
-        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_mov.mov")]),
-        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_mp4.mp4")]),
-        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_wmv.wmv")]),
-    ]
-    save_directory = OUTPUT_PATH
-
-    def check_read_nwb(self, nwbfile_path: str):
-        with NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True) as io:
-            nwbfile = io.read()
-            video_type = Path(self.test_kwargs["file_paths"][0]).suffix[1:]
-            assert f"Video: video_{video_type}" in nwbfile.acquisition
-
-    def check_interface_align_timestamps(self):
-        all_unaligned_timestamps = self.interface.get_original_timestamps()
-
-        random_number_generator = np.random.default_rng(seed=0)
-        aligned_timestamps = [
-            unaligned_timestamps + 1.23 + random_number_generator.random(size=unaligned_timestamps.shape)
-            for unaligned_timestamps in all_unaligned_timestamps
-        ]
-        self.interface.align_timestamps(aligned_timestamps=aligned_timestamps)
-
-        retrieved_aligned_timestamps = self.interface.get_timestamps()
-        assert_array_equal(x=retrieved_aligned_timestamps, y=aligned_timestamps)
-
-    def check_shift_timestamps_by_start_time(self):
-        self.setUpFreshInterface()
-
-        starting_time = 1.23
-        self.interface.align_timestamps(aligned_timestamps=self.interface.get_original_timestamps())
-        self.interface.align_starting_time(starting_time=starting_time)
-        all_aligned_timestamps = self.interface.get_timestamps()
-
-        unaligned_timestamps = self.interface.get_original_timestamps()
-        all_expected_timestamps = [timestamps + starting_time for timestamps in unaligned_timestamps]
-        [
-            assert_array_equal(x=aligned_timestamps, y=expected_timestamps)
-            for aligned_timestamps, expected_timestamps in zip(all_aligned_timestamps, all_expected_timestamps)
-        ]
-
-    def check_align_segment_starting_times(self):
-        self.setUpFreshInterface()
-
-        segment_starting_times = [1.23 * file_path_index for file_path_index in range(len(self.test_kwargs))]
-        self.interface.align_segment_starting_times(segment_starting_times=segment_starting_times)
-        all_aligned_timestamps = self.interface.get_timestamps()
-
-        unaligned_timestamps = self.interface.get_original_timestamps()
-        all_expected_timestamps = [
-            timestamps + segment_starting_time
-            for timestamps, segment_starting_time in zip(unaligned_timestamps, segment_starting_times)
-        ]
-        for aligned_timestamps, expected_timestamps in zip(all_aligned_timestamps, all_expected_timestamps):
-            assert_array_equal(x=aligned_timestamps, y=expected_timestamps)
-
-    def check_interface_original_timestamps_inmutability(self):
-        self.setUpFreshInterface()
-
-        all_pre_alignment_original_timestamps = self.interface.get_original_timestamps()
-
-        all_aligned_timestamps = [
-            pre_alignment_original_timestamps + 1.23
-            for pre_alignment_original_timestamps in all_pre_alignment_original_timestamps
-        ]
-        self.interface.align_timestamps(aligned_timestamps=all_aligned_timestamps)
-
-        all_post_alignment_original_timestamps = self.interface.get_original_timestamps()
-        for post_alignment_original_timestamps, pre_alignment_original_timestamps in zip(
-            all_post_alignment_original_timestamps, all_pre_alignment_original_timestamps
-        ):
-            assert_array_equal(x=post_alignment_original_timestamps, y=pre_alignment_original_timestamps)
-
-    def check_nwbfile_temporal_alignment(self):
-        pass  # TODO in separate PR
-
-    def test_interface_alignment(self):
-        interface_kwargs = self.interface_kwargs
-        if isinstance(interface_kwargs, dict):
-            interface_kwargs = [interface_kwargs]
-        for num, kwargs in enumerate(interface_kwargs):
-            with self.subTest(str(num)):
-                self.case = num
-                self.test_kwargs = kwargs
-
-                self.check_interface_get_original_timestamps()
-                self.check_interface_get_timestamps()
-                self.check_interface_align_timestamps()
-                self.check_shift_timestamps_by_start_time()
-                self.check_interface_original_timestamps_inmutability()
-                self.check_align_segment_starting_times()
-
-                self.check_nwbfile_temporal_alignment()
-
-
 class TestSLEAPInterface(DataInterfaceTestMixin, TemporalAlignmentMixin, unittest.TestCase):
     data_interface_cls = SLEAPInterface
     interface_kwargs = dict(
@@ -174,12 +62,7 @@ class TestSLEAPInterface(DataInterfaceTestMixin, TemporalAlignmentMixin, unittes
     )
     save_directory = OUTPUT_PATH
 
-    def run_conversion(self, nwbfile_path: str):
-        metadata = self.interface.get_metadata()
-        metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
-        self.interface.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
-
-    def check_read_nwb(self, nwbfile_path: str):
+    def check_read_nwb(self, nwbfile_path: str):  # This is currently structured to be file-specific
         with NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True) as io:
             nwbfile = io.read()
             assert "SLEAP_VIDEO_000_20190128_113421" in nwbfile.processing

--- a/tests/test_on_data/test_gin_behavior.py
+++ b/tests/test_on_data/test_gin_behavior.py
@@ -142,7 +142,7 @@ class TestVideoConversions(TestCase):
         cls.video_files = list((BEHAVIOR_DATA_PATH / "videos" / "CFR").iterdir())
         cls.video_files.sort()
         cls.number_of_video_files = len(cls.video_files)
-        cls.segment_starting_times = [0.0, 50.0, 100.0, 150.0, 175.0]
+        cls.aligned_segment_starting_times = [0.0, 50.0, 100.0, 150.0, 175.0]
 
     def _get_metadata(self):
         """TODO: temporary helper function to fetch new metadata each time; need to debug in follow-up."""
@@ -153,7 +153,7 @@ class TestVideoConversions(TestCase):
     def test_real_videos(self):
         # TODO - merge this with the data mixin in follow-up
         for file_index, (file_path, segment_starting_time) in enumerate(
-            zip(self.video_files, self.segment_starting_times)
+            zip(self.video_files, self.aligned_segment_starting_times)
         ):
             self.file_index = file_index
 
@@ -163,15 +163,15 @@ class TestVideoConversions(TestCase):
             source_data = dict(Video=dict(file_paths=[file_path]))
             self.converter = VideoTestNWBConverter(source_data)
             self.interface = self.converter.data_interface_objects["Video"]
-            self.interface.align_segment_starting_times(
-                segment_starting_times=[self.segment_starting_times[self.file_index]]
+            self.interface.set_aligned_segment_starting_times(
+                aligned_segment_starting_times=[self.aligned_segment_starting_times[self.file_index]]
             )
 
-            self.check_video_starting_times()
+            self.check_video_set_aligned_starting_times()
             self.check_video_custom_module()
             self.check_video_chunking()
 
-    def check_video_starting_times(self):
+    def check_video_set_aligned_starting_times(self):
         self._get_metadata()
         conversion_options = dict(Video=dict(external_mode=False))
         nwbfile_path = OUTPUT_PATH / "check_video_starting_times.nwb"
@@ -187,9 +187,9 @@ class TestVideoConversions(TestCase):
             self.image_series = nwbfile.acquisition[self.image_series_name]
 
             if self.image_series.starting_time is not None:
-                assert self.segment_starting_times[self.file_index] == self.image_series.starting_time
+                assert self.aligned_segment_starting_times[self.file_index] == self.image_series.starting_time
             else:
-                assert self.segment_starting_times[self.file_index] == self.image_series.timestamps[0]
+                assert self.aligned_segment_starting_times[self.file_index] == self.image_series.timestamps[0]
 
     def check_video_custom_module(self):
         self._get_metadata()

--- a/tests/test_on_data/test_gin_icephys.py
+++ b/tests/test_on_data/test_gin_icephys.py
@@ -62,26 +62,26 @@ class TestIcephysNwbConversions(unittest.TestCase):
         )
     ]
 
-    def check_align_global_starting_time(self):
+    def check_align_starting_time(self):  # TODO - use the mixin class in the future
         fresh_interface = self.data_interface_cls(file_paths=self.file_paths)
 
         global_starting_time = 1.23
-        relative_starting_times = [[0.1]]
-        fresh_interface.align_starting_times(starting_times=relative_starting_times)
+        relative_segment_starting_times = [[0.1]]
+        fresh_interface.align_segment_starting_times(segment_starting_times=relative_segment_starting_times)
         fresh_interface.align_global_starting_time(global_starting_time=global_starting_time)
 
         neo_reader_starting_times = [reader._t_starts for reader in fresh_interface.readers_list]
         expecting_starting_times = [[1.33]]
         self.assertListEqual(list1=neo_reader_starting_times, list2=expecting_starting_times)
 
-    def check_align_starting_times(self):
+    def check_align_segment_starting_times(self):
         fresh_interface = self.data_interface_cls(file_paths=self.file_paths)
 
-        starting_times = [[1.2]]
-        fresh_interface.align_starting_times(starting_times=starting_times)
+        segment_starting_times = [[1.2]]
+        fresh_interface.align_segment_starting_times(segment_starting_times=segment_starting_times)
 
         neo_reader_starting_times = [reader._t_starts for reader in fresh_interface.readers_list]
-        self.assertListEqual(list1=neo_reader_starting_times, list2=starting_times)
+        self.assertListEqual(list1=neo_reader_starting_times, list2=segment_starting_times)
 
     @parameterized.expand(input=parameterized_recording_list, name_func=custom_name_func)
     def test_convert_abf_to_nwb(self, data_interface, interface_kwargs):

--- a/tests/test_on_data/test_gin_icephys.py
+++ b/tests/test_on_data/test_gin_icephys.py
@@ -65,10 +65,10 @@ class TestIcephysNwbConversions(unittest.TestCase):
     def check_align_starting_time(self):  # TODO - use the mixin class in the future
         fresh_interface = self.data_interface_cls(file_paths=self.file_paths)
 
-        global_starting_time = 1.23
+        starting_time = 1.23
         relative_segment_starting_times = [[0.1]]
         fresh_interface.align_segment_starting_times(segment_starting_times=relative_segment_starting_times)
-        fresh_interface.align_global_starting_time(global_starting_time=global_starting_time)
+        fresh_interface.align_starting_time(starting_time=starting_time)
 
         neo_reader_starting_times = [reader._t_starts for reader in fresh_interface.readers_list]
         expecting_starting_times = [[1.33]]
@@ -116,8 +116,8 @@ class TestIcephysNwbConversions(unittest.TestCase):
             # Test number of traces = n_electrodes * n_segments
             npt.assert_equal(len(nwbfile.acquisition), n_electrodes * n_segments)
 
-            self.check_align_global_starting_time()
-            self.check_align_starting_times()
+            self.check_align_starting_time()
+            self.check_align_segment_starting_times()
 
 
 if __name__ == "__main__":

--- a/tests/test_on_data/test_gin_icephys.py
+++ b/tests/test_on_data/test_gin_icephys.py
@@ -62,26 +62,30 @@ class TestIcephysNwbConversions(unittest.TestCase):
         )
     ]
 
-    def check_align_starting_time(self):  # TODO - use the mixin class in the future
+    def check_set_aligned_starting_time(self):  # TODO - use the mixin class in the future
         fresh_interface = self.data_interface_cls(file_paths=self.file_paths)
 
-        starting_time = 1.23
+        aligned_starting_time = 1.23
         relative_segment_starting_times = [[0.1]]
-        fresh_interface.align_segment_starting_times(segment_starting_times=relative_segment_starting_times)
-        fresh_interface.align_starting_time(starting_time=starting_time)
+        fresh_interface.set_aligned_segment_starting_times(
+            aligned_segment_starting_times=relative_segment_starting_times
+        )
+        fresh_interface.set_aligned_starting_time(aligned_starting_time=aligned_starting_time)
 
         neo_reader_starting_times = [reader._t_starts for reader in fresh_interface.readers_list]
         expecting_starting_times = [[1.33]]
         self.assertListEqual(list1=neo_reader_starting_times, list2=expecting_starting_times)
 
-    def check_align_segment_starting_times(self):
+    def check_set_aligned_segment_starting_times(self):
         fresh_interface = self.data_interface_cls(file_paths=self.file_paths)
 
-        segment_starting_times = [[1.2]]
-        fresh_interface.align_segment_starting_times(segment_starting_times=segment_starting_times)
+        aligned_segment_starting_times = [[1.2]]
+        fresh_interface.set_aligned_segment_starting_times(
+            aligned_segment_starting_times=aligned_segment_starting_times
+        )
 
         neo_reader_starting_times = [reader._t_starts for reader in fresh_interface.readers_list]
-        self.assertListEqual(list1=neo_reader_starting_times, list2=segment_starting_times)
+        self.assertListEqual(list1=neo_reader_starting_times, list2=aligned_segment_starting_times)
 
     @parameterized.expand(input=parameterized_recording_list, name_func=custom_name_func)
     def test_convert_abf_to_nwb(self, data_interface, interface_kwargs):
@@ -116,8 +120,8 @@ class TestIcephysNwbConversions(unittest.TestCase):
             # Test number of traces = n_electrodes * n_segments
             npt.assert_equal(len(nwbfile.acquisition), n_electrodes * n_segments)
 
-            self.check_align_starting_time()
-            self.check_align_segment_starting_times()
+            self.check_set_aligned_starting_time()
+            self.check_set_aligned_segment_starting_times()
 
 
 if __name__ == "__main__":

--- a/tests/test_on_data/test_temporal_alignment/test_temporal_alignment_methods.py
+++ b/tests/test_on_data/test_temporal_alignment/test_temporal_alignment_methods.py
@@ -438,8 +438,8 @@ class TestNIDQInterfaceOnSignalAlignment(TestNIDQInterfacePulseTimesAlignment):
             channel_name="nidq#XA0"  # The channel receiving pulses from the DLC system
         )[0]
 
-        self.trial_interface.align_starting_time(starting_time=inferred_aligned_trial_start_time)
-        self.behavior_interface.align_starting_time(starting_time=inferred_aligned_trial_start_time)
+        self.trial_interface.set_aligned_starting_time(aligned_starting_time=inferred_aligned_trial_start_time)
+        self.behavior_interface.set_aligned_starting_time(aligned_starting_time=inferred_aligned_trial_start_time)
 
         assert_array_equal(x=self.trial_interface.get_timestamps(column="start_time"), y=self.aligned_trial_start_times)
         assert_array_equal(
@@ -488,9 +488,11 @@ class TestNIDQInterfaceOnSignalAlignment(TestNIDQInterfacePulseTimesAlignment):
             channel_name="nidq#XA0"  # The channel receiving pulses from the DLC system
         )[0]
 
-        converter.data_interface_objects["Trials"].align_starting_time(starting_time=inferred_aligned_trial_start_time)
-        converter.data_interface_objects["Behavior"].align_starting_time(
-            starting_time=inferred_aligned_trial_start_time
+        converter.data_interface_objects["Trials"].set_aligned_starting_time(
+            aligned_starting_time=inferred_aligned_trial_start_time
+        )
+        converter.data_interface_objects["Behavior"].set_aligned_starting_time(
+            aligned_starting_time=inferred_aligned_trial_start_time
         )
 
         nwbfile_path = self.tmpdir / "test_nidq_on_signal_alignment_nwbconverter_direct_modification.nwb"
@@ -511,11 +513,11 @@ class TestNIDQInterfaceOnSignalAlignment(TestNIDQInterfacePulseTimesAlignment):
                     channel_name="nidq#XA0"  # The channel receiving pulses from the DLC system
                 )[0]
 
-                self.data_interface_objects["Trials"].align_starting_time(
-                    starting_time=inferred_aligned_trial_start_time
+                self.data_interface_objects["Trials"].set_aligned_starting_time(
+                    aligned_starting_time=inferred_aligned_trial_start_time
                 )
-                self.data_interface_objects["Behavior"].align_starting_time(
-                    starting_time=inferred_aligned_trial_start_time
+                self.data_interface_objects["Behavior"].set_aligned_starting_time(
+                    aligned_starting_time=inferred_aligned_trial_start_time
                 )
 
         source_data = dict(

--- a/tests/test_on_data/test_temporal_alignment/test_temporal_alignment_methods.py
+++ b/tests/test_on_data/test_temporal_alignment/test_temporal_alignment_methods.py
@@ -98,7 +98,7 @@ class TestNIDQInterfacePulseTimesAlignment(TestCase):
             channel_name="nidq#XA0"  # The channel receiving pulses from the DLC system
         )
 
-        self.trial_interface.align_timestamps(
+        self.trial_interface.set_aligned_timestamps(
             aligned_timestamps=inferred_aligned_trial_start_timestamps,
             column="start_time",
             interpolate_other_columns=True,
@@ -162,12 +162,12 @@ class TestNIDQInterfacePulseTimesAlignment(TestCase):
             channel_name="nidq#XA0"  # The channel receiving pulses from the DLC system
         )
 
-        converter.data_interface_objects["Trials"].align_timestamps(
+        converter.data_interface_objects["Trials"].set_aligned_timestamps(
             aligned_timestamps=inferred_aligned_trial_start_timestamps, column="start_time"
         )
 
         # True stop times are not tracked, so estimate them from using the known regular trial length
-        converter.data_interface_objects["Trials"].align_timestamps(
+        converter.data_interface_objects["Trials"].set_aligned_timestamps(
             aligned_timestamps=inferred_aligned_trial_start_timestamps + self.regular_trial_length, column="stop_time"
         )
 
@@ -197,12 +197,12 @@ class TestNIDQInterfacePulseTimesAlignment(TestCase):
                     channel_name="nidq#XA0"  # The channel receiving pulses from the DLC system
                 )
 
-                self.data_interface_objects["Trials"].align_timestamps(
+                self.data_interface_objects["Trials"].set_aligned_timestamps(
                     aligned_timestamps=inferred_aligned_trial_start_timestamps, column="start_time"
                 )
 
                 # True stop times are not tracked, so estimate them from using the known regular trial length
-                self.data_interface_objects["Trials"].align_timestamps(
+                self.data_interface_objects["Trials"].set_aligned_timestamps(
                     # for this usage, the regular trial length would be hard-coded
                     aligned_timestamps=inferred_aligned_trial_start_timestamps + 1.0,
                     column="stop_time",
@@ -268,10 +268,12 @@ class TestExternalPulseTimesAlignment(TestNIDQInterfacePulseTimesAlignment):
         unaligned_trial_start_timestamps = self.trial_interface.get_original_timestamps(column="start_time")
         externally_aligned_timestamps = self.aligned_trial_start_times
 
-        self.trial_interface.align_timestamps(aligned_timestamps=externally_aligned_timestamps, column="start_time")
+        self.trial_interface.set_aligned_timestamps(
+            aligned_timestamps=externally_aligned_timestamps, column="start_time"
+        )
 
         # True stop times are not tracked, so estimate them from using the known regular trial length
-        self.trial_interface.align_timestamps(
+        self.trial_interface.set_aligned_timestamps(
             aligned_timestamps=externally_aligned_timestamps + self.regular_trial_length, column="stop_time"
         )
 
@@ -329,12 +331,12 @@ class TestExternalPulseTimesAlignment(TestNIDQInterfacePulseTimesAlignment):
         )
         externally_aligned_timestamps = self.aligned_trial_start_times
 
-        converter.data_interface_objects["Trials"].align_timestamps(
+        converter.data_interface_objects["Trials"].set_aligned_timestamps(
             aligned_timestamps=externally_aligned_timestamps, column="start_time"
         )
 
         # True stop times are not tracked, so estimate them from using the known regular trial length
-        converter.data_interface_objects["Trials"].align_timestamps(
+        converter.data_interface_objects["Trials"].set_aligned_timestamps(
             aligned_timestamps=externally_aligned_timestamps + self.regular_trial_length, column="stop_time"
         )
 
@@ -364,12 +366,12 @@ class TestExternalPulseTimesAlignment(TestNIDQInterfacePulseTimesAlignment):
                 )
                 externally_aligned_timestamps = mimic_reading_externally_aligned_timestamps()
 
-                self.data_interface_objects["Trials"].align_timestamps(
+                self.data_interface_objects["Trials"].set_aligned_timestamps(
                     aligned_timestamps=externally_aligned_timestamps, column="start_time"
                 )
 
                 # True stop times are not tracked, so estimate them from using the known regular trial length
-                self.data_interface_objects["Trials"].align_timestamps(
+                self.data_interface_objects["Trials"].set_aligned_timestamps(
                     # for this usage, the regular trial length would be hard-coded
                     aligned_timestamps=externally_aligned_timestamps + 1.0,
                     column="stop_time",


### PR DESCRIPTION
fix #301 

Various cleanups around the repo to bring things up to the current standard for temporal alignment related methods and tests

Also adjusting the final naming conventions for the few methods that are simple setters as opposed to those that perform actual operations

On that note, I did notice that `align_starting_time` and `align_segment_starting_times` do actually perform operations on the underlying objects in the majority of cases so they aren't strictly setters; special cases include icephys, sorters without recordings attached, and sometimes video; but since it always has the possibility of being an operation as opposed to a strict setter 

As such it is only the `timestamps` notion that has setters and getters as methods referencing some type of underlying property