### PR TITLE
Improve sonpy installation for M1 Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # (Upcoming)
 
+### Fixes
+
+* The `sonpy` package for the Spike2 interface no longer attempts installation on M1 Macs. [PR #563](https://github.com/catalystneuro/neuroconv/pull/563)
+
 
 
 # v0.4.2

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import sys
+import platform
 from collections import defaultdict
 from pathlib import Path
 from shutil import copy
@@ -46,7 +48,7 @@ if not gin_config_file_local.exists():
     copy(src=gin_config_file_base, dst=gin_config_file_local)
 
 # Bug related to sonpy on M1 Mac being installed but not running properly
-if sys.platform == "darwin" and processor() == "arm":
+if sys.platform == "darwin" and platform.processor() == "arm":
     extras_require.pop("sonpy")
     extras_require["ecephys"].remove(
         next(requirement for requirement in extras_require["sonpy"] if "sonpy" in requirement)

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,12 @@ gin_config_file_local = Path("./tests/test_on_data/gin_test_config.json")
 if not gin_config_file_local.exists():
     copy(src=gin_config_file_base, dst=gin_config_file_local)
 
+# Bug related to sonpy on M1 Mac being installed but not running properly
+if sys.platform == "darwin" and processor() == "arm":
+    extras_require.pop("sonpy")
+    extras_require["ecephys"].remove(next(requirement for requirement in extras_require["sonpy"] if "sonpy" in requirement))
+    extras_require["full"].remove(next(requirement for requirement in extras_require["sonpy"] if "sonpy" in requirement))
+
 setup(
     name="neuroconv",
     version="0.4.3",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-import sys
 import platform
+import sys
 from collections import defaultdict
 from pathlib import Path
 from shutil import copy

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,12 @@ if not gin_config_file_local.exists():
 # Bug related to sonpy on M1 Mac being installed but not running properly
 if sys.platform == "darwin" and processor() == "arm":
     extras_require.pop("sonpy")
-    extras_require["ecephys"].remove(next(requirement for requirement in extras_require["sonpy"] if "sonpy" in requirement))
-    extras_require["full"].remove(next(requirement for requirement in extras_require["sonpy"] if "sonpy" in requirement))
+    extras_require["ecephys"].remove(
+        next(requirement for requirement in extras_require["sonpy"] if "sonpy" in requirement)
+    )
+    extras_require["full"].remove(
+        next(requirement for requirement in extras_require["sonpy"] if "sonpy" in requirement)
+    )
 
 setup(
     name="neuroconv",

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,7 @@ if sys.platform == "darwin" and platform.processor() == "arm":
     extras_require["ecephys"].remove(
         next(requirement for requirement in extras_require["ecephys"] if "sonpy" in requirement)
     )
-    extras_require["full"].remove(
-        next(requirement for requirement in extras_require["full"] if "sonpy" in requirement)
-    )
+    extras_require["full"].remove(next(requirement for requirement in extras_require["full"] if "sonpy" in requirement))
 
 setup(
     name="neuroconv",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ if not gin_config_file_local.exists():
 
 # Bug related to sonpy on M1 Mac being installed but not running properly
 if sys.platform == "darwin" and platform.processor() == "arm":
-    extras_require.pop("sonpy")
+    extras_require.pop("spike2")
     extras_require["ecephys"].remove(
         next(requirement for requirement in extras_require["sonpy"] if "sonpy" in requirement)
     )

--- a/setup.py
+++ b/setup.py
@@ -50,11 +50,12 @@ if not gin_config_file_local.exists():
 # Bug related to sonpy on M1 Mac being installed but not running properly
 if sys.platform == "darwin" and platform.processor() == "arm":
     extras_require.pop("spike2")
+
     extras_require["ecephys"].remove(
-        next(requirement for requirement in extras_require["sonpy"] if "sonpy" in requirement)
+        next(requirement for requirement in extras_require["ecephys"] if "sonpy" in requirement)
     )
     extras_require["full"].remove(
-        next(requirement for requirement in extras_require["sonpy"] if "sonpy" in requirement)
+        next(requirement for requirement in extras_require["full"] if "sonpy" in requirement)
     )
 
 setup(

--- a/src/neuroconv/datainterfaces/ecephys/spike2/spike2datainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spike2/spike2datainterface.py
@@ -10,7 +10,7 @@ def _test_sonpy_installation() -> None:
     get_package(
         package_name="sonpy",
         excluded_python_versions=["3.10", "3.11"],
-        excluded_platforms_and_python_versions=dict(darwin=["3.7"]),
+        excluded_platforms_and_python_versions=dict(darwin=dict(arm=["3.8", "3.9", "3.10", "3.11"])),
     )
 
 

--- a/src/neuroconv/tools/importing.py
+++ b/src/neuroconv/tools/importing.py
@@ -35,11 +35,20 @@ def get_package(
         use the 'excluded_platforms_and_python_versions' keyword argument instead.
         Allows all Python versions by default.
     excluded_platforms_and_python_versions : dict, optional
-        mapping string platform names to a list of string versions. In case some combinations of platforms or Python
-        versions are not allowed for the given package, specify this dictionary to raise a more specific error to
-        that issue. For example, `excluded_platforms_and_python_versions = dict(darwin=["3.7"])` will raise an
-        informative error when running on MacOS with Python version 3.7. Allows all platforms and Python versions by
-        default.
+        Mapping of string platform names to a list of string versions.
+        Valid platform strings are: ["linux", "win32", "darwin"] or any other variant used by sys.platform
+
+        In case some combinations of platforms or Python versions are not allowed for the given package,
+        specify this dictionary to raise a more specific error to that issue.
+
+        For example, `excluded_platforms_and_python_versions = dict(darwin=["3.7"])` will raise an
+        informative error when running on MacOS with Python version 3.7.
+
+        This also applies to specific architectures of platforms, such as
+        `excluded_platforms_and_python_versions = dict(darwin=dict(arm=["3.7"]))` to exclude a specific Python
+        version for M1 Macs.
+
+        Allows all platforms and Python versions by default.
 
     Raises
     ------


### PR DESCRIPTION
As discovered by @rly on https://github.com/NeurodataWithoutBorders/nwb-guide/issues/354, despite the fact that neuroconv as a package works fine due to our previous lazy interface + exclusion principles at the interface level, it still attempts to install it (even seems to grab some files from the PyPI package) but fails at a point during the environment build process

This excludes it entirely from being bundled with NeuroConv in this situation

Also some docstring improvements

Unfortunately no way to test this in CI