### PR TITLE
[Bug] Split tables requirements across versions

### DIFF
--- a/src/neuroconv/datainterfaces/behavior/deeplabcut/requirements.txt
+++ b/src/neuroconv/datainterfaces/behavior/deeplabcut/requirements.txt
@@ -1,3 +1,3 @@
 dlc2nwb>=0.3
-tables<2.8.0;python_version<'3.9'  # imported by package but not included in pip setup (is included in setup.cfg)
+tables<3.9.0;python_version<'3.9'  # imported by package but not included in pip setup (is included in setup.cfg)
 tables;python_version>='3.9'

--- a/src/neuroconv/datainterfaces/behavior/deeplabcut/requirements.txt
+++ b/src/neuroconv/datainterfaces/behavior/deeplabcut/requirements.txt
@@ -1,2 +1,3 @@
 dlc2nwb>=0.3
-tables  # imported by package but not included in pip setup (is included in setup.cfg)
+tables<2.8.0;python_version<'3.9'  # imported by package but not included in pip setup (is included in setup.cfg)
+tables;python_version>='3.9'


### PR DESCRIPTION
Tests on `main` failed yesterday due to a new release of https://pypi.org/project/tables/#history which causes a dependency conflict with blosc2 on Python 3.8