### PR TITLE
Use `ndx-probeinterface` to handle devices from SpikeInterface

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/requirements.txt
+++ b/src/neuroconv/datainterfaces/ecephys/requirements.txt
@@ -1,2 +1,3 @@
 spikeinterface>=0.98.2
+ndx-probeinterface>=0.1.0
 packaging<22.0

--- a/src/neuroconv/tools/probeinterface/__init__.py
+++ b/src/neuroconv/tools/probeinterface/__init__.py
@@ -1,0 +1,1 @@
+from .probeinterface import add_probe, add_probe_group

--- a/src/neuroconv/tools/probeinterface/probeinterface.py
+++ b/src/neuroconv/tools/probeinterface/probeinterface.py
@@ -1,0 +1,41 @@
+import ndx_probeinterface
+from probeinterface import Probe, ProbeGroup
+from pynwb.file import NWBFile
+
+from ...utils import DeepDict
+
+
+def add_probe(probe: Probe, nwbfile: NWBFile, metadata: DeepDict = None):
+    """Add a probe to an NWBFile.
+
+    Parameters
+    ----------
+    probe : Probe
+        Probe object to add to the NWBFile.
+    nwbfile : NWBFile
+        NWBFile to add the probe to.
+    metadata : dict, optional
+        Metadata to add to the probe, by default None
+    """
+    ndx_probes = ndx_probeinterface.Probe.from_probeinterface(probe)
+    ndx_probe = ndx_probes[0]
+    if ndx_probe.name not in nwbfile.devices:
+        nwbfile.add_device(ndx_probe)
+
+
+def add_probe_group(probe_group: ProbeGroup, nwbfile: NWBFile, metadata: DeepDict = None):
+    """Add a probe group to an NWBFile.
+
+    Parameters
+    ----------
+    probe_group : ProbeGroup
+        ProbeGroup object to add to the NWBFile.
+    nwbfile : NWBFile
+        NWBFile to add the probe to.
+    metadata : dict, optional
+        Metadata to add to the probe, by default None
+    """
+    ndx_probes = ndx_probeinterface.Probe.from_probeinterface(probe_group)
+    for ndx_probe in ndx_probes:
+        if ndx_probe.name not in nwbfile.devices:
+            nwbfile.add_device(ndx_probe)


### PR DESCRIPTION
Instead of adding a default Device, the `add_devices` in the `spikeinterface` tools, will add `ndx_probeinterface.Probe` devices, which is specific to `probeinterface` objects.

Still WIP, needs some polish on the extension side.


### TODO 
- [ ] Add tests