### PR TITLE
Daily email notification for failures

### DIFF
--- a/.github/workflows/dailies.yml
+++ b/.github/workflows/dailies.yml
@@ -9,6 +9,10 @@ jobs:
 
   run-daily-tests:
     uses: catalystneuro/neuroconv/.github/workflows/testing.yml@main
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      S3_GIN_BUCKET: ${{ secrets.S3_GIN_BUCKET }}
 
   run-daily-doc-link-checks:
     uses: catalystneuro/neuroconv/.github/workflows/test-external-links.yml@main

--- a/.github/workflows/dailies.yml
+++ b/.github/workflows/dailies.yml
@@ -1,0 +1,30 @@
+name: Daily workflows
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 16 * * *"  # Daily at noon EST
+
+jobs:
+
+  run-daily-tests:
+    uses: catalystneuro/neuroconv/.github/workflows/testing.yml@main
+
+  run-daily-doc-link-checks:
+    uses: catalystneuro/neuroconv/.github/workflows/test-external-links.yml@main
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: [run-daily-tests, run-daily-doc-link-checks]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    steps:
+    - uses: dawidd6/action-send-mail@v3
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465  # TSL
+        username: ${{ secrets.MAIL_USERNAME }}
+        password: ${{ secrets.MAIL_PASSWORD }}
+        subject: NeuroConv Daily Failure
+        to: ${{ secrets.DAILY_FAILURE_EMAIL_LIST }}  # add more with commas, no separation
+        from: NeuroConv
+        body: "The daily workflow for the NWB Inspector failed: please check status at https://github.com/catalystneuro/neuroconv/actions/workflows/dailies.yml"

--- a/.github/workflows/test-external-links.yml
+++ b/.github/workflows/test-external-links.yml
@@ -2,6 +2,7 @@ name: Testing External Links
 on:
   pull_request:
   merge_group:
+  workflow_call:
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Turns out I haven't been getting the native GitHub notifications for daily failures, similar to what happened on the NWB Inspector a while back

This should fix it

Happy to add anyone else that wants to the email list