### PR TITLE
Add `CellExplorerRecordingInterface` 

### DIFF
--- a/.github/workflows/dev-testing.yml
+++ b/.github/workflows/dev-testing.yml
@@ -68,7 +68,7 @@ jobs:
         id: cache-ephys-datasets
         with:
           path: ./ephy_testing_data
-          key: ephys-datasets-2023-06-25-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
+          key: ephys-datasets-2023-06-26-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
       - name: Get ophys_testing_data current head hash
         id: ophys
         run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"

--- a/.github/workflows/dev-testing.yml
+++ b/.github/workflows/dev-testing.yml
@@ -68,7 +68,7 @@ jobs:
         id: cache-ephys-datasets
         with:
           path: ./ephy_testing_data
-          key: ephys-datasets-2022-08-18-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
+          key: ephys-datasets-2023-06-25-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
       - name: Get ophys_testing_data current head hash
         id: ophys
         run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"

--- a/.github/workflows/dev-testing.yml
+++ b/.github/workflows/dev-testing.yml
@@ -64,7 +64,7 @@ jobs:
         id: ephys
         run: echo "::set-output name=HASH_EPHY_DATASET::$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"
       - name: Cache ephys dataset - ${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-ephys-datasets
         with:
           path: ./ephy_testing_data
@@ -73,7 +73,7 @@ jobs:
         id: ophys
         run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"
       - name: Cache ophys dataset - ${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-ophys-datasets
         with:
           path: ./ophys_testing_data
@@ -82,7 +82,7 @@ jobs:
         id: behavior
         run: echo "::set-output name=HASH_BEHAVIOR_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/behavior_testing_data.git HEAD | cut -f1)"
       - name: Cache behavior dataset - ${{ steps.behavior.outputs.HASH_BEHAVIOR_DATASET }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-behavior-datasets
         with:
           path: ./behavior_testing_data
@@ -90,19 +90,19 @@ jobs:
 
 
 
-      - if: steps.cache-ephys-datasets.outputs.cache-hit == false || steps.cache-ophys-datasets.outputs.cache-hit == false || steps.cache-behavior-datasets.outputs.cache-hit == false
+      - if: steps.cache-ephys-datasets.outputs.cache-hit != 'true' || steps.cache-ophys-datasets.outputs.cache-hit != 'true' || steps.cache-behavior-datasets.outputs.cache-hit != 'true'
         name: Install and configure AWS CLI
         run: |
           pip install awscli
           aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - if: steps.cache-ephys-datasets.outputs.cache-hit == false
+      - if: steps.cache-ephys-datasets.outputs.cache-hit != 'true'
         name: Download ephys dataset from S3
         run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data ./ephy_testing_data
-      - if: steps.cache-ophys-datasets.outputs.cache-hit == false
+      - if: steps.cache-ophys-datasets.outputs.cache-hit != 'true'
         name: Download ophys dataset from S3
         run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/ophys_testing_data ./ophys_testing_data
-      - if: steps.cache-behavior-datasets.outputs.cache-hit == false
+      - if: steps.cache-behavior-datasets.outputs.cache-hit != 'true'
         name: Download behavior dataset from S3
         run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data ./behavior_testing_data
 

--- a/.github/workflows/formatwise-installation-testing.yml
+++ b/.github/workflows/formatwise-installation-testing.yml
@@ -42,16 +42,16 @@ jobs:
         id: ephys
         run: echo "::set-output name=HASH_EPHY_DATASET::$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"
       - name: Cache ephys dataset - ${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-ephys-datasets
         with:
           path: ./ephy_testing_data
-          key: ephys-datasets-2022-08-18-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
+          key: ephys-datasets-2023-06-25-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
       - name: Get ophys_testing_data current head hash
         id: ophys
         run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"
       - name: Cache ophys dataset - ${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-ophys-datasets
         with:
           path: ./ophys_testing_data
@@ -60,7 +60,7 @@ jobs:
         id: behavior
         run: echo "::set-output name=HASH_BEHAVIOR_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/behavior_testing_data.git HEAD | cut -f1)"
       - name: Cache behavior dataset - ${{ steps.behavior.outputs.HASH_BEHAVIOR_DATASET }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-behavior-datasets
         with:
           path: ./behavior_testing_data

--- a/.github/workflows/formatwise-installation-testing.yml
+++ b/.github/workflows/formatwise-installation-testing.yml
@@ -46,7 +46,7 @@ jobs:
         id: cache-ephys-datasets
         with:
           path: ./ephy_testing_data
-          key: ephys-datasets-2023-06-25-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
+          key: ephys-datasets-2023-06-26-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
       - name: Get ophys_testing_data current head hash
         id: ophys
         run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -84,16 +84,16 @@ jobs:
         id: ephys
         run: echo "::set-output name=HASH_EPHY_DATASET::$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"
       - name: Cache ephys dataset - ${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-ephys-datasets
         with:
           path: ./ephy_testing_data
-          key: ephys-datasets-2022-08-18-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
+          key: ephys-datasets-2023-06-25-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
       - name: Get ophys_testing_data current head hash
         id: ophys
         run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"
       - name: Cache ophys dataset - ${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-ophys-datasets
         with:
           path: ./ophys_testing_data
@@ -102,7 +102,7 @@ jobs:
         id: behavior
         run: echo "::set-output name=HASH_BEHAVIOR_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/behavior_testing_data.git HEAD | cut -f1)"
       - name: Cache behavior dataset - ${{ steps.behavior.outputs.HASH_BEHAVIOR_DATASET }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-behavior-datasets
         with:
           path: ./behavior_testing_data

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -88,7 +88,7 @@ jobs:
         id: cache-ephys-datasets
         with:
           path: ./ephy_testing_data
-          key: ephys-datasets-2023-06-25-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
+          key: ephys-datasets-2023-06-26-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
       - name: Get ophys_testing_data current head hash
         id: ophys
         run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -110,19 +110,19 @@ jobs:
 
 
 
-      - if: steps.cache-ephys-datasets.outputs.cache-hit == false || steps.cache-ophys-datasets.outputs.cache-hit == false || steps.cache-behavior-datasets.outputs.cache-hit == false
+      - if: steps.cache-ephys-datasets.outputs.cache-hit != 'true' || steps.cache-ophys-datasets.outputs.cache-hit != 'true' || steps.cache-behavior-datasets.outputs.cache-hit != 'true'
         name: Install and configure AWS CLI
         run: |
           pip install awscli
           aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - if: steps.cache-ephys-datasets.outputs.cache-hit == false
+      - if: steps.cache-ephys-datasets.outputs.cache-hit != 'true'
         name: Download ephys dataset from S3
         run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data ./ephy_testing_data
-      - if: steps.cache-ophys-datasets.outputs.cache-hit == false
+      - if: steps.cache-ophys-datasets.outputs.cache-hit != 'true'
         name: Download ophys dataset from S3
         run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/ophys_testing_data ./ophys_testing_data
-      - if: steps.cache-behavior-datasets.outputs.cache-hit == false
+      - if: steps.cache-behavior-datasets.outputs.cache-hit != 'true'
         name: Download behavior dataset from S3
         run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data ./behavior_testing_data
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 * Added a common `.temporally_align_data_interfaces` method to the `NWBConverter` class to use as a specification of the protocol for temporally aligning the data interfaces of the converter. [PR #362](https://github.com/catalystneuro/neuroconv/pull/362)
 
-* Added `CellExplorerRecordingInterface` for adding data in the CellExplorer format. [#488](https://github.com/catalystneuro/neuroconv/pull/488)
-* `CellExplorerRecordingInterface` now supports the extacting sampling frequency from new format [PR #491](https://github.com/catalystneuro/neuroconv/pull/491)
+* Added `CellExplorerRecordingInterface` for adding data raw and lfp data from the CellExplorer format. [#488](https://github.com/catalystneuro/neuroconv/pull/488)
+* `CellExplorerSortingInterface` now supports the extacting sampling frequency from the new data format [PR #491](https://github.com/catalystneuro/neuroconv/pull/491)
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@
 
 * Added a common `.temporally_align_data_interfaces` method to the `NWBConverter` class to use as a specification of the protocol for temporally aligning the data interfaces of the converter. [PR #362](https://github.com/catalystneuro/neuroconv/pull/362)
 
-
+* Added `CellExplorerRecordingInterface` for adding data in the CellExplorer format. [#488](https://github.com/catalystneuro/neuroconv/pull/488)
+* `CellExplorerRecordingInterface` now supports the extacting sampling frequency from new format [PR #491](https://github.com/catalystneuro/neuroconv/pull/491)
 
 ### Improvements
 
 * Avoid redundant timestamp creation in `add_eletrical_series`` for recording objects without time vector [PR #495](https://github.com/catalystneuro/neuroconv/pull/495)
 
 
+### Testing
+* Added gin test for `CellExplorerRecordingInterface` [#488](https://github.com/catalystneuro/neuroconv/pull/488)
 
 # v0.3.0 (June 7, 2023)
 
@@ -71,8 +74,7 @@
   Added `photon_series_type` to `get_nwb_imaging_metadata()` to fill metadata for `OnePhotonSeries` or `TwoPhotonSeries`. [PR #462](https://github.com/catalystneuro/neuroconv/pull/462)
 * Split `align_timestamps` and `align_starting_times` into `align_segment_timestamps` and `align_segment_starting_times` for API consistency for multi-segment `RecordingInterface`s. [PR #463](https://github.com/catalystneuro/neuroconv/pull/463)
 * Rename `align_timestamps` and `align_segmentt_timestamps` into `set_aligned_timestamps` and `set_aligned_segment_timestamps` to more clearly indicate their usage and behavior. [PR #470](https://github.com/catalystneuro/neuroconv/pull/470)
-* Added `CellExplorerRecordingInterface` for adding data in the CellExplorer format. [#488](https://github.com/catalystneuro/neuroconv/pull/488)
-* `CellExplorerRecordingInterface` now supports the extacting sampling frequency from new format [PR #491](https://github.com/catalystneuro/neuroconv/pull/491)
+
 
 ### Testing
 * The tests for `automatic_dandi_upload` now follow up-to-date DANDI validation rules for file name conventions. [PR #310](https://github.com/catalystneuro/neuroconv/pull/310)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@
 
 * Added a common `.temporally_align_data_interfaces` method to the `NWBConverter` class to use as a specification of the protocol for temporally aligning the data interfaces of the converter. [PR #362](https://github.com/catalystneuro/neuroconv/pull/362)
 
-* Added `CellExplorerRecordingInterface` for adding data raw and lfp data from the CellExplorer format. [#488](https://github.com/catalystneuro/neuroconv/pull/488)
-* `CellExplorerSortingInterface` now supports exrtacting sampling frequency from the new data format [PR #491](https://github.com/catalystneuro/neuroconv/pull/491)
+* Added `CellExplorerRecordingInterface` for adding data raw and lfp data from the CellExplorer format. CellExplorer's new format contains a `basename.session.mat` file containing
+    rich metadata about the session which can be used to extract the recording information such as sampling frequency and type and channel metadata such as
+    groups, location and brain area [#488](https://github.com/catalystneuro/neuroconv/pull/488)
+* `CellExplorerSortingInterface` now supports exrtacting sampling frequency from the new data format. CellExplorer's new format contains a `basename.session.mat` file containing
+    rich metadata including the sorting sampling frequency [PR #491](https://github.com/catalystneuro/neuroconv/pull/491)
 * Added `MiniscopeBehaviorInterface` for Miniscope behavioral data. The interface uses `ndx-miniscope` extension to add a `Miniscope` device with the behavioral camera metadata,
   and an `ImageSeries` in external mode that is linked to the device. [PR #482](https://github.com/catalystneuro/neuroconv/pull/482)
 
@@ -21,7 +24,9 @@
 
 
 ### Testing
-* Added gin test for `CellExplorerRecordingInterface` [#488](https://github.com/catalystneuro/neuroconv/pull/488)
+* Added gin test for `CellExplorerRecordingInterface`. CellExplorer's new format contains a `basename.session.mat` file containing
+    rich metadata about the session which can be used to extract the recording information such as sampling frequency and type and channel metadata such as
+    groups, location and brain area [#488](https://github.com/catalystneuro/neuroconv/pull/488).
 
 # v0.3.0 (June 7, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
   Added `photon_series_type` to `get_nwb_imaging_metadata()` to fill metadata for `OnePhotonSeries` or `TwoPhotonSeries`. [PR #462](https://github.com/catalystneuro/neuroconv/pull/462)
 * Split `align_timestamps` and `align_starting_times` into `align_segment_timestamps` and `align_segment_starting_times` for API consistency for multi-segment `RecordingInterface`s. [PR #463](https://github.com/catalystneuro/neuroconv/pull/463)
 * Rename `align_timestamps` and `align_segmentt_timestamps` into `set_aligned_timestamps` and `set_aligned_segment_timestamps` to more clearly indicate their usage and behavior. [PR #470](https://github.com/catalystneuro/neuroconv/pull/470)
-* Added `CellExplorerRecordingInterface` for adding electrode metadata in the CellExplorer format. [TBD](TBD)
+* Added `CellExplorerRecordingInterface` for adding electrode metadata in the CellExplorer format. [#488](https://github.com/catalystneuro/neuroconv/pull/488)
 
 ### Testing
 * The tests for `automatic_dandi_upload` now follow up-to-date DANDI validation rules for file name conventions. [PR #310](https://github.com/catalystneuro/neuroconv/pull/310)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
   Added `photon_series_type` to `get_nwb_imaging_metadata()` to fill metadata for `OnePhotonSeries` or `TwoPhotonSeries`. [PR #462](https://github.com/catalystneuro/neuroconv/pull/462)
 * Split `align_timestamps` and `align_starting_times` into `align_segment_timestamps` and `align_segment_starting_times` for API consistency for multi-segment `RecordingInterface`s. [PR #463](https://github.com/catalystneuro/neuroconv/pull/463)
 * Rename `align_timestamps` and `align_segmentt_timestamps` into `set_aligned_timestamps` and `set_aligned_segment_timestamps` to more clearly indicate their usage and behavior. [PR #470](https://github.com/catalystneuro/neuroconv/pull/470)
+* Added `CellExplorerRecordingInterface` for adding electrode metadata in the CellExplorer format. [TBD](TBD)
 
 ### Testing
 * The tests for `automatic_dandi_upload` now follow up-to-date DANDI validation rules for file name conventions. [PR #310](https://github.com/catalystneuro/neuroconv/pull/310)

--- a/src/neuroconv/datainterfaces/__init__.py
+++ b/src/neuroconv/datainterfaces/__init__.py
@@ -17,7 +17,11 @@ from .ecephys.blackrock.blackrockdatainterface import (
     BlackrockRecordingInterface,
     BlackrockSortingInterface,
 )
-from .ecephys.cellexplorer.cellexplorerdatainterface import CellExplorerSortingInterface
+from .ecephys.cellexplorer.cellexplorerdatainterface import (
+    CellExplorerLFPInterface,
+    CellExplorerRecordingInterface,
+    CellExplorerSortingInterface,
+)
 from .ecephys.edf.edfdatainterface import EDFRecordingInterface
 from .ecephys.intan.intandatainterface import IntanRecordingInterface
 from .ecephys.kilosort.kilosortdatainterface import KiloSortSortingInterface
@@ -97,6 +101,8 @@ interface_list = [
     IntanRecordingInterface,
     CEDRecordingInterface,
     CellExplorerSortingInterface,
+    CellExplorerRecordingInterface,
+    CellExplorerLFPInterface,
     BlackrockRecordingInterface,
     BlackrockSortingInterface,
     OpenEphysRecordingInterface,

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -182,31 +182,48 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
 
     https://cellexplorer.org/
 
-    CellExplorer's new format contains a `basename.session.mat` file,
-    (where basename is isually a session identifier) containing the
-    following fields:
+    Parameters
+    ----------
+    folder_path : Path or str
+        The folder where the session data is located. It should contain a
+        `{folder.name}.session.mat` file and the binary files `{folder.name}.dat`
+        or `{folder.name}.lfp` for the LFP interface.
+    verbose : bool, default: True
+            Whether to output verbose text.
+    es_key : str, default: "ElectricalSeries" and "ElectricalSeriesLFP" for the LFP interface
+
+    Notes
+    -----
+    CellExplorer's new format contains a `basename.session.mat` file containing
+    rich metadata about the session. basename is the name of the session
+    folder / directory and works as a session identifier.
+
+    Link to the documentation detailing the file's structure:
+    https://cellexplorer.org/datastructure/data-structure-and-format/#session-metadata
+
+    Specifically, we can use the following fields from `basename.session.mat`
+    to create a recording extractor using `BinaryRecordingExtractor` from
+    spikeinterface:
 
     * Sampling frequency
     * Gains
     * Dtype
 
-    Link to the documentation detailing the file's structure:
-    https://cellexplorer.org/datastructure/data-structure-and-format/#session-metadata
+    Where the binary file is named `basename.dat` for the raw data and
+    `basename.lfp` for lfp data.
 
-    If the binary file is available (basename.dat or basename.lfp),
-    the interface will use the `BinaryRecordingExtractor` object from spikeinterface
-    to load the data.
-
-    The metadata for this electrode is also extracted from the `basename.session.mat`
+    The metadata for the channels is extracted from the `basename.session.mat`
     file. The logic of the extraction is described on the function:
 
     `add_channel_metadata_to_recorder_from_session_file`.
 
-    Note that, while all the new data produced by CellExplorer should have a `session.mat` file,  it is not clear
-    if all the channel metadata is always available.
+    Note that, while all the new data produced by CellExplorer should have a
+    `session.mat` file,  it is not clear if all the channel metadata is always
+    available.
 
-    Besides, the current implementation also supports extracting channel metadata from the `chanMap.mat` file used by
-    Kilosort. The logic of the extraction is described on the function:
+    Besides, the current implementation also supports extracting channel metadata
+    from the `chanMap.mat` file used by Kilosort. The logic of the extraction is
+    described on the function:
 
     `add_channel_metadata_to_recorder_from_channel_map_file`.
 
@@ -220,7 +237,7 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
     Detailed information can be found in the following link
     https://cellexplorer.org/datastructure/data-structure-and-format/#channels
 
-    Future versions of this interface will support the extraction of this metadata from these files.
+    Future versions of this interface will support the extraction of this metadata from these files as well
     """
 
     sampling_frequency_key = "sr"

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -8,7 +8,7 @@ from pynwb import NWBFile
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
 from ....tools import get_package
-from ....utils import FilePathType
+from ....utils import FilePathType, FolderPathType
 
 
 class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
@@ -42,7 +42,7 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
     sampling_frequency_key = "sr"
     binary_file_extension = "dat"
 
-    def __init__(self, folder_path, verbose=True, es_key: str = "ElectricalSeries"):
+    def __init__(self, folder_path: FolderPathType, verbose=True, es_key: str = "ElectricalSeries"):
         self.folder_path = Path(folder_path)
 
         # No super here, we need to do everything by hand
@@ -137,7 +137,7 @@ class CellExplorerLFPInterface(CellExplorerRecordingInterface):
     sampling_frequency_key = "srLfp"
     binary_file_extension = "lfp"
 
-    def __init__(self, folder_path, verbose=True, es_key: str = "ElectricalSeriesLFP"):
+    def __init__(self, folder_path: FolderPathType, verbose=True, es_key: str = "ElectricalSeriesLFP"):
         super().__init__(folder_path, verbose, es_key)
 
     def add_to_nwbfile(

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -1,9 +1,7 @@
 from pathlib import Path
-from warnings import warn
 
 import numpy as np
 import scipy
-from spikeinterface.core.numpyextractors import NumpyRecording
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
@@ -70,6 +68,8 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
         # dtype = extracellular_data["precision"]  # TODO: This information will be used when writing the series
 
         channel_ids = None
+        from spikeinterface.core.numpyextractors import NumpyRecording
+
         dummy_recording = NumpyRecording(
             traces_list=traces_list,
             sampling_frequency=sampling_frequency,

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -129,7 +129,8 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
         if new_cell_explorer_format:
             from pymatreader import read_mat
 
-            sampling_frequency = read_mat(file_path)["spikes"]["sr"]
+            spikes_data = read_mat(file_path)["spikes"]
+            sampling_frequency = spikes_data.get("sr", None)
 
         super().__init__(spikes_matfile_path=file_path, sampling_frequency=sampling_frequency, verbose=verbose)
         self.source_data = dict(file_path=file_path)

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -90,7 +90,7 @@ def add_channel_metadata_to_recorder_from_session_file(
             corresponding_channel_ids = [str(id) for id in channels]
             values = [brain_region_name] * len(channel_ids)
             recording_extractor.set_property(
-                key="location",
+                key="brain_area",
                 ids=corresponding_channel_ids,
                 values=values,
             )

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -165,7 +165,7 @@ def add_channel_metadata_to_recorder_from_channel_map_file(
 
 class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
     """
-    Addds raw and lfp data from binary files with the new CellExplorer format:
+    Adds raw and lfp data from binary files with the new CellExplorer format:
 
     https://cellexplorer.org/
 

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -90,7 +90,7 @@ def add_channel_metadata_to_recorder_from_session_file(
             corresponding_channel_ids = [str(id) for id in channels]
             values = [brain_region_name] * len(channel_ids)
             recording_extractor.set_property(
-                key="brain_region",
+                key="location",
                 ids=corresponding_channel_ids,
                 values=values,
             )
@@ -274,6 +274,9 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
         self.recording_extractor = add_channel_metadata_to_recorder_from_channel_map_file(
             recording_extractor=self.recording_extractor, session_path=self.folder_path
         )
+
+    def get_metadata(self) -> dict:
+        return super().get_metadata()
 
     def get_original_timestamps(self):
         num_frames = self.recording_extractor.get_num_frames()

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -22,15 +22,6 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
             Path to .spikes.cellinfo.mat file.
         verbose: bool, default: True
         """
-        # TODO: Remove spikeextractors backend
-        warn(
-            message=(
-                "Interfaces using a spikeextractors backend will soon be deprecated! "
-                "Please use the SpikeInterface backend instead."
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
 
         hdf5storage = get_package(package_name="hdf5storage")
 

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -275,9 +275,6 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
             recording_extractor=self.recording_extractor, session_path=self.folder_path
         )
 
-    def get_metadata(self) -> dict:
-        return super().get_metadata()
-
     def get_original_timestamps(self):
         num_frames = self.recording_extractor.get_num_frames()
         sampling_frequency = self.recording_extractor.get_sampling_frequency()

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -24,19 +24,23 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
     Link to the documentation detailing the file's structure:
     https://cellexplorer.org/datastructure/data-structure-and-format/#session-metadata
 
-    If the binary file is available (session.dat), the interface will use the `BinaryRecordingExtractor` to load the
-    data. Otherwise, it will use the `NumpyRecording` extractor, which is a dummy extractor that only contains
-    metadata. This can be used to add the electrode using `write_electrical_series=False` as a conversion option.
+    If the binary file is available (session.dat or session.lfp), the interface will use the
+    `BinaryRecordingExtractor` from spikeinterface to load the data. Otherwise, it will use the
+    `NumpyRecording` extractor, which is a dummy extractor that only contains metadata.  This can be used to add
+    the electrode using `write_electrical_series=False` as a conversion option.
 
-    In its current form, the `chanMap.mat` file is employed to extract the electrode coordinates within the probe.
-    To my understanding, this file is generated for using kilosort, and it is not granted that it will
-    be universally available for all future conversion projects. Ideally, the format should also contain
-    files for channel info and channel coordinates, although these are absent in the current conversion:
+    In cell explorer usually the data about the electrodes and the recording device comes three files:
+    * `basename.ChannelName.channelinfo.mat`: general data container for channel-wise dat
+    * `basename.chanCoords.channelinfo.mat`: contains the coordinates of the electrodes in the probe
+    * `basename.ccf.channelinfo.mat`: Allen Institute’s Common Coordinate Framework (CCF)
 
+    Detailed information can be found in the following link
     https://cellexplorer.org/datastructure/data-structure-and-format/#channels
 
-    As we accumulate more examples moving forward, we will be able to figure out what's better. This is a first
-    iteration.
+    Plus, the file `chanMap.mat` used by Kilosort is usually available on CellExplorer datasets.
+    The `chanMap.mat` can then be used to extract the electrode coordinates within the probe.
+    To my understanding, this file is generated for using kilosort, and therefore it is not available for all datasets.
+
     """
 
     sampling_frequency_key = "sr"

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from pathlib import Path
 from typing import Literal, Optional
 
@@ -42,6 +40,7 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
     """
 
     sampling_frequency_key = "sr"
+    binary_file_extension = "dat"
 
     def __init__(self, folder_path, verbose=True, es_key: str = "ElectricalSeries"):
         self.folder_path = Path(folder_path)
@@ -69,7 +68,7 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
         dtype = np.dtype(extracellular_data["precision"])
         sampling_frequency = float(extracellular_data[self.sampling_frequency_key])
 
-        binary_file_path = self.folder_path / f"{self.session}.dat"
+        binary_file_path = self.folder_path / f"{self.session}.{self.binary_file_extension}"
         if binary_file_path.is_file():
             from spikeinterface.core.binaryrecordingextractor import (
                 BinaryRecordingExtractor,
@@ -136,6 +135,7 @@ class CellExplorerLFPInterface(CellExplorerRecordingInterface):
     ]
 
     sampling_frequency_key = "srLfp"
+    binary_file_extension = "lfp"
 
     def __init__(self, folder_path, verbose=True, es_key: str = "ElectricalSeriesLFP"):
         super().__init__(folder_path, verbose, es_key)
@@ -143,15 +143,15 @@ class CellExplorerLFPInterface(CellExplorerRecordingInterface):
     def add_to_nwbfile(
         self,
         nwbfile: NWBFile,
-        metadata: dict | None = None,
+        metadata: Optional[dict] = None,
         stub_test: bool = False,
-        starting_time: float | None = None,
+        starting_time: Optional[float] = None,
         write_as: Literal["raw", "lfp", "processed"] = "lfp",
         write_electrical_series: bool = True,
-        compression: str | None = None,
-        compression_opts: int | None = None,
+        compression: Optional[str] = None,
+        compression_opts: Optional[int] = None,
         iterator_type: str = "v2",
-        iterator_opts: dict | None = None,
+        iterator_opts: Optional[dict] = None,
     ):
         return super().add_to_nwbfile(
             nwbfile,

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -13,35 +13,33 @@ from ....utils import FilePathType
 
 class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
     """
-    This interface is a temporary hack for adding CellExplorer metadata in a conversion.
+    This interface serves as an temporary solution for integrating CellExplorer metadata during a conversion process.
 
-    The new format of cell explorer contains a .session.mat file with the metadata:
+    CellExplorer's new format (https://cellexplorer.org/) contains a `session.mat` file, which has the following field:
 
-    https://cellexplorer.org/
-
-    The new format contains a session.mat file with the following fields:
     * Sampling frequency
-    * Gains for both raw data and lfp. The former is a file named session.dat and the latter session.lfp
+    * Gains for both raw data (held in a file named session.dat) and lfp (located in session.lfp)
     * Dtype for both raw data and lfp.
 
-    Link to the documentation of the file:
+    Here's a link to the documentation detailing the file's structure:
     https://cellexplorer.org/datastructure/data-structure-and-format/#session-metadata
 
-    This is enough to create a memmap from which we can extract the data and create a recording extractor.
-    This should be done if we get more conversions projects with CellExplorer data and this interface is the
-    first step in that direction.
+    This metadata is sufficient to build a memmap, which in turn should make straigthfoward to build a recording
+    extractor.  If we encounter more conversion projects involving CellExplorer data, we should do this.
+    This interface then will seve as a steping stone to this long-term and more robust solution.
 
-    Meanwhile, this is meant to be used to add the electrode metadata in a conversion. That is,
-    this should only be used with ` write_electrical_series=False` as a conversion option.
+    In the meantime, the interface is intended for use in adding electrode metadata during a conversion,
+    specifically when using `write_electrical_series=False` as a conversion option.
 
-    In the current instantiation, the file `chanMap.mat` is used to extrat the coordinates of the electrodes
-    in the probe. As far as I understand this file is created to use kilosort so it is not clear if it will be
-    availalbe for all conversion projects. In fact, there should be a channel info and channel coords files as well
-    in the format but they are not present in the current conversion:
+    In its current form, the `chanMap.ma`t file is employed to extract the electrode coordinates within the probe.
+    To my understanding, this file is generated for using kilosort, and it is not granted that it will
+    be universally available for all future conversion projects. Ideally, the format should also contain
+    files for channel info and channel coordinates, although these are absent in the current conversion:
 
     https://cellexplorer.org/datastructure/data-structure-and-format/#channels
 
-    As we get more examples in the future we can refine this further. This is a first iteration.
+    As we accumulate more examples moving forward, we will be able to figure out what's better. This is a first
+    iteration.
     """
 
     def __init__(self, folder_path, verbose=True):

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -3,10 +3,109 @@ from warnings import warn
 
 import numpy as np
 import scipy
+from spikeinterface.core.numpyextractors import NumpyRecording
 
+from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
 from ....tools import get_package
 from ....utils import FilePathType
+
+
+class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
+    """
+    This interface is a temporary hack for adding CellExplorer metadata in a conversion.
+
+    The new format of cell explorer contains a .session.mat file with the metadata:
+
+    https://cellexplorer.org/
+
+    The new format contains a session.mat file with the following fields:
+    * Sampling frequency
+    * Gains for both raw data and lfp. The former is a file named session.dat and the latter session.lfp
+    * Dtype for both raw data and lfp.
+
+    Link to the documentation of the file:
+    https://cellexplorer.org/datastructure/data-structure-and-format/#session-metadata
+
+    This is enough to create a memmap from which we can extract the data and create a recording extractor.
+    This should be done if we get more conversions projects with CellExplorer data and this interface is the
+    first step in that direction.
+
+    Meanwhile, this is meant to be used to add the electrode metadata in a conversion. That is,
+    this should only be used with ` write_electrical_series=False` as a conversion option.
+
+    In the current instantiation, the file `chanMap.mat` is used to extrat the coordinates of the electrodes
+    in the probe. As far as I understand this file is created to use kilosort so it is not clear if it will be
+    availalbe for all conversion projects. In fact, there should be a channel info and channel coords files as well
+    in the format but they are not present in the current conversion:
+
+    https://cellexplorer.org/datastructure/data-structure-and-format/#channels
+
+    As we get more examples in the future we can refine this further. This is a first iteration.
+    """
+
+    def __init__(self, folder_path, verbose=True):
+        self.folder_path = Path(folder_path)
+
+        # No super here, we need to do everything by hand
+        self.verbose = verbose
+        self.es_key = "raw"
+        self.subset_channels = None
+        self.source_data = dict(folder_path=folder_path)
+
+        self.session = self.folder_path.name
+
+        session_data_file_path = self.folder_path / f"{self.session}.session.mat"
+        assert session_data_file_path.is_file(), f"File {session_data_file_path} does not exist"
+
+        from pymatreader import read_mat
+
+        session_data = read_mat(session_data_file_path)["session"]
+
+        extracellular_data = session_data["extracellular"]
+
+        num_channels = extracellular_data["nChannels"]
+        sampling_frequency = extracellular_data["sr"]
+        gain = extracellular_data["leastSignificantBit"]  # 0.195
+        traces_list = [np.empty(shape=(1, num_channels))]
+        # sampilng_frequency_lfp = extracellular_data["srLfp"]  # TODO: Add another LFP interface when writing series
+        # dtype = extracellular_data["precision"]  # TODO: This information will be used when writing the series
+
+        channel_ids = None
+        dummy_recording = NumpyRecording(
+            traces_list=traces_list,
+            sampling_frequency=sampling_frequency,
+            channel_ids=channel_ids,
+        )
+        self.recording_extractor = dummy_recording
+        self.recording_extractor.set_channel_gains(channel_ids=channel_ids, gains=np.ones(num_channels) * gain)
+
+        self.chan_map_file_path = self.folder_path / f"chanMap.mat"
+        if self.chan_map_file_path.is_file():
+            channel_map_data = read_mat(self.chan_map_file_path)
+            channel_groups = channel_map_data["connected"]
+            channel_group_names = [f"Group{group_index + 1}" for group_index in channel_groups]
+
+            channel_indices = channel_map_data["chanMap0ind"]
+            channel_ids = [str(channel_indices[i]) for i in channel_indices]
+            channel_name = [
+                f"ch{channel_index}grp{channel_group}"
+                for channel_index, channel_group in zip(channel_indices, channel_groups)
+            ]
+            base_ids = self.recording_extractor.get_channel_ids()
+            self.recording_extractor = self.recording_extractor.channel_slice(
+                channel_ids=base_ids, renamed_channel_ids=channel_ids
+            )
+            x_coords = channel_map_data["xcoords"]
+            y_coords = channel_map_data["ycoords"]
+            locations = np.array((x_coords, y_coords)).T.astype("float32")
+            self.recording_extractor.set_channel_locations(channel_ids=channel_ids, locations=locations)
+
+            self.recording_extractor.set_property(key="channel_name", values=channel_name)
+            self.recording_extractor.set_property(key="group", ids=channel_ids, values=channel_groups)
+            self.recording_extractor.set_property(key="group_name", ids=channel_ids, values=channel_group_names)
+
+        self._number_of_segments = self.recording_extractor.get_num_segments()
 
 
 class CellExplorerSortingInterface(BaseSortingExtractorInterface):
@@ -25,7 +124,16 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
 
         hdf5storage = get_package(package_name="hdf5storage")
 
-        super().__init__(spikes_matfile_path=file_path, verbose=verbose)
+        # Temporary hack untill spkeinterface next release
+        file_path = Path(file_path)
+        new_cell_explorer_format = "spikes.cellinfo.mat" in file_path.name
+        sampling_frequency = None
+        if new_cell_explorer_format:
+            from pymatreader import read_mat
+
+            sampling_frequency = read_mat(file_path)["spikes"]["sr"]
+
+        super().__init__(spikes_matfile_path=file_path, sampling_frequency=sampling_frequency, verbose=verbose)
         self.source_data = dict(file_path=file_path)
         spikes_matfile_path = Path(file_path)
 
@@ -126,4 +234,5 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
                     )
                 )
         metadata.update(Ecephys=dict(UnitProperties=unit_properties))
+
         return metadata

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -322,7 +322,7 @@ class CellExplorerLFPInterface(CellExplorerRecordingInterface):
         starting_time: Optional[float] = None,
         write_as: Literal["raw", "lfp", "processed"] = "lfp",
         write_electrical_series: bool = True,
-        compression: Optional[str] = None,
+        compression: Optional[str] = "gzip",
         compression_opts: Optional[int] = None,
         iterator_type: str = "v2",
         iterator_opts: Optional[dict] = None,

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -189,7 +189,7 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
     Note that, while all the new
     data produced by CellExplorer should have this file it is not clear if the channel metadata is always available.
 
-    Besides, the current implementation also supports extracing channel metadata fromthe `chanMap.mat` file used by
+    Besides, the current implementation also supports extracting channel metadata from the `chanMap.mat` file used by
     Kilosort. The logic of the extraction is described on the function:
 
     `add_channel_metadata_to_recorder_from_channel_map_file`.

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -165,9 +165,11 @@ def add_channel_metadata_to_recorder_from_channel_map_file(
 
 class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
     """
-    This interface serves as an temporary solution for integrating CellExplorer metadata during a conversion process.
+    Addds raw and lfp data from binary files with the new CellExplorer format:
 
-    CellExplorer's new format (https://cellexplorer.org/) contains a `session.mat` file, which has the following field:
+    https://cellexplorer.org/
+
+    CellExplorer's new format contains a `session.mat` file, which has the following fields:
 
     * Sampling frequency
     * Gains for both raw data (held in a file named session.dat) and lfp (located in session.lfp)
@@ -178,16 +180,16 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
 
     If the binary file is available (session.dat or session.lfp), the interface will use the
     `BinaryRecordingExtractor` from spikeinterface to load the data. Otherwise, it will use the
-    `NumpyRecording` extractor, which is a dummy extractor that only contains metadata.  This can be used to add
-    the electrode using `write_electrical_series=False` as a conversion option.
+    `NumpyRecording` extractor to create a dummy extractor that only contains channel metadata.
+    This can be used to add the metadata to nwb using `write_electrical_series=False` as a conversion option.
 
     The metadata for this electrode is also extracted from the `session.mat` file. The logic of the extraction is
     described on the function:
 
     `add_channel_metadata_to_recorder_from_session_file`.
 
-    Note that, while all the new
-    data produced by CellExplorer should have this file it is not clear if the channel metadata is always available.
+    Note that, while all the new data produced by CellExplorer should have a `session.mat` file,  it is not clear
+    if all the channel metadata is always available.
 
     Besides, the current implementation also supports extracting channel metadata from the `chanMap.mat` file used by
     Kilosort. The logic of the extraction is described on the function:

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Literal, Optional
 

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -11,7 +11,45 @@ from ....tools import get_package
 from ....utils import FilePathType, FolderPathType
 
 
-def add_ecephys_metadata_to_recorder_from_session(recording_extractor, session_path):
+def add_channel_metadata_to_recorder_from_session_file(
+    recording_extractor,
+    session_path: FolderPathType,
+):
+    """
+    Extracts channel metadata from the CellExplorer's `session.mat` file and adds it to the given recording extractor.
+
+    The metadata includes electrode groups, channel locations, and brain regions. The function will  skip addition
+    if the `session.mat` file is not found in the given session path. This is done to support calling the
+    when using files produced by the old cellexplorer format (Buzcode) which does not have a `session.mat` file.
+
+    Parameters
+    ----------
+    recording_extractor : BaseRecording from spikeinterface
+        The recording extractor to which the metadata will be added.
+    session_path : str or Path
+        The path to the directory containing the CellExplorer session.
+
+    Returns
+    -------
+    RecordingExtractor
+        The same recording extractor passed in the `recording_extractor` argument, but with added metadata as
+        channel properties.
+
+    Notes
+    -----
+    1. The channel locations are retrieved from the `chanCoords` field in the `extracellular` section of the
+    `session.mat` file. They are set in the recording extractor using the `set_channel_locations` method.
+
+    2. The electrode group information is extracted from the `electrodeGroups` field in the `extracellular` section of the
+    `session.mat` file. The groups are set in the recording extractor using the `set_property` method with the `group`
+    key.
+
+    3. The brain region data is fetched from the `brainRegions` section of the `session.mat` file. The brain regions are
+    set in the recording extractor using the `set_property` method with the `brain_region` key.
+
+    """
+
+    session_path = Path(session_path)
     session_path = session_path / f"{session_path.stem}.session.mat"
     if not session_path.is_file():
         return recording_extractor
@@ -60,14 +98,50 @@ def add_ecephys_metadata_to_recorder_from_session(recording_extractor, session_p
     return recording_extractor
 
 
-def add_ecephys_metadata_to_recorder_from_channel_map(recording_extractor, session_path):
+def add_channel_metadata_to_recorder_from_channel_map_file(
+    recording_extractor,
+    session_path: FolderPathType,
+):
+    """
+    Extracts channel metadata from the `chanMap.mat` file used by Kilosort and adds it to the given recording extractor.
+
+    The metadata includes channel groups, channel locations, and channel names. The function will skip addition of
+    properties if the `chanMap.mat` file is not found in the given session path.
+
+    Parameters
+    ----------
+    recording_extractor : BaseRecording from spikeinterface
+        The recording extractor to which the metadata will be added.
+    session_path : Path or str
+        The path to the directory containing the session.
+
+    Returns
+    -------
+    RecordingExtractor
+        The same recording extractor passed in the `recording_extractor` argument, but with added metadata.
+
+    Notes
+    -----
+    1. The channel locations are retrieved from the `xcoords` and `ycoords` fields in the `chanMap.mat` file. They are
+    set in the recording extractor using the `set_channel_locations` method.
+
+    2. The channel groups are extracted from the `connected` field in the `chanMap.mat` file. The groups are set in the
+    recording extractor using the `set_property` method with the `group` key.
+
+    3. The channel names are composed of the channel index and group, and are set in the recording extractor using the
+    `set_property` method with the `channel_name` key.
+
+    4. Channel group names are created based on the group index and are set in the recording extractor using the
+    `set_property` method with the `group_name` key.
+    """
+
+    session_path = Path(session_path)
     chan_map_file_path = session_path / f"chanMap.mat"
     if chan_map_file_path.is_file():
         from pymatreader import read_mat
 
         channel_map_data = read_mat(chan_map_file_path)
         channel_groups = channel_map_data["connected"]
-        channel_group_names = [f"Group{group_index + 1}" for group_index in channel_groups]
 
         channel_indices = channel_map_data["chanMap0ind"]
         channel_ids = [str(channel_indices[i]) for i in channel_indices]
@@ -85,7 +159,6 @@ def add_ecephys_metadata_to_recorder_from_channel_map(recording_extractor, sessi
 
         recording_extractor.set_property(key="channel_name", values=channel_name)
         recording_extractor.set_property(key="group", ids=channel_ids, values=channel_groups)
-        recording_extractor.set_property(key="group_name", ids=channel_ids, values=channel_group_names)
 
     return recording_extractor
 
@@ -108,7 +181,22 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
     `NumpyRecording` extractor, which is a dummy extractor that only contains metadata.  This can be used to add
     the electrode using `write_electrical_series=False` as a conversion option.
 
-    In cell explorer usually the data about the electrodes and the recording device comes three files:
+    The metadata for this electrode is also extracted from the `session.mat` file. The logic of the extraction is
+    described on the function:
+
+    `add_channel_metadata_to_recorder_from_session_file`.
+
+    Note that, while all the new
+    data produced by CellExplorer should have this file it is not clear if the channel metadata is always available.
+
+    Besides, the current implementation also supports extracing channel metadata fromthe `chanMap.mat` file used by
+    Kilosort. The logic of the extraction is described on the function:
+
+    `add_channel_metadata_to_recorder_from_channel_map_file`.
+
+    Bear in mind that this file is not always available for all datasets.
+
+    From the documentation we also know that channel data can also be found in the following files:
     * `basename.ChannelName.channelinfo.mat`: general data container for channel-wise dat
     * `basename.chanCoords.channelinfo.mat`: contains the coordinates of the electrodes in the probe
     * `basename.ccf.channelinfo.mat`: Allen Institute’s Common Coordinate Framework (CCF)
@@ -116,16 +204,7 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
     Detailed information can be found in the following link
     https://cellexplorer.org/datastructure/data-structure-and-format/#channels
 
-    Note also that `chanCoords` information can be found in the `session.mat` file embedded in the
-    `extracellular` field.
-
-    Also, bear in mind that the `session.mat` file might contain information about the area where the extracellular
-    recording took place. This information is located in the `brainRegions` field.
-
-    In addition, the file `chanMap.mat` used by Kilosort is usually available on CellExplorer datasets.
-    The `chanMap.mat` can then be used to extract the electrode coordinates within the probe.
-    To my understanding, this file is generated for using kilosort, and therefore it is not available for all datasets.
-
+    Future versions of this interface will support the extraction of this metadata from these files.
     """
 
     sampling_frequency_key = "sr"
@@ -145,9 +224,9 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
         session_data_file_path = self.folder_path / f"{self.session}.session.mat"
         assert session_data_file_path.is_file(), f"File {session_data_file_path} does not exist"
 
-        ignore_fields = ["animal", "behavioralTracking", "timeSeries", "spikeSorting", "epochs"]
         from pymatreader import read_mat
 
+        ignore_fields = ["animal", "behavioralTracking", "timeSeries", "spikeSorting", "epochs"]
         session_data = read_mat(filename=session_data_file_path, ignore_fields=ignore_fields)["session"]
         extracellular_data = session_data["extracellular"]
         num_channels = int(extracellular_data["nChannels"])
@@ -188,10 +267,11 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
             self.recording_extractor = dummy_recording
             self.recording_extractor.set_channel_gains(channel_ids=channel_ids, gains=np.ones(num_channels) * gain)
 
-        self.recording_extractor = add_ecephys_metadata_to_recorder_from_session(
+        self.recording_extractor = add_channel_metadata_to_recorder_from_session_file(
             recording_extractor=self.recording_extractor, session_path=self.folder_path
         )
-        self.recording_extractor = add_ecephys_metadata_to_recorder_from_channel_map(
+
+        self.recording_extractor = add_channel_metadata_to_recorder_from_channel_map_file(
             recording_extractor=self.recording_extractor, session_path=self.folder_path
         )
 

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -21,17 +21,17 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
     * Gains for both raw data (held in a file named session.dat) and lfp (located in session.lfp)
     * Dtype for both raw data and lfp.
 
-    Here's a link to the documentation detailing the file's structure:
+    Link to the documentation detailing the file's structure:
     https://cellexplorer.org/datastructure/data-structure-and-format/#session-metadata
 
     This metadata is sufficient to build a memmap, which in turn should make straigthfoward to build a recording
     extractor.  If we encounter more conversion projects involving CellExplorer data, we should do this.
-    This interface then will seve as a steping stone to this long-term and more robust solution.
+    This interface then will serve as a steping stone to this long-term and more robust solution.
 
     In the meantime, the interface is intended for use in adding electrode metadata during a conversion,
     specifically when using `write_electrical_series=False` as a conversion option.
 
-    In its current form, the `chanMap.ma`t file is employed to extract the electrode coordinates within the probe.
+    In its current form, the `chanMap.mat` file is employed to extract the electrode coordinates within the probe.
     To my understanding, this file is generated for using kilosort, and it is not granted that it will
     be universally available for all future conversion projects. Ideally, the format should also contain
     files for channel info and channel coordinates, although these are absent in the current conversion:
@@ -122,7 +122,7 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
 
         hdf5storage = get_package(package_name="hdf5storage")
 
-        # Temporary hack untill spkeinterface next release
+        # Temporary hack until spkeinterface next release
         file_path = Path(file_path)
         new_cell_explorer_format = "spikes.cellinfo.mat" in file_path.name
         sampling_frequency = None

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -56,16 +56,14 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
 
         from pymatreader import read_mat
 
-        session_data = read_mat(session_data_file_path)["session"]
-        import h5py
-
-        file = h5py.File(session_data_file_path, "r")
+        ignore_fields = ["animal", "behavioralTracking", "timeSeries", "spikeSorting", "epochs"]
+        session_data = read_mat(filename=session_data_file_path, ignore_fields=ignore_fields)["session"]
 
         extracellular_data = session_data["extracellular"]
 
-        num_channels = extracellular_data["nChannels"]
+        num_channels = int(extracellular_data["nChannels"])
         sampling_frequency = extracellular_data["sr"]
-        gain = extracellular_data["leastSignificantBit"]  # 0.195
+        gain = float(extracellular_data["leastSignificantBit"])  # 0.195
         gains_to_uv = np.ones(num_channels) * gain
         dtype = extracellular_data["precision"]
         # sampilng_frequency_lfp = extracellular_data["srLfp"]  # TODO: Add another LFP interface when writing series

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/requirements.txt
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/requirements.txt
@@ -1,1 +1,2 @@
 hdf5storage>=0.1.18
+pymatreader>=0.0.30

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -276,7 +276,9 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
 
         if recording.get_num_segments() == 1:
             # Spikeinterface behavior is to load the electrode table channel_name property as a channel_id
-            nwb_recording = NwbRecordingExtractor(file_path=nwbfile_path, electrical_series_name=electrical_series_name)
+            self.nwb_recording = NwbRecordingExtractor(
+                file_path=nwbfile_path, electrical_series_name=electrical_series_name
+            )
             if "channel_name" in recording.get_property_keys():
                 renamed_channel_ids = recording.get_property("channel_name")
             else:
@@ -288,10 +290,10 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
             # Edge case that only occurs in testing, but should eventually be fixed nonetheless
             # The NwbRecordingExtractor on spikeinterface experiences an issue when duplicated channel_ids
             # are specified, which occurs during check_recordings_equal when there is only one channel
-            if nwb_recording.get_channel_ids()[0] != nwb_recording.get_channel_ids()[-1]:
-                check_recordings_equal(RX1=recording, RX2=nwb_recording, return_scaled=False)
-                if recording.has_scaled_traces() and nwb_recording.has_scaled_traces():
-                    check_recordings_equal(RX1=recording, RX2=nwb_recording, return_scaled=True)
+            if self.nwb_recording.get_channel_ids()[0] != self.nwb_recording.get_channel_ids()[-1]:
+                check_recordings_equal(RX1=recording, RX2=self.nwb_recording, return_scaled=False)
+                if recording.has_scaled_traces() and self.nwb_recording.has_scaled_traces():
+                    check_recordings_equal(RX1=recording, RX2=self.nwb_recording, return_scaled=True)
 
     def check_interface_set_aligned_timestamps(self):
         self.setUpFreshInterface()

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -112,7 +112,7 @@ class DataInterfaceTestMixin:
                 self.check_metadata_schema_valid()
                 self.check_conversion_options_schema_valid()
                 self.check_metadata()
-                self.nwbfile_path = str(self.save_directory / f"{self.__name__}_{num}.nwb")
+                self.nwbfile_path = str(self.save_directory / f"{self.__class__.__name__}_{num}.nwb")
                 self.run_conversion(nwbfile_path=self.nwbfile_path)
                 self.check_read_nwb(nwbfile_path=self.nwbfile_path)
 

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -112,7 +112,7 @@ class DataInterfaceTestMixin:
                 self.check_metadata_schema_valid()
                 self.check_conversion_options_schema_valid()
                 self.check_metadata()
-                self.nwbfile_path = str(self.save_directory / f"{self.data_interface_cls.__name__}_{num}.nwb")
+                self.nwbfile_path = str(self.save_directory / f"{self.__name__}_{num}.nwb")
                 self.run_conversion(nwbfile_path=self.nwbfile_path)
                 self.check_read_nwb(nwbfile_path=self.nwbfile_path)
 

--- a/tests/test_on_data/test_recording_interfaces.py
+++ b/tests/test_on_data/test_recording_interfaces.py
@@ -117,7 +117,7 @@ class TestCellExplorerRecordingInterface(RecordingExtractorInterfaceTestMixin, T
                 self.case = num
                 self.test_kwargs = kwargs
                 self.interface = self.data_interface_cls(**self.test_kwargs)
-                self.nwbfile_path = str(self.save_directory / f"{self.data_interface_cls.__name__}_{num}.nwb")
+                self.nwbfile_path = str(self.save_directory / f"{self.data_interface_cls.__name__}_{num}_channel.nwb")
 
                 metadata = self.interface.get_metadata()
                 metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())

--- a/tests/test_on_data/test_recording_interfaces.py
+++ b/tests/test_on_data/test_recording_interfaces.py
@@ -127,7 +127,7 @@ class TestCellExplorerRecordingInterface(RecordingExtractorInterfaceTestMixin, T
                     metadata=metadata,
                 )
 
-                # Test addition to recording extrator
+                # Test addition to recording extractor
                 recording_extractor = self.interface.recording_extractor
                 for key, expected_value in expected_channel_properties_recorder.items():
                     extracted_value = recording_extractor.get_channel_property(channel_id=channel_id, key=key)

--- a/tests/test_on_data/test_recording_interfaces.py
+++ b/tests/test_on_data/test_recording_interfaces.py
@@ -13,6 +13,7 @@ from neuroconv.datainterfaces import (
     BiocamRecordingInterface,
     BlackrockRecordingInterface,
     CEDRecordingInterface,
+    CellExplorerRecordingInterface,
     EDFRecordingInterface,
     IntanRecordingInterface,
     MaxOneRecordingInterface,
@@ -81,6 +82,17 @@ class TestBlackrockRecordingInterface(RecordingExtractorInterfaceTestMixin, Test
 class TestCEDRecordingInterface(RecordingExtractorInterfaceTestMixin, TestCase):
     data_interface_cls = CEDRecordingInterface
     interface_kwargs = dict(file_path=str(DATA_PATH / "spike2" / "m365_1sec.smrx"))
+    save_directory = OUTPUT_PATH
+
+
+class TestCellExplorerRecordingInterface(RecordingExtractorInterfaceTestMixin, TestCase):
+    data_interface_cls = CellExplorerRecordingInterface
+    interface_kwargs = [
+        dict(folder_path=str(DATA_PATH / "cellexplorer" / "dataset_4" / "Peter_MS22_180629_110319_concat_stubbed")),
+        dict(
+            folder_path=str(DATA_PATH / "cellexplorer" / "dataset_4" / "Peter_MS22_180629_110319_concat_stubbed_hdf5")
+        ),
+    ]
     save_directory = OUTPUT_PATH
 
 

--- a/tests/test_on_data/test_recording_interfaces.py
+++ b/tests/test_on_data/test_recording_interfaces.py
@@ -7,6 +7,7 @@ import jsonschema
 import numpy as np
 from hdmf.testing import TestCase
 from packaging import version
+from pynwb import NWBHDF5IO
 
 from neuroconv.datainterfaces import (
     AlphaOmegaRecordingInterface,
@@ -96,27 +97,52 @@ class TestCellExplorerRecordingInterface(RecordingExtractorInterfaceTestMixin, T
     ]
     save_directory = OUTPUT_PATH
 
-    def check_read(self, nwbfile_path):
-        super().check_read(nwbfile_path)
-
+    def test_add_channel_metadata_to_nwb(self):
         channel_id = "1"
-        expected_channel_properties = {
+        expected_channel_properties_recorder = {
             "location": np.array([791.5, -160.0]),
             "brain_area": "CA1 - Field CA1",
-            "group": "group5",
+            "group": "Group 5",
+        }
+        expected_channel_properties_electrodes = {
+            "rel_x": 791.5,
+            "rel_y": -160.0,
+            "location": "CA1 - Field CA1",
+            "group_name": "Group 5",
         }
 
-        # Test in memory
-        recording_extractor = self.interface.recording_extractor
-        for key, exp_value in expected_channel_properties.items():
-            extracted_value = recording_extractor.get_channel_property(channel_id=channel_id, key=key)
-            assert exp_value == extracted_value[0]
+        interface_kwargs = self.interface_kwargs
+        for num, kwargs in enumerate(interface_kwargs):
+            with self.subTest(str(num)):
+                self.case = num
+                self.test_kwargs = kwargs
+                self.interface = self.data_interface_cls(**self.test_kwargs)
+                self.nwbfile_path = str(self.save_directory / f"{self.data_interface_cls.__name__}_{num}.nwb")
 
-        # Test in nwb recording
-        recording_extractor = self.nwb_recording
-        for key, exp_value in expected_channel_properties.items():
-            extracted_value = recording_extractor.get_channel_property(channel_id=channel_id, key=key)
-            assert exp_value == extracted_value[0]
+                metadata = self.interface.get_metadata()
+                metadata["NWBFile"].update(session_start_time=datetime.now().astimezone())
+                self.interface.run_conversion(
+                    nwbfile_path=self.nwbfile_path,
+                    overwrite=True,
+                    metadata=metadata,
+                )
+
+                # Test addition to recording extrator
+                recording_extractor = self.interface.recording_extractor
+                for key, expected_value in expected_channel_properties_recorder.items():
+                    extracted_value = recording_extractor.get_channel_property(channel_id=channel_id, key=key)
+                    if key == "location":
+                        assert np.allclose(expected_value, extracted_value)
+                    else:
+                        assert expected_value == extracted_value
+
+                # Test addition to electrodes table
+                with NWBHDF5IO(self.nwbfile_path, "r") as io:
+                    nwbfile = io.read()
+                    electrode_table = nwbfile.electrodes.to_dataframe()
+                    electrode_table_row = electrode_table.query(f"channel_name=='{channel_id}'").iloc[0]
+                    for key, value in expected_channel_properties_electrodes.items():
+                        assert electrode_table_row[key] == value
 
 
 @skipIf(platform == "darwin", reason="Not supported for OSX.")

--- a/tests/test_on_data/test_recording_interfaces.py
+++ b/tests/test_on_data/test_recording_interfaces.py
@@ -4,6 +4,7 @@ from sys import platform
 from unittest import skip, skipIf
 
 import jsonschema
+import numpy as np
 from hdmf.testing import TestCase
 from packaging import version
 
@@ -94,6 +95,28 @@ class TestCellExplorerRecordingInterface(RecordingExtractorInterfaceTestMixin, T
         ),
     ]
     save_directory = OUTPUT_PATH
+
+    def check_read(self, nwbfile_path):
+        super().check_read(nwbfile_path)
+
+        channel_id = "1"
+        expected_channel_properties = {
+            "location": np.array([791.5, -160.0]),
+            "brain_area": "CA1 - Field CA1",
+            "group": "group5",
+        }
+
+        # Test in memory
+        recording_extractor = self.interface.recording_extractor
+        for key, exp_value in expected_channel_properties.items():
+            extracted_value = recording_extractor.get_channel_property(channel_id=channel_id, key=key)
+            assert exp_value == extracted_value[0]
+
+        # Test in nwb recording
+        recording_extractor = self.nwb_recording
+        for key, exp_value in expected_channel_properties.items():
+            extracted_value = recording_extractor.get_channel_property(channel_id=channel_id, key=key)
+            assert exp_value == extracted_value[0]
 
 
 @skipIf(platform == "darwin", reason="Not supported for OSX.")


### PR DESCRIPTION
OK, after working on https://github.com/catalystneuro/neuroconv/pull/488 I realized that we have already a Binary recorder that can be used directly to load the binary files. This, coupled with the information in the new `session.mat` of CellExplorer is all we need to build this extractor.

This should work for both adding the metadata and also the raw data and lfp for which we usually use the Neuroscope interface so we don't need to duplicate interfaces:

![image](https://github.com/catalystneuro/neuroconv/assets/6429509/806132f6-a668-411f-be4a-46f98f098abc)

