### PR TITLE
Add complete session start time to FicTrac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # (Upcoming)
+
+### Features
+Addedd `session_start_time` extraction to `FicTracDataInterface`. [PR #598](https://github.com/catalystneuro/neuroconv/pull/598)
+
+
 ### Fixes
 Remove `starting_time` reset to default value (0.0) when adding the rate and updating the `photon_series_kwargs` or `roi_response_series_kwargs`, in `add_photon_series` or `add_fluorescence_traces`. [PR #595](https://github.com/catalystneuro/neuroconv/pull/595)
 
-### Fixes
-
 * Changed the date parsing in `OpenEphysLegacyRecordingInterface` to `datetime.strptime` with the expected date format explicitly set to `"%d-%b-%Y %H%M%S"`. [PR #577](https://github.com/catalystneuro/neuroconv/pull/577)
 * Pin lower bound HDMF version to `3.10.0`. [PR #586](https://github.com/catalystneuro/neuroconv/pull/586)
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # (Upcoming)
 
 ### Features
-Addedd `session_start_time` extraction to `FicTracDataInterface`. [PR #598](https://github.com/catalystneuro/neuroconv/pull/598)
+Added `session_start_time` extraction to `FicTracDataInterface`. [PR #598](https://github.com/catalystneuro/neuroconv/pull/598)
 
 
 ### Fixes

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -2,7 +2,11 @@ import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
-from zoneinfo import ZoneInfo
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 from pynwb.behavior import CompassDirection, SpatialSeries
 from pynwb.file import NWBFile
@@ -102,7 +106,7 @@ class FicTracDataInterface(BaseDataInterface):
 
         import pandas as pd
 
-        # The first row only contains the session start time and unvalid data
+        # The first row only contains the session start time and invalid data
         fictrac_data_df = pd.read_csv(self.file_path, sep=",", skiprows=1, header=None, names=self.data_columns)
 
         # Get the timestamps

--- a/src/neuroconv/datainterfaces/behavior/fictrac/requirements.txt
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/requirements.txt
@@ -1,0 +1,1 @@
+backports.zoneinfo;python_version<"3.9"

--- a/src/neuroconv/datainterfaces/behavior/fictrac/requirements.txt
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/requirements.txt
@@ -1,1 +1,0 @@
-backports.zoneinfo;python_version<"3.9"

--- a/tests/test_on_data/test_behavior_interfaces.py
+++ b/tests/test_on_data/test_behavior_interfaces.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import numpy as np
 from natsort import natsorted
@@ -36,6 +37,10 @@ class TestFicTracDataInterface(DataInterfaceTestMixin, unittest.TestCase):
     ]
 
     save_directory = OUTPUT_PATH
+
+    def check_extracted_metadata(self, metadata: dict):
+        expected_session_start_time = datetime(2023, 7, 24, 9, 30, 55, 440600, tzinfo=ZoneInfo("UTC"))
+        assert metadata["NWBFile"]["session_start_time"] == expected_session_start_time
 
 
 class TestVideoInterface(VideoInterfaceMixin, unittest.TestCase):

--- a/tests/test_on_data/test_behavior_interfaces.py
+++ b/tests/test_on_data/test_behavior_interfaces.py
@@ -1,7 +1,6 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
-from zoneinfo import ZoneInfo
 
 import numpy as np
 from natsort import natsorted
@@ -39,7 +38,7 @@ class TestFicTracDataInterface(DataInterfaceTestMixin, unittest.TestCase):
     save_directory = OUTPUT_PATH
 
     def check_extracted_metadata(self, metadata: dict):
-        expected_session_start_time = datetime(2023, 7, 24, 9, 30, 55, 440600, tzinfo=ZoneInfo("UTC"))
+        expected_session_start_time = datetime(2023, 7, 24, 9, 30, 55, 440600, tzinfo=timezone.utc)
         assert metadata["NWBFile"]["session_start_time"] == expected_session_start_time
 
 


### PR DESCRIPTION
When working on the Clandining conversion I realized that the first line of the data header has non-valid values save the timestamp. The timestamp is the unix time epoch in milliseconds which can be used to extract a more complete `session_start_time` as previously we were extracting only the date.

I did some other improvements to the code like adding `starting_time` when they are not zero which were not done before. 