### PR TITLE
Support adding data in meters in `FicTracDataInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 ### Features
 * Added `session_start_time` extraction to `FicTracDataInterface`. [PR #598](https://github.com/catalystneuro/neuroconv/pull/598)
 * Added `imaging_plane_name` keyword argument to `add_imaging_plane` function to determine which imaging plane to add from the metadata by name instead of `imaging_plane_index`.
-  Added reference for `imaging_plane` to default plane segmentation metadata. [PR #594](https://github.com/catalystneuro/neuroconv/pull/594)
+* Added reference for `imaging_plane` to default plane segmentation metadata. [PR #594](https://github.com/catalystneuro/neuroconv/pull/594)
+* Changed Compass container for Position container in the `FicTracDataInterface`.  [PR #605](https://github.com/catalystneuro/neuroconv/pull/605)
+* Added option to write units in meters by providing a radius in `FicTracDataInterface`. [PR #605](https://github.com/catalystneuro/neuroconv/pull/605)
 
 ### Fixes
 * Remove `starting_time` reset to default value (0.0) when adding the rate and updating the `photon_series_kwargs` or `roi_response_series_kwargs`, in `add_photon_series` or `add_fluorescence_traces`. [PR #595](https://github.com/catalystneuro/neuroconv/pull/595)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 * Added `session_start_time` extraction to `FicTracDataInterface`. [PR #598](https://github.com/catalystneuro/neuroconv/pull/598)
 * Added `imaging_plane_name` keyword argument to `add_imaging_plane` function to determine which imaging plane to add from the metadata by name instead of `imaging_plane_index`.
 * Added reference for `imaging_plane` to default plane segmentation metadata. [PR #594](https://github.com/catalystneuro/neuroconv/pull/594)
-* Changed Compass container for Position container in the `FicTracDataInterface`.  [PR #605](https://github.com/catalystneuro/neuroconv/pull/605)
-* Added option to write units in meters by providing a radius in `FicTracDataInterface`. [PR #605](https://github.com/catalystneuro/neuroconv/pull/605)
+* Changed Compass container for Position container in the `FicTracDataInterface`.  [PR #606](https://github.com/catalystneuro/neuroconv/pull/605)
+* Added option to write units in meters by providing a radius in `FicTracDataInterface`. [PR #606](https://github.com/catalystneuro/neuroconv/pull/605)
 
 ### Fixes
 * Remove `starting_time` reset to default value (0.0) when adding the rate and updating the `photon_series_kwargs` or `roi_response_series_kwargs`, in `add_photon_series` or `add_fluorescence_traces`. [PR #595](https://github.com/catalystneuro/neuroconv/pull/595)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Features
 
 * Added Pydantic data models of `DatasetInfo` (immutable summary of core dataset values such as maximum shape and dtype) and `DatasetConfiguration` for both HDF5 and Zarr datasets (the optional layer that specifies chunk/buffering/compression). [PR #567](https://github.com/catalystneuro/neuroconv/pull/567)
+* Added alignment methods to `FicTracDataInterface`.  [PR #607](https://github.com/catalystneuro/neuroconv/pull/607)
 
 ### Fixes
 

--- a/docs/conversion_examples_gallery/behavior/fictrac.rst
+++ b/docs/conversion_examples_gallery/behavior/fictrac.rst
@@ -20,9 +20,5 @@ Convert FicTrac pose estimation data to NWB using :py:class:`~neuroconv.datainte
 
     >>> interface = FicTracDataInterface(file_path=file_path, verbose=False)
 
-    >>> metadata = interface.get_metadata()
-    >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=tz.gettz("US/Pacific"))
-    >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> interface.run_conversion(nwbfile_path=path_to_save_nwbfile, metadata=metadata)

