### PR TITLE
Remove oudated warning from CellExplorerSortingInterface

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -22,15 +22,6 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
             Path to .spikes.cellinfo.mat file.
         verbose: bool, default: True
         """
-        # TODO: Remove spikeextractors backend
-        warn(
-            message=(
-                "Interfaces using a spikeextractors backend will soon be deprecated! "
-                "Please use the SpikeInterface backend instead."
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
 
         hdf5storage = get_package(package_name="hdf5storage")
 


### PR DESCRIPTION
As stated in the title. Probably left there after we droped spike extractor.