### PR TITLE
pin upper bound on EDF lib numpy

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/edf/requirements.txt
+++ b/src/neuroconv/datainterfaces/ecephys/edf/requirements.txt
@@ -1,1 +1,2 @@
 pyedflib>=0.1.30
+numpy<1.25.0;python_version>="3.11"


### PR DESCRIPTION
CI has been failing on Python 3.11 over the weekend, seeing if this fixes it

Specifically it's an import problem through numpy caused by EDF lib