### PR TITLE
`CellExplorerSortingInterface` to get sampling frequency from new CellExplorer format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
   Added `photon_series_type` to `get_nwb_imaging_metadata()` to fill metadata for `OnePhotonSeries` or `TwoPhotonSeries`. [PR #462](https://github.com/catalystneuro/neuroconv/pull/462)
 * Split `align_timestamps` and `align_starting_times` into `align_segment_timestamps` and `align_segment_starting_times` for API consistency for multi-segment `RecordingInterface`s. [PR #463](https://github.com/catalystneuro/neuroconv/pull/463)
 * Rename `align_timestamps` and `align_segmentt_timestamps` into `set_aligned_timestamps` and `set_aligned_segment_timestamps` to more clearly indicate their usage and behavior. [PR #470](https://github.com/catalystneuro/neuroconv/pull/470)
+* `CellExplorerRecordingInterface` now supports the extacting sampling frequency from new format [PR #491](https://github.com/catalystneuro/neuroconv/pull/491)
 
 ### Testing
 * The tests for `automatic_dandi_upload` now follow up-to-date DANDI validation rules for file name conventions. [PR #310](https://github.com/catalystneuro/neuroconv/pull/310)

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -33,7 +33,7 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
         try:
             matlab_file = scipy.io.loadmat(file_name=str(file_path), simplify_cells=True)
             if "spikes" not in matlab_file.keys():
-                raise ValueError(f"Matlab file  {file_path} does not contain `spikes` field")
+                raise KeyError(f"CellExplorer file '{file_path}' does not contain 'spikes' field.")
             spikes_mat = matlab_file["spikes"]
             assert isinstance(spikes_mat, dict), f"field `spikes` must be a dict, not {type(spikes_mat)}!"
 

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -25,7 +25,31 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
 
         hdf5storage = get_package(package_name="hdf5storage")
 
-        super().__init__(spikes_matfile_path=file_path, verbose=verbose)
+        file_path = Path(file_path)
+
+        # Temporary hack to get sampling frequency from the spikes cellinfo file until next SI release.
+        is_new_cell_explorer_format = "spikes.cellinfo.mat" in file_path.name
+        sampling_frequency = None
+
+        if is_new_cell_explorer_format:
+            import h5py
+
+            try:
+                matlab_file = scipy.io.loadmat(file_name=str(file_path), simplify_cells=True)
+                spikes_mat = matlab_file["spikes"]
+                assert isinstance(spikes_mat, dict), f"field `spikes` must be a dict, not {type(spikes_mat)}!"
+
+            except NotImplementedError:
+                matlab_file = h5py.File(name=file_path, mode="r")
+                spikes_mat = matlab_file["spikes"]
+                assert isinstance(spikes_mat, h5py.Group), f"field `spikes` must be a Group, not {type(spikes_mat)}!"
+
+            sampling_frequency = spikes_mat.get("sr", None)
+            sampling_frequency = (
+                sampling_frequency[()] if isinstance(sampling_frequency, h5py.Dataset) else sampling_frequency
+            )
+
+        super().__init__(spikes_matfile_path=file_path, sampling_frequency=sampling_frequency, verbose=verbose)
         self.source_data = dict(file_path=file_path)
         spikes_matfile_path = Path(file_path)
 
@@ -126,4 +150,5 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
                     )
                 )
         metadata.update(Ecephys=dict(UnitProperties=unit_properties))
+
         return metadata

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -40,7 +40,7 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
         except NotImplementedError:
             matlab_file = h5py.File(name=file_path, mode="r")
             if "spikes" not in matlab_file.keys():
-                raise ValueError(f"Matlab file  {file_path} does not contain `spikes` field")
+                raise KeyError(f"CellExplorer file '{file_path}' does not contain 'spikes' field.")
             spikes_mat = matlab_file["spikes"]
             assert isinstance(spikes_mat, h5py.Group), f"field `spikes` must be a Group, not {type(spikes_mat)}!"
 


### PR DESCRIPTION
As mentioned before, in the new CellExplorer format the sampling frequency is the in the same file where the spikes are. I made the changes in spikeinterface to take this into account https://github.com/SpikeInterface/spikeinterface/pull/1628 but we won't have a release in a while.

Meanwhile, we will need this temporary change to the interface so we can use it in the current conversions.
