### PR TITLE
add configuration metadata to fictrac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Added alignment methods to `FicTracDataInterface`.  [PR #607](https://github.com/catalystneuro/neuroconv/pull/607)
 * Added alignment methods support to `MockRecordingInterface` [PR #611](https://github.com/catalystneuro/neuroconv/pull/611)
 * Added `NeuralynxNvtInterface`, which can read position tracking NVT files. [PR #580](https://github.com/catalystneuro/neuroconv/pull/580)
+* Added configuration metadata to `FicTracDataInterface`.  [PR #618](https://github.com/catalystneuro/neuroconv/pull/618)
 
 ### Fixes
 * Remove `starting_time` reset to default value (0.0) when adding the rate and updating the `photon_series_kwargs` or `roi_response_series_kwargs`, in `add_photon_series` or `add_fluorescence_traces`. [PR #595](https://github.com/catalystneuro/neuroconv/pull/595)

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -204,7 +204,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
 
         starting_time = timestamps[0]
 
-        # Note: Returns timestamps from the Graber classess in fictrac library. The most common is for them to be
+        # Note: Returns timestamps from the Graber classes in fictrac library. The most common is for them to be
         # video timestamp extracted with OpenCV with all the caveats that come with it.
         rate = calculate_regular_series_rate(series=timestamps)  # Returns None if the series is not regular
         if rate:

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -301,7 +301,7 @@ def extract_session_start_time(file_path: FilePathType) -> datetime:
     return utc_datetime
 
 
-def parse_fictrac_config(file_path: str) -> dict:
+def parse_fictrac_config(file_path: FilePathType) -> dict:
     """
     Parse a FicTrac configuration file and return a dictionary of its parameters.
 

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -170,9 +170,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
 
         self._timestamps = None
         self._starting_time = None
-        if metadata_file_path is not None:
-            self.metadata_file_path = Path(metadata_file_path)
-            self.configuration_metadata = parse_fictrac_config(self.metadata_file_path)
+        self.configuration_metadata = parse_fictrac_config(metadata_file_path) if metadata_file_path else None
 
     def get_metadata(self):
         metadata = super().get_metadata()
@@ -218,16 +216,16 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
         position_container = Position(name="FicTrac")
         if self.configuration_metadata is not None:
             comments = f"configuration_metadata = {json.dumps(self.configuration_metadata)}"
-        else:
-            comments = None
 
         for data_dict in self.column_to_nwb_mapping.values():
             spatial_series_kwargs = dict(
                 name=data_dict["spatial_series_name"],
                 description=data_dict["description"],
                 reference_frame=data_dict["reference_frame"],
-                comments=comments,
             )
+
+            if self.configuration_metadata is not None:
+                spatial_series_kwargs["comments"] = comments
 
             column_in_dat_file = data_dict["column_in_dat_file"]
             data = fictrac_data_df[column_in_dat_file].to_numpy()

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -173,7 +173,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
 
         self.configuration_metadata = None
         if self.configuration_file_path is not None:
-            self.configuration_metadata = parse_fictrac_config(file_path=configuration_file_path)
+            self.configuration_metadata = parse_fictrac_config(file_path=self.configuration_file_path)
 
         self._timestamps = None
         self._starting_time = None

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -424,7 +424,7 @@ def parse_fictrac_config(file_path: FilePathType) -> dict:
         value = int(x) if x.isdigit() else x
         return value
 
-    KEY_PARSERS = {
+    key_parsers = {
         "src_fn": parse_int_or_string,
         "vfov": float,
         "do_display": parse_bool,
@@ -476,6 +476,6 @@ def parse_fictrac_config(file_path: FilePathType) -> dict:
         key = key.strip()
         value = value.strip()
 
-        parser = KEY_PARSERS.get(key, lambda x: x)
+        parser = key_parsers.get(key, lambda x: x)
         parsed_config[key] = parser(value)
     return parsed_config

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -145,7 +145,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
         self,
         file_path: FilePathType,
         radius: Optional[float] = None,
-        configuration_file_path: FilePathType = None,
+        configuration_file_path: Optional[FilePathType] = None,
         verbose: bool = True,
     ):
         """
@@ -164,15 +164,19 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
         """
         self.file_path = Path(file_path)
         self.verbose = verbose
-        self._timestamps = None
         self.radius = radius
         super().__init__(file_path=file_path)
 
+        self.configuration_file_path = configuration_file_path
+        if self.configuration_file_path is None and (self.file_path.parent / "config.txt").is_file():
+            self.configuration_file_path = self.file_path.parent / "config.txt"
+
+        self.configuration_metadata = None
+        if self.configuration_file_path is not None:
+            self.configuration_metadata = parse_fictrac_config(file_path=configuration_file_path)
+
         self._timestamps = None
         self._starting_time = None
-        self.configuration_metadata = (
-            parse_fictrac_config(file_path=configuration_file_path) if configuration_file_path else None
-        )
 
     def get_metadata(self):
         metadata = super().get_metadata()

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -225,8 +225,9 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
             write_timestamps = True
 
         position_container = Position(name="FicTrac")
+        # TODO: make FicTrac extension of the Position container to attach these specific attributes with documentation
         if self.configuration_metadata is not None:
-            comments = f"configuration_metadata = {json.dumps(self.configuration_metadata)}"
+            comments = json.dumps(self.configuration_metadata)
 
         for data_dict in self.column_to_nwb_mapping.values():
             spatial_series_kwargs = dict(

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -145,7 +145,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
         self,
         file_path: FilePathType,
         radius: Optional[float] = None,
-        metadata_file_path: FilePathType = None,
+        configuration_file_path: FilePathType = None,
         verbose: bool = True,
     ):
         """
@@ -157,7 +157,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
             Path to the .dat file (the output of fictrac)
         radius : float, optional
             The radius of the ball in meters. If provided the data will be converted to meters and stored as such.
-        metadata_file_path : a string or a path, optional
+        configuration_file_path : a string or a path, optional
             Path to the .txt file with the configuration metadata. Usually called config.txt
         verbose : bool, default: True
             controls verbosity. ``True`` by default.
@@ -170,7 +170,9 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
 
         self._timestamps = None
         self._starting_time = None
-        self.configuration_metadata = parse_fictrac_config(file_path=metadata_file_path) if metadata_file_path else None
+        self.configuration_metadata = (
+            parse_fictrac_config(file_path=configuration_file_path) if configuration_file_path else None
+        )
 
     def get_metadata(self):
         metadata = super().get_metadata()

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -216,7 +216,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
         timestamps = self.get_timestamps()
         starting_time = timestamps[0]
 
-        # Note: Returns timestamps from the Graber classes in fictrac library. The most common is for them to be
+        # Note: Returns the timestamps from the sources in FicTrac (.e.g OpenCV videos, PGR or Basler). The most common  is OpenCV with all the caveats that come with it.
         # video timestamp extracted with OpenCV with all the caveats that come with it.
         rate = calculate_regular_series_rate(series=timestamps)  # Returns None if the series is not regular
         if rate:

--- a/src/neuroconv/datainterfaces/behavior/neuralynx/nvt_utils.py
+++ b/src/neuroconv/datainterfaces/behavior/neuralynx/nvt_utils.py
@@ -51,7 +51,7 @@ def read_header(filename: str) -> Dict[str, Union[str, datetime, float, int, Lis
     def parse_bool(x):
         return x.lower() == "true"
 
-    KEY_PARSERS = {
+    key_parsers = {
         "TimeCreated": nlx_date_parser,
         "TimeClosed": nlx_date_parser,
         "RecordSize": int,
@@ -80,7 +80,7 @@ def read_header(filename: str) -> Dict[str, Union[str, datetime, float, int, Lis
                 value = value.strip()
 
                 # Use the key-specific parser if available, otherwise use default parsing
-                parser = KEY_PARSERS.get(key, lambda x: x)
+                parser = key_parsers.get(key, lambda x: x)
                 out[key] = parser(value)
     return out
 

--- a/tests/test_on_data/test_behavior_interfaces.py
+++ b/tests/test_on_data/test_behavior_interfaces.py
@@ -169,7 +169,7 @@ class TestFicTracDataInterfaceWithRadius(DataInterfaceTestMixin, unittest.TestCa
 
                 assert spatial_series.timestamps[0] == 0.0
 
-                
+
 class TestFicTracDataInterfaceTiming(TemporalAlignmentMixin, unittest.TestCase):
     data_interface_cls = FicTracDataInterface
     interface_kwargs = [dict(file_path=str(BEHAVIOR_DATA_PATH / "FicTrac" / "sample" / "sample-20230724_113055.dat"))]

--- a/tests/test_on_data/test_behavior_interfaces.py
+++ b/tests/test_on_data/test_behavior_interfaces.py
@@ -113,6 +113,35 @@ class TestFicTracDataInterfaceWithRadius(DataInterfaceTestMixin, unittest.TestCa
         assert metadata["NWBFile"]["session_start_time"] == expected_session_start_time
 
     def check_read_nwb(self, nwbfile_path: str):  # This is currently structured to be file-specific
+        configuration_metadata = (
+            '{"version": "v2.1.1", '
+            '"build_date": "Jul 24 2023", '
+            '"c2a_cnrs_xy": [191, 171, 128, 272, 20, 212, 99, 132], '
+            '"c2a_r": [0.722445, -0.131314, -0.460878], '
+            '"c2a_src": "c2a_cnrs_xy", '
+            '"c2a_t": [-0.674396, 0.389373, 2.889648], '
+            '"do_display": true, '
+            '"max_bad_frames": -1, '
+            '"opt_bound": 0.35, '
+            '"opt_do_global": false, '
+            '"opt_max_err": -1.0, '
+            '"opt_max_evals": 50, '
+            '"opt_tol": 0.001, '
+            '"q_factor": 6, '
+            '"roi_c": [-0.22939, 0.099969, 0.968187], '
+            '"roi_circ": [63, 171, 81, 145, 106, 135, 150, 160], '
+            '"roi_ignr": [[96, 156, 113, 147, 106, 128, 82, 130, 81, 150], '
+            "[71, 213, 90, 219, 114, 218, 135, 211, 154, 196, 150, 217, 121, 228, 99, 234, 75, 225]], "
+            '"roi_r": 0.124815, '
+            '"save_debug": false, '
+            '"save_raw": false, '
+            '"src_fn": "sample.mp4", '
+            '"src_fps": -1.0, '
+            '"thr_ratio": 1.25, '
+            '"thr_win_pc": 0.25, '
+            '"vfov": 45.0}'
+        )
+
         with NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True) as io:
             nwbfile = io.read()
 
@@ -132,6 +161,9 @@ class TestFicTracDataInterfaceWithRadius(DataInterfaceTestMixin, unittest.TestCa
                 expected_units = "meters"
                 assert spatial_series.unit == expected_units
                 assert spatial_series.conversion == self.interface.radius
+
+                expected_metadata = f"configuration_metadata = {configuration_metadata}"
+                assert spatial_series.comments == expected_metadata
 
 
 class TestFicTracDataInterfaceTiming(TemporalAlignmentMixin, unittest.TestCase):

--- a/tests/test_on_data/test_behavior_interfaces.py
+++ b/tests/test_on_data/test_behavior_interfaces.py
@@ -36,7 +36,7 @@ class TestFicTracDataInterface(DataInterfaceTestMixin, unittest.TestCase):
     interface_kwargs = [
         dict(
             file_path=str(BEHAVIOR_DATA_PATH / "FicTrac" / "sample" / "sample-20230724_113055.dat"),
-            metadata_file_path=BEHAVIOR_DATA_PATH / "FicTrac" / "sample" / "config.txt",
+            configuration_file_path=BEHAVIOR_DATA_PATH / "FicTrac" / "sample" / "config.txt",
         ),
     ]
 

--- a/tests/test_on_data/test_behavior_interfaces.py
+++ b/tests/test_on_data/test_behavior_interfaces.py
@@ -164,7 +164,7 @@ class TestFicTracDataInterfaceWithRadius(DataInterfaceTestMixin, unittest.TestCa
                 assert spatial_series.unit == expected_units
                 assert spatial_series.conversion == self.interface.radius
 
-                expected_metadata = f"configuration_metadata = {configuration_metadata}"
+                expected_metadata = f"{configuration_metadata}"
                 assert spatial_series.comments == expected_metadata
 
                 assert spatial_series.timestamps[0] == 0.0

--- a/tests/test_on_data/test_behavior_interfaces.py
+++ b/tests/test_on_data/test_behavior_interfaces.py
@@ -34,7 +34,10 @@ except ImportError:
 class TestFicTracDataInterface(DataInterfaceTestMixin, unittest.TestCase):
     data_interface_cls = FicTracDataInterface
     interface_kwargs = [
-        dict(file_path=str(BEHAVIOR_DATA_PATH / "FicTrac" / "sample" / "sample-20230724_113055.dat")),
+        dict(
+            file_path=str(BEHAVIOR_DATA_PATH / "FicTrac" / "sample" / "sample-20230724_113055.dat"),
+            metadata_file_path=BEHAVIOR_DATA_PATH / "FicTrac" / "sample" / "config.txt",
+        ),
     ]
 
     save_directory = OUTPUT_PATH
@@ -44,6 +47,34 @@ class TestFicTracDataInterface(DataInterfaceTestMixin, unittest.TestCase):
         assert metadata["NWBFile"]["session_start_time"] == expected_session_start_time
 
     def check_read_nwb(self, nwbfile_path: str):  # This is currently structured to be file-specific
+        configuration_metadata = (
+            '{"version": "v2.1.1", '
+            '"build_date": "Jul 24 2023", '
+            '"c2a_cnrs_xy": [191, 171, 128, 272, 20, 212, 99, 132], '
+            '"c2a_r": [0.722445, -0.131314, -0.460878], '
+            '"c2a_src": "c2a_cnrs_xy", '
+            '"c2a_t": [-0.674396, 0.389373, 2.889648], '
+            '"do_display": true, '
+            '"max_bad_frames": -1, '
+            '"opt_bound": 0.35, '
+            '"opt_do_global": false, '
+            '"opt_max_err": -1.0, '
+            '"opt_max_evals": 50, '
+            '"opt_tol": 0.001, '
+            '"q_factor": 6, '
+            '"roi_c": [-0.22939, 0.099969, 0.968187], '
+            '"roi_circ": [63, 171, 81, 145, 106, 135, 150, 160], '
+            '"roi_ignr": [[96, 156, 113, 147, 106, 128, 82, 130, 81, 150], '
+            "[71, 213, 90, 219, 114, 218, 135, 211, 154, 196, 150, 217, 121, 228, 99, 234, 75, 225]], "
+            '"roi_r": 0.124815, '
+            '"save_debug": false, '
+            '"save_raw": false, '
+            '"src_fn": "sample.mp4", '
+            '"src_fps": -1.0, '
+            '"thr_ratio": 1.25, '
+            '"thr_win_pc": 0.25, '
+            '"vfov": 45.0}'
+        )
         with NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True) as io:
             nwbfile = io.read()
 
@@ -63,6 +94,9 @@ class TestFicTracDataInterface(DataInterfaceTestMixin, unittest.TestCase):
 
                 expected_units = "radians"
                 assert spatial_series.unit == expected_units
+
+                expected_metadata = f"configuration_metadata = {configuration_metadata}"
+                assert spatial_series.comments == expected_metadata
 
 
 class TestFicTracDataInterfaceWithRadius(DataInterfaceTestMixin, unittest.TestCase):

--- a/tests/test_on_data/test_behavior_interfaces.py
+++ b/tests/test_on_data/test_behavior_interfaces.py
@@ -96,7 +96,7 @@ class TestFicTracDataInterface(DataInterfaceTestMixin, unittest.TestCase):
                 assert spatial_series.unit == expected_units
                 assert spatial_series.conversion == 1.0
 
-                expected_metadata = f"configuration_metadata = {configuration_metadata}"
+                expected_metadata = f"{configuration_metadata}"
                 assert spatial_series.comments == expected_metadata
 
                 assert spatial_series.timestamps[0] == 0.0


### PR DESCRIPTION
As in the title. The metadata is added as a comment to each of the SpatialSeries. Added a test for this.

Ben suggested to change the parsing function to something along the lines of #580 so I did it here as well
