### PR TITLE
Add `CellExplorerRecordingInterface` for adding electrode metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
   Added `photon_series_type` to `get_nwb_imaging_metadata()` to fill metadata for `OnePhotonSeries` or `TwoPhotonSeries`. [PR #462](https://github.com/catalystneuro/neuroconv/pull/462)
 * Split `align_timestamps` and `align_starting_times` into `align_segment_timestamps` and `align_segment_starting_times` for API consistency for multi-segment `RecordingInterface`s. [PR #463](https://github.com/catalystneuro/neuroconv/pull/463)
 * Rename `align_timestamps` and `align_segmentt_timestamps` into `set_aligned_timestamps` and `set_aligned_segment_timestamps` to more clearly indicate their usage and behavior. [PR #470](https://github.com/catalystneuro/neuroconv/pull/470)
+* Added `CellExplorerRecordingInterface` for adding electrode metadata in the CellExplorer format. [TBD](TBD)
 
 ### Testing
 * The tests for `automatic_dandi_upload` now follow up-to-date DANDI validation rules for file name conventions. [PR #310](https://github.com/catalystneuro/neuroconv/pull/310)

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -3,10 +3,109 @@ from warnings import warn
 
 import numpy as np
 import scipy
+from spikeinterface.core.numpyextractors import NumpyRecording
 
+from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
 from ....tools import get_package
 from ....utils import FilePathType
+
+
+class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
+    """
+    This interface is a temporary hack for adding CellExplorer metadata in a conversion.
+
+    The new format of cell explorer contains a .session.mat file with the metadata:
+
+    https://cellexplorer.org/
+
+    The new format contains a session.mat file with the following fields:
+    * Sampling frequency
+    * Gains for both raw data and lfp. The former is a file named session.dat and the latter session.lfp
+    * Dtype for both raw data and lfp.
+
+    Link to the documentation of the file:
+    https://cellexplorer.org/datastructure/data-structure-and-format/#session-metadata
+
+    This is enough to create a memmap from which we can extract the data and create a recording extractor.
+    This should be done if we get more conversions projects with CellExplorer data and this interface is the
+    first step in that direction.
+
+    Meanwhile, this is meant to be used to add the electrode metadata in a conversion. That is,
+    this should only be used with ` write_electrical_series=False` as a conversion option.
+
+    In the current instantiation, the file `chanMap.mat` is used to extrat the coordinates of the electrodes
+    in the probe. As far as I understand this file is created to use kilosort so it is not clear if it will be
+    availalbe for all conversion projects. In fact, there should be a channel info and channel coords files as well
+    in the format but they are not present in the current conversion:
+
+    https://cellexplorer.org/datastructure/data-structure-and-format/#channels
+
+    As we get more examples in the future we can refine this further. This is a first iteration.
+    """
+
+    def __init__(self, folder_path, verbose=True):
+        self.folder_path = Path(folder_path)
+
+        # No super here, we need to do everything by hand
+        self.verbose = verbose
+        self.es_key = "raw"
+        self.subset_channels = None
+        self.source_data = dict(folder_path=folder_path)
+
+        self.session = self.folder_path.name
+
+        session_data_file_path = self.folder_path / f"{self.session}.session.mat"
+        assert session_data_file_path.is_file(), f"File {session_data_file_path} does not exist"
+
+        from pymatreader import read_mat
+
+        session_data = read_mat(session_data_file_path)["session"]
+
+        extracellular_data = session_data["extracellular"]
+
+        num_channels = extracellular_data["nChannels"]
+        sampling_frequency = extracellular_data["sr"]
+        gain = extracellular_data["leastSignificantBit"]  # 0.195
+        traces_list = [np.empty(shape=(1, num_channels))]
+        # sampilng_frequency_lfp = extracellular_data["srLfp"]  # TODO: Add another LFP interface when writing series
+        # dtype = extracellular_data["precision"]  # TODO: This information will be used when writing the series
+
+        channel_ids = None
+        dummy_recording = NumpyRecording(
+            traces_list=traces_list,
+            sampling_frequency=sampling_frequency,
+            channel_ids=channel_ids,
+        )
+        self.recording_extractor = dummy_recording
+        self.recording_extractor.set_channel_gains(channel_ids=channel_ids, gains=np.ones(num_channels) * gain)
+
+        self.chan_map_file_path = self.folder_path / f"chanMap.mat"
+        if self.chan_map_file_path.is_file():
+            channel_map_data = read_mat(self.chan_map_file_path)
+            channel_groups = channel_map_data["connected"]
+            channel_group_names = [f"Group{group_index + 1}" for group_index in channel_groups]
+
+            channel_indices = channel_map_data["chanMap0ind"]
+            channel_ids = [str(channel_indices[i]) for i in channel_indices]
+            channel_name = [
+                f"ch{channel_index}grp{channel_group}"
+                for channel_index, channel_group in zip(channel_indices, channel_groups)
+            ]
+            base_ids = self.recording_extractor.get_channel_ids()
+            self.recording_extractor = self.recording_extractor.channel_slice(
+                channel_ids=base_ids, renamed_channel_ids=channel_ids
+            )
+            x_coords = channel_map_data["xcoords"]
+            y_coords = channel_map_data["ycoords"]
+            locations = np.array((x_coords, y_coords)).T.astype("float32")
+            self.recording_extractor.set_channel_locations(channel_ids=channel_ids, locations=locations)
+
+            self.recording_extractor.set_property(key="channel_name", values=channel_name)
+            self.recording_extractor.set_property(key="group", ids=channel_ids, values=channel_groups)
+            self.recording_extractor.set_property(key="group_name", ids=channel_ids, values=channel_group_names)
+
+        self._number_of_segments = self.recording_extractor.get_num_segments()
 
 
 class CellExplorerSortingInterface(BaseSortingExtractorInterface):
@@ -25,7 +124,16 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
 
         hdf5storage = get_package(package_name="hdf5storage")
 
-        super().__init__(spikes_matfile_path=file_path, verbose=verbose)
+        # Temporary hack untill spkeinterface next release
+        file_path = Path(file_path)
+        new_cell_explorer_format = "spikes.cellinfo.mat" in file_path.name
+        sampling_frequency = None
+        if new_cell_explorer_format:
+            from pymatreader import read_mat
+
+            sampling_frequency = read_mat(file_path)["spikes"]["sr"]
+
+        super().__init__(spikes_matfile_path=file_path, sampling_frequency=sampling_frequency, verbose=verbose)
         self.source_data = dict(file_path=file_path)
         spikes_matfile_path = Path(file_path)
 
@@ -126,4 +234,5 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
                     )
                 )
         metadata.update(Ecephys=dict(UnitProperties=unit_properties))
+
         return metadata

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/requirements.txt
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/requirements.txt
@@ -1,1 +1,2 @@
 hdf5storage>=0.1.18
+pymatreader>=0.0.30


### PR DESCRIPTION
I was discussing with @CodyCBakerPhD today on how to do this best. Our initial plan was to add this as metadata of the cell explorer interface but when I started working on this I realized that it will be more complicated than I thought. It seems easier to add this interface which we might expand in the future but right now can be used for adding the electrode metadata.

A detailed description of how this works in provided in the docstring.