--- a/docs/conversion_examples_gallery/behavior/fictrac.rst
+++ b/docs/conversion_examples_gallery/behavior/fictrac.rst
@@ -18,7 +18,15 @@ Convert FicTrac pose estimation data to NWB using :py:class:`~neuroconv.datainte
 
     >>> file_path = BEHAVIOR_DATA_PATH / "FicTrac" / "sample" / "sample-20230724_113055.dat"
 
-    >>> interface = FicTracDataInterface(file_path=file_path, verbose=False)
+    >>> radius = 0.035  # If you have the radius of the ball (in meters), you can pass it to the interface and the data will be saved in meters
+    >>> interface = FicTracDataInterface(file_path=file_path, radius=radius, verbose=False)
 
+    >>> # Extract what metadata we can from the source files
+    >>> metadata = interface.get_metadata()
+    >>> # For data provenance we add the time zone information to the conversion
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=tz.gettz("US/Pacific"))
+    >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+
+    >>> # For data provenance we add the time zone information to the conversion
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> interface.run_conversion(nwbfile_path=path_to_save_nwbfile, metadata=metadata)

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -54,7 +54,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
 
     column_to_nwb_mapping = spatial_series_descriptions = {
         "rotation_delta_cam": {
-            "columns_in_dat_file": ["rotation_delta_x_cam", "rotation_delta_y_cam", "rotation_delta_z_cam"],
+            "column_in_dat_file": ["rotation_delta_x_cam", "rotation_delta_y_cam", "rotation_delta_z_cam"],
             "spatial_series_name": "SpatialSeriesRotationDeltaCameraFrame",
             "description": (
                 "Change in orientation since last frame from the camera's perspective. "
@@ -65,7 +65,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
             "reference_frame": "camera",
         },
         "rotation_delta_lab": {
-            "columns_in_dat_file": ["rotation_delta_x_lab", "rotation_delta_y_lab", "rotation_delta_z_lab"],
+            "column_in_dat_file": ["rotation_delta_x_lab", "rotation_delta_y_lab", "rotation_delta_z_lab"],
             "spatial_series_name": "SpatialSeriesRotationDeltaLabFrame",
             "description": (
                 "Change in orientation since last frame from the lab's perspective. "
@@ -76,7 +76,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
             "reference_frame": "lab",
         },
         "rotation_cam": {
-            "columns_in_dat_file": ["rotation_x_cam", "rotation_y_cam", "rotation_z_cam"],
+            "column_in_dat_file": ["rotation_x_cam", "rotation_y_cam", "rotation_z_cam"],
             "spatial_series_name": "SpatialSeriesRotationCameraFrame",
             "description": (
                 "Orientation in radians from the camera's perspective. "
@@ -87,7 +87,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
             "reference_frame": "camera",
         },
         "rotation_lab": {
-            "columns_in_dat_file": ["rotation_x_lab", "rotation_y_lab", "rotation_z_lab"],
+            "column_in_dat_file": ["rotation_x_lab", "rotation_y_lab", "rotation_z_lab"],
             "spatial_series_name": "SpatialSeriesRotationLabFrame",
             "description": (
                 "Orientation in radians from the lab's perspective. "
@@ -98,13 +98,13 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
             "reference_frame": "lab",
         },
         "animal_heading": {
-            "columns_in_dat_file": ["animal_heading"],
+            "column_in_dat_file": ["animal_heading"],
             "spatial_series_name": "SpatialSeriesAnimalHeading",
             "description": "Animal's heading direction in radians from the lab's perspective.",
             "reference_frame": "lab",
         },
         "movement_direction": {
-            "columns_in_dat_file": ["movement_direction"],
+            "column_in_dat_file": ["movement_direction"],
             "spatial_series_name": "SpatialSeriesMovementDirection",
             "description": (
                 "Instantaneous running direction of the animal in the lab coordinates. "
@@ -113,13 +113,13 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
             "reference_frame": "lab",
         },
         "movement_speed": {
-            "columns_in_dat_file": ["movement_speed"],
+            "column_in_dat_file": ["movement_speed"],
             "spatial_series_name": "SpatialSeriesMovementSpeed",
             "description": "Instantaneous running speed of the animal in radians per frame.",
             "reference_frame": "lab",
         },
         "position_lab": {
-            "columns_in_dat_file": ["x_pos_radians_lab", "y_pos_radians_lab"],
+            "column_in_dat_file": ["x_pos_radians_lab", "y_pos_radians_lab"],
             "spatial_series_name": "SpatialSeriesPosition",
             "description": (
                 "x and y positions in the lab frame in radians, inferred by integrating " "the rotation over time."
@@ -127,14 +127,14 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
             "reference_frame": "lab",
         },
         "integrated_motion": {
-            "columns_in_dat_file": ["forward_motion_lab", "side_motion_lab"],
+            "column_in_dat_file": ["forward_motion_lab", "side_motion_lab"],
             "spatial_series_name": "SpatialSeriesIntegratedMotion",
             "description": ("Integrated x/y position of the sphere in laboratory coordinates, neglecting heading."),
             "reference_frame": "lab",
         },
         "rotation_delta_error": {
             "spatial_series_name": "SpatialSeriesRotationDeltaError",
-            "columns_in_dat_file": ["rotation_delta_error"],
+            "column_in_dat_file": ["rotation_delta_error"],
             "description": "Error in rotation delta in radians from the lab's perspective.",
             "reference_frame": "lab",
         },
@@ -217,8 +217,8 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
                 reference_frame=data_dict["reference_frame"],
             )
 
-            columns_in_dat_file = data_dict["columns_in_dat_file"]
-            data = fictrac_data_df[columns_in_dat_file].to_numpy()
+            column_in_dat_file = data_dict["column_in_dat_file"]
+            data = fictrac_data_df[column_in_dat_file].to_numpy()
             if self.radius is not None:
                 data = data * self.radius
                 units = "meters"
@@ -244,11 +244,11 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
     def get_original_timestamps(self):
         import pandas as pd
 
-        fictrac_data_df = pd.read_csv(
-            self.file_path, sep=",", skiprows=1, header=None, names=self.columns_in_dat_file, usecols=["timestamp"]
-        )
+        timestamp_index = self.columns_in_dat_file.index("timestamp")
 
-        return fictrac_data_df["timestamp"].values / 1000.0
+        fictrac_data_df = pd.read_csv(self.file_path, sep=",", skiprows=1, header=None, usecols=[timestamp_index])
+
+        return fictrac_data_df[timestamp_index].values / 1000.0
 
     def get_timestamps(self):
         timestamps = self._timestamps if self._timestamps is not None else self.get_original_timestamps()

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -123,7 +123,7 @@ class FicTracDataInterface(BaseDataInterface):
         position_container = Position(name="FicTrac")
 
         for data_dict in self.column_to_nwb_mapping.values():
-            spatial_seriess_kwargs = dict(
+            spatial_series_kwargs = dict(
                 name=data_dict["spatial_series_name"],
                 description=data_dict["description"],
                 reference_frame=data_dict["reference_frame"],
@@ -137,16 +137,16 @@ class FicTracDataInterface(BaseDataInterface):
             else:
                 units = "radians"
 
-            spatial_seriess_kwargs.update(data=data, unit=units)
+            spatial_series_kwargs.update(data=data, unit=units)
 
             if write_timestamps:
-                spatial_seriess_kwargs["timestamps"] = timestamps
+                spatial_series_kwargs["timestamps"] = timestamps
             else:
-                spatial_seriess_kwargs["rate"] = rate
-                spatial_seriess_kwargs["starting_time"] = starting_time
+                spatial_series_kwargs["rate"] = rate
+                spatial_series_kwargs["starting_time"] = starting_time
 
             # Create the spatial series and add it to the container
-            spatial_series = SpatialSeries(**spatial_seriess_kwargs)
+            spatial_series = SpatialSeries(**spatial_series_kwargs)
             position_container.add_spatial_series(spatial_series)
 
         # Add the compass direction container to the processing module

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -52,6 +52,94 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
         "alt_timestamp",
     ]
 
+    column_to_nwb_mapping = spatial_series_descriptions = {
+        "rotation_delta_cam": {
+            "columns_in_dat_file": ["rotation_delta_x_cam", "rotation_delta_y_cam", "rotation_delta_z_cam"],
+            "spatial_series_name": "SpatialSeriesRotationDeltaCameraFrame",
+            "description": (
+                "Change in orientation since last frame from the camera's perspective. "
+                "x: rotation to the sphere's right (pitch), "
+                "y: rotation under the sphere (yaw), "
+                "z: rotation behind the sphere (roll)"
+            ),
+            "reference_frame": "camera",
+        },
+        "rotation_delta_lab": {
+            "columns_in_dat_file": ["rotation_delta_x_lab", "rotation_delta_y_lab", "rotation_delta_z_lab"],
+            "spatial_series_name": "SpatialSeriesRotationDeltaLabFrame",
+            "description": (
+                "Change in orientation since last frame from the lab's perspective. "
+                "x: rotation in front of subject (roll), "
+                "y: rotation to subject's right (pitch), "
+                "z: rotation under the subject (yaw)"
+            ),
+            "reference_frame": "lab",
+        },
+        "rotation_cam": {
+            "columns_in_dat_file": ["rotation_x_cam", "rotation_y_cam", "rotation_z_cam"],
+            "spatial_series_name": "SpatialSeriesRotationCameraFrame",
+            "description": (
+                "Orientation in radians from the camera's perspective. "
+                "x: rotation to the sphere's right (pitch), "
+                "y: rotation under the sphere (yaw), "
+                "z: rotation behind the sphere (roll)"
+            ),
+            "reference_frame": "camera",
+        },
+        "rotation_lab": {
+            "columns_in_dat_file": ["rotation_x_lab", "rotation_y_lab", "rotation_z_lab"],
+            "spatial_series_name": "SpatialSeriesRotationLabFrame",
+            "description": (
+                "Orientation in radians from the lab's perspective. "
+                "x: rotation in front of subject (roll), "
+                "y: rotation to subject's right (pitch), "
+                "z: rotation under the subject (yaw)"
+            ),
+            "reference_frame": "lab",
+        },
+        "animal_heading": {
+            "columns_in_dat_file": ["animal_heading"],
+            "spatial_series_name": "SpatialSeriesAnimalHeading",
+            "description": "Animal's heading direction in radians from the lab's perspective.",
+            "reference_frame": "lab",
+        },
+        "movement_direction": {
+            "columns_in_dat_file": ["movement_direction"],
+            "spatial_series_name": "SpatialSeriesMovementDirection",
+            "description": (
+                "Instantaneous running direction of the animal in the lab coordinates. "
+                "Direction inferred by the ball's rotation (roll and pitch)"
+            ),
+            "reference_frame": "lab",
+        },
+        "movement_speed": {
+            "columns_in_dat_file": ["movement_speed"],
+            "spatial_series_name": "SpatialSeriesMovementSpeed",
+            "description": "Instantaneous running speed of the animal in radians per frame.",
+            "reference_frame": "lab",
+        },
+        "position_lab": {
+            "columns_in_dat_file": ["x_pos_radians_lab", "y_pos_radians_lab"],
+            "spatial_series_name": "SpatialSeriesPosition",
+            "description": (
+                "x and y positions in the lab frame in radians, inferred by integrating " "the rotation over time."
+            ),
+            "reference_frame": "lab",
+        },
+        "integrated_motion": {
+            "columns_in_dat_file": ["forward_motion_lab", "side_motion_lab"],
+            "spatial_series_name": "SpatialSeriesIntegratedMotion",
+            "description": ("Integrated x/y position of the sphere in laboratory coordinates, neglecting heading."),
+            "reference_frame": "lab",
+        },
+        "rotation_delta_error": {
+            "spatial_series_name": "SpatialSeriesRotationDeltaError",
+            "columns_in_dat_file": ["rotation_delta_error"],
+            "description": "Error in rotation delta in radians from the lab's perspective.",
+            "reference_frame": "lab",
+        },
+    }
+
     def __init__(
         self,
         file_path: FilePathType,
@@ -176,94 +264,6 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
 
     def set_aligned_starting_time(self, aligned_starting_time):
         self._starting_time = aligned_starting_time
-
-    column_to_nwb_mapping = spatial_series_descriptions = {
-        "rotation_delta_cam": {
-            "columns_in_dat_file": ["rotation_delta_x_cam", "rotation_delta_y_cam", "rotation_delta_z_cam"],
-            "spatial_series_name": "SpatialSeriesRotationDeltaCameraFrame",
-            "description": (
-                "Change in orientation since last frame from the camera's perspective. "
-                "x: rotation to the sphere's right (pitch), "
-                "y: rotation under the sphere (yaw), "
-                "z: rotation behind the sphere (roll)"
-            ),
-            "reference_frame": "camera",
-        },
-        "rotation_delta_lab": {
-            "columns_in_dat_file": ["rotation_delta_x_lab", "rotation_delta_y_lab", "rotation_delta_z_lab"],
-            "spatial_series_name": "SpatialSeriesRotationDeltaLabFrame",
-            "description": (
-                "Change in orientation since last frame from the lab's perspective. "
-                "x: rotation in front of subject (roll), "
-                "y: rotation to subject's right (pitch), "
-                "z: rotation under the subject (yaw)"
-            ),
-            "reference_frame": "lab",
-        },
-        "rotation_cam": {
-            "columns_in_dat_file": ["rotation_x_cam", "rotation_y_cam", "rotation_z_cam"],
-            "spatial_series_name": "SpatialSeriesRotationCameraFrame",
-            "description": (
-                "Orientation in radians from the camera's perspective. "
-                "x: rotation to the sphere's right (pitch), "
-                "y: rotation under the sphere (yaw), "
-                "z: rotation behind the sphere (roll)"
-            ),
-            "reference_frame": "camera",
-        },
-        "rotation_lab": {
-            "columns_in_dat_file": ["rotation_x_lab", "rotation_y_lab", "rotation_z_lab"],
-            "spatial_series_name": "SpatialSeriesRotationLabFrame",
-            "description": (
-                "Orientation in radians from the lab's perspective. "
-                "x: rotation in front of subject (roll), "
-                "y: rotation to subject's right (pitch), "
-                "z: rotation under the subject (yaw)"
-            ),
-            "reference_frame": "lab",
-        },
-        "animal_heading": {
-            "columns_in_dat_file": ["animal_heading"],
-            "spatial_series_name": "SpatialSeriesAnimalHeading",
-            "description": "Animal's heading direction in radians from the lab's perspective.",
-            "reference_frame": "lab",
-        },
-        "movement_direction": {
-            "columns_in_dat_file": ["movement_direction"],
-            "spatial_series_name": "SpatialSeriesMovementDirection",
-            "description": (
-                "Instantaneous running direction of the animal in the lab coordinates. "
-                "Direction inferred by the ball's rotation (roll and pitch)"
-            ),
-            "reference_frame": "lab",
-        },
-        "movement_speed": {
-            "columns_in_dat_file": ["movement_speed"],
-            "spatial_series_name": "SpatialSeriesMovementSpeed",
-            "description": "Instantaneous running speed of the animal in radians per frame.",
-            "reference_frame": "lab",
-        },
-        "position_lab": {
-            "columns_in_dat_file": ["x_pos_radians_lab", "y_pos_radians_lab"],
-            "spatial_series_name": "SpatialSeriesPosition",
-            "description": (
-                "x and y positions in the lab frame in radians, inferred by integrating " "the rotation over time."
-            ),
-            "reference_frame": "lab",
-        },
-        "integrated_motion": {
-            "columns_in_dat_file": ["forward_motion_lab", "side_motion_lab"],
-            "spatial_series_name": "SpatialSeriesIntegratedMotion",
-            "description": ("Integrated x/y position of the sphere in laboratory coordinates, neglecting heading."),
-            "reference_frame": "lab",
-        },
-        "rotation_delta_error": {
-            "spatial_series_name": "SpatialSeriesRotationDeltaError",
-            "columns_in_dat_file": ["rotation_delta_error"],
-            "description": "Error in rotation delta in radians from the lab's perspective.",
-            "reference_frame": "lab",
-        },
-    }
 
 
 def extract_session_start_time(file_path: FilePathType) -> datetime:

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -129,8 +129,8 @@ class FicTracDataInterface(BaseDataInterface):
                 reference_frame=data_dict["reference_frame"],
             )
 
-            columns = data_dict["columns_in_dat_file"]
-            data = fictrac_data_df[columns].to_numpy()
+            columns_in_dat_file = data_dict["columns_in_dat_file"]
+            data = fictrac_data_df[columns_in_dat_file].to_numpy()
             if self.radius is not None:
                 data = data * self.radius
                 units = "meters"

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -102,7 +102,7 @@ class FicTracDataInterface(BaseDataInterface):
         import pandas as pd
 
         # The first row only contains the session start time and invalid data
-        fictrac_data_df = pd.read_csv(self.file_path, sep=",", skiprows=1, header=None, names=self.columns_in_data_file)
+        fictrac_data_df = pd.read_csv(self.file_path, sep=",", skiprows=1, header=None, names=self.columns_in_dat_file)
 
         # Get the timestamps
         timestamps_milliseconds = fictrac_data_df["timestamp"].values

--- a/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscope_utils.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscope_utils.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from dateutil import parser
 
+from ....tools import get_package
+
 
 def get_xml_file_path(data_file_path: str) -> str:
     """
@@ -16,7 +18,7 @@ def get_xml_file_path(data_file_path: str) -> str:
 
 def get_xml(xml_file_path: str):
     """Auxiliary function for retrieving root of xml."""
-    from lxml import etree
+    etree = get_package(package_name="lxml.etree")
 
     return etree.parse(xml_file_path).getroot()
 

--- a/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscope_utils.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscope_utils.py
@@ -18,9 +18,9 @@ def get_xml_file_path(data_file_path: str) -> str:
 
 def get_xml(xml_file_path: str):
     """Auxiliary function for retrieving root of xml."""
-    lxml = get_package(package_name="lxml")
+    from xml import etree
 
-    return lxml.etree.parse(xml_file_path).getroot()
+    return etree.parse(xml_file_path).getroot()
 
 
 def safe_find(root, key: str, findall: bool = False):

--- a/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscope_utils.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscope_utils.py
@@ -3,8 +3,6 @@ from pathlib import Path
 
 from dateutil import parser
 
-from ....tools import get_package
-
 
 def get_xml_file_path(data_file_path: str) -> str:
     """
@@ -18,7 +16,7 @@ def get_xml_file_path(data_file_path: str) -> str:
 
 def get_xml(xml_file_path: str):
     """Auxiliary function for retrieving root of xml."""
-    from xml import etree
+    from lxml import etree
 
     return etree.parse(xml_file_path).getroot()
 

--- a/tests/test_on_data/test_behavior_interfaces.py
+++ b/tests/test_on_data/test_behavior_interfaces.py
@@ -8,6 +8,7 @@ from ndx_miniscope import Miniscope
 from ndx_miniscope.utils import get_timestamps
 from numpy.testing import assert_array_equal
 from pynwb import NWBHDF5IO
+from pynwb.behavior import Position
 
 from neuroconv.datainterfaces import (
     DeepLabCutInterface,
@@ -33,6 +34,7 @@ class TestFicTracDataInterface(DataInterfaceTestMixin, unittest.TestCase):
     data_interface_cls = FicTracDataInterface
     interface_kwargs = [
         dict(file_path=str(BEHAVIOR_DATA_PATH / "FicTrac" / "sample" / "sample-20230724_113055.dat")),
+        dict(file_path=str(BEHAVIOR_DATA_PATH / "FicTrac" / "sample" / "sample-20230724_113055.dat"), radius=1.0),
     ]
 
     save_directory = OUTPUT_PATH
@@ -40,6 +42,31 @@ class TestFicTracDataInterface(DataInterfaceTestMixin, unittest.TestCase):
     def check_extracted_metadata(self, metadata: dict):
         expected_session_start_time = datetime(2023, 7, 24, 9, 30, 55, 440600, tzinfo=timezone.utc)
         assert metadata["NWBFile"]["session_start_time"] == expected_session_start_time
+
+    def check_read_nwb(self, nwbfile_path: str):  # This is currently structured to be file-specific
+        with NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True) as io:
+            nwbfile = io.read()
+
+            fictrac_position_container = nwbfile.processing["Behavior"].data_interfaces["FicTrac"]
+            assert isinstance(fictrac_position_container, Position)
+
+            assert len(fictrac_position_container.spatial_series) == 10
+
+            column_to_nwb_mapping = self.interface.column_to_nwb_mapping
+            for data_dict in column_to_nwb_mapping.values():
+                spatial_series_name = data_dict["spatial_series_name"]
+                assert spatial_series_name in fictrac_position_container.spatial_series
+
+                reference_frame = data_dict["reference_frame"]
+                spatial_series = fictrac_position_container.spatial_series[spatial_series_name]
+                assert reference_frame == spatial_series.reference_frame
+
+                if self.case == 0:
+                    expected_units = "radians"
+                elif self.case == 1:
+                    expected_units = "meters"
+
+                assert spatial_series.unit == expected_units
 
 
 class TestVideoInterface(VideoInterfaceMixin, unittest.TestCase):


### PR DESCRIPTION
As discussed with @bendichter last week. Added an extra argument in the `__init__` of the interface called radius which is the radius of the treadmill foam ball in the setup. If provided, the units are converted to actual distances and stored as such.

I also changed the container from Compass to Position as discussed.