### PR TITLE
Add docstrings for filtering out non-neural channel functions in Neuroscope Interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 * Add `Spike2RecordingInterface` to conversion gallery. [PR #338](https://github.com/catalystneuro/neuroconv/pull/338)
 * Remove authors from module docstrings [PR #354](https://github.com/catalystneuro/neuroconv/pull/354)
 * Add examples for `LocalPathExpander` usage [PR #456](https://github.com/catalystneuro/neuroconv/pull/456)
+* Add better docstrings to the aux functions of the Neuroscope interface [PR #485](https://github.com/catalystneuro/neuroconv/pull/485)
 
 ### Pending deprecation
 * Change name from `CedRecordingInterface` to `Spike2RecordingInterface`. [PR #338](https://github.com/catalystneuro/neuroconv/pull/338)

--- a/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscope_utils.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscope_utils.py
@@ -41,16 +41,39 @@ def safe_nested_find(root, keys: list):
         return root
 
 
-def get_shank_channels(xml_file_path: str) -> list:
+def get_neural_channels(xml_file_path: str) -> list:
     """
-    Retrieve the list of structured shank-only channels.
+    Extracts the channels corresponding to neural data from an XML file.
 
-    These are channels involved into spike detection.
-    These are a subset of channels obtained in`get_channel_goups`.
+    Parameters
+    ----------
+    xml_file_path : str
+        Path to the XML file containing the necessary data.
 
     Returns
     -------
+    list
         List reflecting the group structure of the channels.
+
+    Notes
+    -----
+    This function attempts to extract the channels that correspond to neural data,
+    specifically those that come from the probe. It uses the `spikeDetection` structure
+    in the XML file to identify the channels involved in spike detection. Channels that are
+    not involved in spike detection, such as auxiliary channels from the intan system, are excluded.
+
+    The function returns a list representing the group structure of the channels.
+
+    Example:
+    [[1, 2, 3], [4, 5, 6], [7, 8, 9]
+
+    Where [1, 2, 3] are the channels in the first group, [4, 5, 6] are the channels in the second group, etc.
+
+    Warning:
+    This function assumes that all the channels that correspond to neural data are involved in spike detection.
+    More concretely, it assumes that the channels appear on the `spikeDetection` field of the XML file.
+    If this is not the case, the function will return an incorrect list of neural channels channels.
+    Please report this as an issue if this is the case.
     """
     root = get_xml(xml_file_path)
     channel_groups = safe_find(safe_nested_find(root, ["spikeDetection", "channelGroups"]), "group", findall=True)

--- a/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -5,8 +5,8 @@ import numpy as np
 
 from .neuroscope_utils import (
     get_channel_groups,
+    get_neural_channels,
     get_session_start_time,
-    get_shank_channels,
     get_xml_file_path,
 )
 from ..baselfpextractorinterface import BaseLFPExtractorInterface
@@ -16,18 +16,54 @@ from ....tools import get_package
 from ....utils import FilePathType, FolderPathType
 
 
-def subset_shank_channels(recording_extractor, xml_file_path: str):
-    """Attempt to create a SubRecordingExtractor containing only channels related to neural data."""
-    shank_channels = get_shank_channels(xml_file_path=xml_file_path)
+def filter_non_neural_channels(recording_extractor, xml_file_path: str):
+    """
+    Subsets the recording extractor to only use channels corresponding to neural data.
 
-    if shank_channels is not None:
-        channel_ids = [channel_id for group in shank_channels for channel_id in group]
-        new_ids = recording_extractor.get_channel_ids()[channel_ids]
-        sub_recording = recording_extractor.channel_slice(new_ids)
+    Parameters
+    ----------
+    recording_extractor : BaseExtractor from spikeinterface
+        The original recording extractor object.
+    xml_file_path : str
+        Path to the XML file containing the Neuroscope metadata.
+
+    Returns
+    -------
+    BaseExtractor from spikeinterface
+        The subset recording extractor object.
+
+    Notes
+    -----
+    This function subsets the given recording extractor to include only channels that
+    correspond to neural data, filtering out auxiliary channels.
+
+    To identify the neural channels, it relies on the `get_neural_channels` function
+    in the `neuroscope_utils.py` module. Please refer to that function for more details and warnings.
+
+    If no neural channels are found o during the process, the original
+    recording extractor is returned unchanged. If all the channels in the original recording extractor are
+    neural channels, then the original recording extractor is returned unchanged as well.
+    """
+
+    neural_channels_as_groups = get_neural_channels(xml_file_path=xml_file_path)
+
+    if neural_channels_as_groups is None:
+        return recording_extractor
     else:
-        sub_recording = recording_extractor
+        # Flat neural channels as groups which is a list of lists and converter to str which is the representation
+        # In spikeinterface of the channel ids
+        neural_channel_ids = [str(channel_id) for group in neural_channels_as_groups for channel_id in group]
+        channel_ids_in_recorder = recording_extractor.get_channel_ids()
 
-    return sub_recording
+        # Get only the channel_ids_in_recorder that are in the neural_channel_ids
+        neural_channel_ids = [channel_id for channel_id in channel_ids_in_recorder if channel_id in neural_channel_ids]
+
+        # If all the channel_ids_in_recorder are in the neural_channel_ids, return the original recording_extractor
+        if len(neural_channel_ids) == len(channel_ids_in_recorder):
+            return recording_extractor
+
+        sub_recording = recording_extractor.channel_slice(channel_ids=neural_channel_ids)
+        return sub_recording
 
 
 def add_recording_extractor_properties(recording_extractor, gain: Optional[float] = None):
@@ -112,7 +148,7 @@ class NeuroScopeRecordingInterface(BaseRecordingExtractorInterface):
 
         add_recording_extractor_properties(recording_extractor=self.recording_extractor, gain=gain)
 
-        self.recording_extractor = subset_shank_channels(
+        self.recording_extractor = filter_non_neural_channels(
             recording_extractor=self.recording_extractor, xml_file_path=xml_file_path
         )
 
@@ -176,7 +212,7 @@ class NeuroScopeLFPInterface(BaseLFPExtractorInterface):
 
         add_recording_extractor_properties(recording_extractor=self.recording_extractor, gain=gain)
 
-        self.recording_extractor = subset_shank_channels(
+        self.recording_extractor = filter_non_neural_channels(
             recording_extractor=self.recording_extractor, xml_file_path=xml_file_path
         )
 


### PR DESCRIPTION
I was discussing with @CodyCBakerPhD today about the logic of these functions as I wanted to have more explicit docstrings to indicate what they do. I have been working on a conversion that uses Neuroscope and thinking on how to best add metadata. I think this is useful to me and future developers that will need to read these functions to understand what they do.