### PR TITLE
Pin ROIExtractors temporarily

### DIFF
--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -47,7 +47,7 @@ jobs:
   run-dev-tests:
     needs: assess-file-changes
     if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' }}
-    uses: catalystneuro/neuroconv/.github/workflows/dev-testing.yml@main
+    uses: catalystneuro/neuroconv/.github/workflows/dev-testing.yml@temporary_roiextractors_in
     secrets:
       DANDI_API_KEY: ${{ secrets.DANDI_API_KEY }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -47,7 +47,7 @@ jobs:
   run-dev-tests:
     needs: assess-file-changes
     if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' }}
-    uses: catalystneuro/neuroconv/.github/workflows/dev-testing.yml@temporary_roiextractors_in
+    uses: catalystneuro/neuroconv/.github/workflows/dev-testing.yml@temporary_roiextractors_pin
     secrets:
       DANDI_API_KEY: ${{ secrets.DANDI_API_KEY }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/dev-testing.yml
+++ b/.github/workflows/dev-testing.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Install full requirements (-e needed for codecov report)
         run: pip install -e .[full,test]
 
-
-      - name: Dev gallery - ROIExtractors
-        run: pip install git+https://github.com/CatalystNeuro/roiextractors@main
+      # TODO - remove this temporarily disabling when new Bruker interfaces are through
+      #- name: Dev gallery - ROIExtractors
+      #  run: pip install git+https://github.com/CatalystNeuro/roiextractors@main
       - name: Dev gallery - PyNWB
         run: pip install git+https://github.com/NeurodataWithoutBorders/pynwb@dev
       - name: Dev gallery - SpikeInterface

--- a/src/neuroconv/datainterfaces/ophys/requirements.txt
+++ b/src/neuroconv/datainterfaces/ophys/requirements.txt
@@ -1,1 +1,1 @@
-roiextractors>=0.5.3
+roiextractors==0.5.3


### PR DESCRIPTION
Latest release of ROIExtractors split the BrukerTifExtractor into distinct categories (multi-channel, multi-plane, volumetric) that can't be automatically routed through a common class; so the current interface only works using the previous version of ROIExtractors

https://github.com/catalystneuro/neuroconv/pull/507 will loosen this pin as a part of its expansion