### PR TITLE
Avoid redundant timestamp creation in `add_electrical_series` for recording objects without time vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * Split `align_timestamps` and `align_starting_times` into `align_segment_timestamps` and `align_segment_starting_times` for API consistency for multi-segment `RecordingInterface`s. [PR #463](https://github.com/catalystneuro/neuroconv/pull/463)
 * Rename `align_timestamps` and `align_segmentt_timestamps` into `set_aligned_timestamps` and `set_aligned_segment_timestamps` to more clearly indicate their usage and behavior. [PR #470](https://github.com/catalystneuro/neuroconv/pull/470)
 * `CellExplorerRecordingInterface` now supports the extacting sampling frequency from new format [PR #491](https://github.com/catalystneuro/neuroconv/pull/491)
+* Avoid redundant timestamp creation in `add_eletrical_series`` for recording objects without time vector [PR #495](https://github.com/catalystneuro/neuroconv/pull/495)
 
 ### Testing
 * The tests for `automatic_dandi_upload` now follow up-to-date DANDI validation rules for file name conventions. [PR #310](https://github.com/catalystneuro/neuroconv/pull/310)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 
 
+### Improvements
+
+* Avoid redundant timestamp creation in `add_eletrical_series`` for recording objects without time vector [PR #495](https://github.com/catalystneuro/neuroconv/pull/495)
+
+
+
 # v0.3.0 (June 7, 2023)
 
 ### Back-compatibility break
@@ -64,7 +70,6 @@
 * Split `align_timestamps` and `align_starting_times` into `align_segment_timestamps` and `align_segment_starting_times` for API consistency for multi-segment `RecordingInterface`s. [PR #463](https://github.com/catalystneuro/neuroconv/pull/463)
 * Rename `align_timestamps` and `align_segmentt_timestamps` into `set_aligned_timestamps` and `set_aligned_segment_timestamps` to more clearly indicate their usage and behavior. [PR #470](https://github.com/catalystneuro/neuroconv/pull/470)
 * `CellExplorerRecordingInterface` now supports the extacting sampling frequency from new format [PR #491](https://github.com/catalystneuro/neuroconv/pull/491)
-* Avoid redundant timestamp creation in `add_eletrical_series`` for recording objects without time vector [PR #495](https://github.com/catalystneuro/neuroconv/pull/495)
 
 ### Testing
 * The tests for `automatic_dandi_upload` now follow up-to-date DANDI validation rules for file name conventions. [PR #310](https://github.com/catalystneuro/neuroconv/pull/310)

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -656,18 +656,27 @@ def add_electrical_series(
         data=H5DataIO(data=ephys_data_iterator, compression=compression, compression_opts=compression_opts)
     )
 
-    # Timestamps vs rate
-    timestamps = recording.get_times(segment_index=segment_index)
-    rate = calculate_regular_series_rate(series=timestamps)  # Returns None if it is not regular
-    starting_time = starting_time if starting_time is not None else 0
+    # Now we decide whether to store the timestamps as a regular series or as an irregular series.
+    if recording.has_time_vector(segment_index=segment_index):
+        # First we check if the recording has a a time vector to avoid creating artificial timestamps
+        timestamps = recording.get_times(segment_index=segment_index)
+        rate = calculate_regular_series_rate(series=timestamps)  # Returns None if it is not regular
+        recording_t_start = timestamps[0]
+    else:
+        rate = recording.get_sampling_frequency()
+        recording_t_start = recording._recording_segments[segment_index].t_start
+        recording_t_start = 0 if recording_t_start is None else recording_t_start
 
+    starting_time = starting_time if starting_time is not None else 0
     if rate:
-        starting_time = starting_time + timestamps[0]
+        starting_time = float(starting_time + recording_t_start)
+        # Note that we call the sampling frequency again because the estimated rate might be different from the
+        # sampling frequency of the recording extractor by some epsilon.
         eseries_kwargs.update(starting_time=starting_time, rate=recording.get_sampling_frequency())
     else:
-        shifted_time_stamps = starting_time + timestamps
+        shifted_timestamps = starting_time + timestamps
         wrapped_timestamps = H5DataIO(
-            data=shifted_time_stamps, compression=compression, compression_opts=compression_opts
+            data=shifted_timestamps, compression=compression, compression_opts=compression_opts
         )
         eseries_kwargs.update(timestamps=wrapped_timestamps)
 

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -664,8 +664,7 @@ def add_electrical_series(
         recording_t_start = timestamps[0]
     else:
         rate = recording.get_sampling_frequency()
-        recording_t_start = recording._recording_segments[segment_index].t_start
-        recording_t_start = 0 if recording_t_start is None else recording_t_start
+        recording_t_start = recording._recording_segments[segment_index].t_start or 0
 
     starting_time = starting_time if starting_time is not None else 0
     if rate:


### PR DESCRIPTION
I have a memory overflow error that is killing my full conversion for some sessions when working on this https://github.com/catalystneuro/buzsaki-lab-to-nwb/pull/66.

I am tracking down the issue and one of the things I noticed is that for very long-recordings extracting the timestamps in `add_electrical_series (to check if they are regular) create a large memory allocation. For example, for the 5 hours long recordings of some sessions the timestamps are ~ 2 GiB. We should avoid that if possible.

On the other hand, when the recording objects in spikeinterface do not have time vectors the call to `get_times` just creates artificial timestamps using the sampling rate which are regular by creation. As our interest is to check whether the timestamps are regular or not this is redundant and this is what this PR seek to avoid: when the recording segment has no time vector the check for regularity if skipped. 

