### PR TITLE
Add ecephys metadata to `CellExplorerSorting` through method

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
@@ -264,8 +264,8 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
             add_electrodes,
         )
 
-        if self.sorting_extractor.has_recording():
-            recording = self.sorting_extractor._recording
+        if hasattr(self, "generate_recording_with_channel_metadata"):
+            recording = self.generate_recording_with_channel_metadata()
         else:
             electrodes_metadata = metadata.get("Ecephys", dict()).get("Electrodes", list())
             if electrodes_metadata:

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -352,27 +352,15 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
 
         file_path = Path(file_path)
 
-        # Temporary hack to get sampling frequency from the spikes cellinfo file until next SI release.
-        import h5py
+        # Temporary hack to get sampling frequency from the spikes cellinfo file until next SI release
+        from pymatreader import read_mat
 
-        try:
-            matlab_file = scipy.io.loadmat(file_name=str(file_path), simplify_cells=True)
-            if "spikes" not in matlab_file.keys():
-                raise KeyError(f"CellExplorer file '{file_path}' does not contain 'spikes' field.")
-            spikes_mat = matlab_file["spikes"]
-            assert isinstance(spikes_mat, dict), f"field `spikes` must be a dict, not {type(spikes_mat)}!"
+        matlab_file = read_mat(file_path)
 
-        except NotImplementedError:
-            matlab_file = h5py.File(name=file_path, mode="r")
-            if "spikes" not in matlab_file.keys():
-                raise KeyError(f"CellExplorer file '{file_path}' does not contain 'spikes' field.")
-            spikes_mat = matlab_file["spikes"]
-            assert isinstance(spikes_mat, h5py.Group), f"field `spikes` must be a Group, not {type(spikes_mat)}!"
-
+        if "spikes" not in matlab_file.keys():
+            raise KeyError(f"CellExplorer file '{file_path}' does not contain 'spikes' field.")
+        spikes_mat = matlab_file["spikes"]
         sampling_frequency = spikes_mat.get("sr", None)
-        sampling_frequency = (
-            sampling_frequency[()] if isinstance(sampling_frequency, h5py.Dataset) else sampling_frequency
-        )
 
         super().__init__(spikes_matfile_path=file_path, sampling_frequency=sampling_frequency, verbose=verbose)
         self.source_data = dict(file_path=file_path)

--- a/tests/test_on_data/test_sorting_interfaces.py
+++ b/tests/test_on_data/test_sorting_interfaces.py
@@ -111,7 +111,7 @@ class TestCellEploreSortingInterface(SortingExtractorInterfaceTestMixin, TestCas
                 )
 
                 # Test that the registered recording has the ``
-                recording_extractor = self.interface.sorting_extractor._recording
+                recording_extractor = self.interface.generate_recording_with_channel_metadata()
                 for key, expected_value in expected_channel_properties_recorder.items():
                     extracted_value = recording_extractor.get_channel_property(channel_id=channel_id, key=key)
                     if key == "location":


### PR DESCRIPTION
This is another option to avoid the creation of an unecessary large time vector for the dummy sorting. 

This probably is telling that we need a lazy mechanism to handle timestamps in spikeinterface. I am thinking about how to do this.

Has #494 as a base. 
