### PR TITLE
[Bug] fix test schema definition

### DIFF
--- a/tests/test_on_data/test_recording_interfaces.py
+++ b/tests/test_on_data/test_recording_interfaces.py
@@ -475,7 +475,7 @@ class TestSpikeGLXRecordingInterface(RecordingExtractorInterfaceTestMixin, TestC
         spikeglx_electrode_table_schema = {
             "type": "array",
             "minItems": 0,
-            "items": {"$ref": "#definitions/SpikeGLXElectrodeColumnEntry"},
+            "items": {"$ref": "#/definitions/SpikeGLXElectrodeColumnEntry"},
             "definitions": {
                 "SpikeGLXElectrodeColumnEntry": {
                     "type": "object",


### PR DESCRIPTION
Daily CI just caught an error caused by the latest release of `jsonschema` (7 hours ago) finding a mistake in a test case

Should be simple fix