### PR TITLE
Add radius as conversion (scaling) instead of adding the scaled data in `FicTrac`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Added alignment methods to `FicTracDataInterface`.  [PR #607](https://github.com/catalystneuro/neuroconv/pull/607)
 * Added alignment methods support to `MockRecordingInterface` [PR #611](https://github.com/catalystneuro/neuroconv/pull/611)
 * Added `NeuralynxNvtInterface`, which can read position tracking NVT files. [PR #580](https://github.com/catalystneuro/neuroconv/pull/580)
+* Adding radius as a conversion factor in `FicTracDataInterface`.  [PR #619](https://github.com/catalystneuro/neuroconv/pull/619)
 
 ### Fixes
 * Remove `starting_time` reset to default value (0.0) when adding the rate and updating the `photon_series_kwargs` or `roi_response_series_kwargs`, in `add_photon_series` or `add_fluorescence_traces`. [PR #595](https://github.com/catalystneuro/neuroconv/pull/595)

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -220,7 +220,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
             column_in_dat_file = data_dict["column_in_dat_file"]
             data = fictrac_data_df[column_in_dat_file].to_numpy()
             if self.radius is not None:
-                data = data * self.radius
+                spatial_series_kwargs["conversion"] = self.radius
                 units = "meters"
             else:
                 units = "radians"

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -238,7 +238,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
             spatial_series = SpatialSeries(**spatial_series_kwargs)
             position_container.add_spatial_series(spatial_series)
 
-        # Add the compass direction container to the processing module
+        # Add the container to the processing module
         processing_module = get_module(nwbfile=nwbfile, name="behavior")
         processing_module.add_data_interface(position_container)
 

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -154,7 +154,8 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
         file_path : a string or a path
             Path to the .dat file (the output of fictrac)
         radius : float, optional
-            The radius of the ball in meters. If provided the data will be converted to meters and stored as such.
+            The radius of the ball in meters. If provided the radius is stored as a conversion factor
+            and the units are set to meters. If not provided the units are set to radians.
         verbose : bool, default: True
             controls verbosity. ``True`` by default.
         """
@@ -238,7 +239,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
             position_container.add_spatial_series(spatial_series)
 
         # Add the compass direction container to the processing module
-        processing_module = get_module(nwbfile=nwbfile, name="Behavior")
+        processing_module = get_module(nwbfile=nwbfile, name="behavior")
         processing_module.add_data_interface(position_container)
 
     def get_original_timestamps(self):

--- a/tests/test_on_data/test_behavior_interfaces.py
+++ b/tests/test_on_data/test_behavior_interfaces.py
@@ -47,7 +47,7 @@ class TestFicTracDataInterface(DataInterfaceTestMixin, unittest.TestCase):
         with NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True) as io:
             nwbfile = io.read()
 
-            fictrac_position_container = nwbfile.processing["Behavior"].data_interfaces["FicTrac"]
+            fictrac_position_container = nwbfile.processing["behavior"].data_interfaces["FicTrac"]
             assert isinstance(fictrac_position_container, Position)
 
             assert len(fictrac_position_container.spatial_series) == 10
@@ -82,7 +82,7 @@ class TestFicTracDataInterfaceWithRadius(DataInterfaceTestMixin, unittest.TestCa
         with NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True) as io:
             nwbfile = io.read()
 
-            fictrac_position_container = nwbfile.processing["Behavior"].data_interfaces["FicTrac"]
+            fictrac_position_container = nwbfile.processing["behavior"].data_interfaces["FicTrac"]
             assert isinstance(fictrac_position_container, Position)
 
             assert len(fictrac_position_container.spatial_series) == 10

--- a/tests/test_on_data/test_behavior_interfaces.py
+++ b/tests/test_on_data/test_behavior_interfaces.py
@@ -63,6 +63,7 @@ class TestFicTracDataInterface(DataInterfaceTestMixin, unittest.TestCase):
 
                 expected_units = "radians"
                 assert spatial_series.unit == expected_units
+                assert spatial_series.conversion == 1.0
 
 
 class TestFicTracDataInterfaceWithRadius(DataInterfaceTestMixin, unittest.TestCase):
@@ -96,6 +97,7 @@ class TestFicTracDataInterfaceWithRadius(DataInterfaceTestMixin, unittest.TestCa
                 assert reference_frame == spatial_series.reference_frame
                 expected_units = "meters"
                 assert spatial_series.unit == expected_units
+                assert spatial_series.conversion == self.interface.radius
 
 
 class TestFicTracDataInterfaceTiming(TemporalAlignmentMixin, unittest.TestCase):


### PR DESCRIPTION
This was a suggestion from @CodyCBakerPhD in our  last conversion which I think makes sense. We were adding the data scaled which increases the error if the measurement of the radius is not very precise. 

This method keeps both the radius, the right units and the original data without imprecisions. 

I modified the test to account for this.