### PR TITLE
Fix `subset_sorting` behavior by explicitly casting non-integer `end_frame` to int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 * The `sonpy` package for the Spike2 interface no longer attempts installation on M1 Macs. [PR #563](https://github.com/catalystneuro/neuroconv/pull/563)
+* Fixed `subset_sorting` to explicitly cast `end_frame` to int to avoid SpikeInterface frame slicing edge case. [PR #565](https://github.com/catalystneuro/neuroconv/pull/565)
 
 
 

--- a/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
@@ -222,7 +222,7 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
                 if any(x)
             ]
         )
-        end_frame = 1.1 * max_min_spike_time
+        end_frame = int(1.1 * max_min_spike_time)
         if self.sorting_extractor.has_recording():
             end_frame = min(end_frame, self.sorting_extractor._recording.get_total_samples())
         stub_sorting_extractor = self.sorting_extractor.frame_slice(start_frame=0, end_frame=end_frame)


### PR DESCRIPTION
Again related to the multiplication by 1.1 in `subset_sorting` in [this line](https://github.com/catalystneuro/neuroconv/blob/main/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py#L225). The resulting `end_frame` can be a non-integer. In SpikeInterface, non-integer `end_frame`s are truncated to int in `FrameSliceRecording` [here](https://github.com/SpikeInterface/spikeinterface/blob/main/src/spikeinterface/core/frameslicerecording.py#L54) but left unchanged in `FrameSliceSorting` [here](https://github.com/SpikeInterface/spikeinterface/blob/main/src/spikeinterface/core/frameslicesorting.py#L79). Since data are sliced based on frames being `< end_frame`, this means the recording excludes `int(end_frame)` while the sorting includes `int(end_frame)`. Only a problem if there also happens to be a spike on `int(end_frame)` so probably a very rare issue, I guess I'm unlucky...

Fixed here just by casting to int beforehand.