### PR TITLE
remove default placeholder for subject description

### DIFF
--- a/src/neuroconv/schemas/base_metadata_schema.json
+++ b/src/neuroconv/schemas/base_metadata_schema.json
@@ -142,7 +142,6 @@
             "U",
             "O"
           ],
-          "default": ""
         },
         "species": {
           "type": "string",

--- a/src/neuroconv/schemas/base_metadata_schema.json
+++ b/src/neuroconv/schemas/base_metadata_schema.json
@@ -142,7 +142,7 @@
             "U",
             "O"
           ],
-          "default": "U"
+          "default": ""
         },
         "species": {
           "type": "string",

--- a/src/neuroconv/schemas/base_metadata_schema.json
+++ b/src/neuroconv/schemas/base_metadata_schema.json
@@ -141,7 +141,7 @@
             "F",
             "U",
             "O"
-          ],
+          ]
         },
         "species": {
           "type": "string",

--- a/src/neuroconv/schemas/base_metadata_schema.json
+++ b/src/neuroconv/schemas/base_metadata_schema.json
@@ -128,7 +128,6 @@
         },
         "description": {
           "type": "string",
-          "default": "no description",
           "description": "Description of subject and where subject came from (e.g., breeder, if animal)."
         },
         "genotype": {


### PR DESCRIPTION
partial fix for https://github.com/NeurodataWithoutBorders/nwb-guide/issues/229

The GUIDE inherits that aspect all the way from the NeuroConv base schema