### PR TITLE
Change identifier of plane to `plane_segmentation_name`

### DIFF
--- a/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
@@ -80,6 +80,7 @@ class BaseSegmentationExtractorInterface(BaseExtractorInterface):
         include_roi_centroids: bool = True,
         include_roi_acceptance: bool = True,
         mask_type: Optional[str] = "image",  # Literal["image", "pixel", "voxel"]
+        plane_segmentation_name: Optional[str] = None,
         iterator_options: Optional[dict] = None,
         compression_options: Optional[dict] = None,
     ):
@@ -112,6 +113,8 @@ class BaseSegmentationExtractorInterface(BaseExtractorInterface):
             Specify your choice between these three as mask_type='image', 'pixel', 'voxel', or None.
             If None, the mask information is not written to the NWB file.
             Defaults to 'image'.
+        plane_segmentation_name : str, optional
+            The name of the plane segmentation to be added.
         iterator_options : dict, optional
             The options to use when iterating over the image masks of the segmentation extractor.
         compression_options : dict, optional
@@ -136,6 +139,7 @@ class BaseSegmentationExtractorInterface(BaseExtractorInterface):
             include_roi_centroids=include_roi_centroids,
             include_roi_acceptance=include_roi_acceptance,
             mask_type=mask_type,
+            plane_segmentation_name=plane_segmentation_name,
             iterator_options=iterator_options,
             compression_options=compression_options,
         )

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -656,7 +656,8 @@ def add_plane_segmentation(
     segmentation_extractor: SegmentationExtractor,
     nwbfile: NWBFile,
     metadata: Optional[dict],
-    plane_segmentation_index: int = 0,
+    plane_segmentation_name: Optional[str] = None,
+    plane_segmentation_index: Optional[int] = None,  # TODO: to be removed
     include_roi_centroids: bool = True,
     include_roi_acceptance: bool = True,
     mask_type: Optional[str] = "image",  # Optional[Literal["image", "pixel"]]
@@ -676,8 +677,8 @@ def add_plane_segmentation(
         The NWBFile to add the plane segmentation to.
     metadata : dict, optional
         The metadata for the plane segmentation.
-    plane_segmentation_index : int, optional
-        The index of the plane segmentation to add.
+    plane_segmentation_name : str, optional
+        The name of the plane segmentation to be added.
     include_roi_centroids : bool, default: True
         Whether to include the ROI centroids on the PlaneSegmentation table.
         If there are a very large number of ROIs (such as in whole-brain recordings),
@@ -721,8 +722,26 @@ def add_plane_segmentation(
     metadata_copy = dict_deep_update(default_metadata, metadata_copy, append_list=False)
 
     image_segmentation_metadata = metadata_copy["Ophys"]["ImageSegmentation"]
-    plane_segmentation_metadata = image_segmentation_metadata["plane_segmentations"][plane_segmentation_index]
-    plane_segmentation_name = plane_segmentation_metadata["name"]
+    plane_segmentation_name = (
+        plane_segmentation_name or default_metadata["Ophys"]["ImageSegmentation"]["plane_segmentations"][0]["name"]
+    )
+    if plane_segmentation_index:
+        warn(
+            "Keyword argument 'plane_segmentation_index' is deprecated and it will be removed on 2024-04-16. Use 'plane_segmentation_name' instead."
+        )
+        plane_segmentation_name = image_segmentation_metadata["plane_segmentations"][plane_segmentation_index]["name"]
+    plane_segmentation_metadata = next(
+        (
+            plane_segmentation_metadata
+            for plane_segmentation_metadata in image_segmentation_metadata["plane_segmentations"]
+            if plane_segmentation_metadata["name"] == plane_segmentation_name
+        ),
+        None,
+    )
+    if plane_segmentation_metadata is None:
+        raise ValueError(
+            f"Metadata for Plane Segmentation '{plane_segmentation_name}' not found in metadata['Ophys']['ImageSegmentation']['plane_segmentations']."
+        )
 
     imaging_plane_name = plane_segmentation_metadata["imaging_plane"]
     add_imaging_plane(nwbfile=nwbfile, metadata=metadata_copy, imaging_plane_name=imaging_plane_name)
@@ -740,10 +759,7 @@ def add_plane_segmentation(
             accepted_ids = [int(roi_id in segmentation_extractor.get_accepted_list()) for roi_id in roi_ids]
             rejected_ids = [int(roi_id in segmentation_extractor.get_rejected_list()) for roi_id in roi_ids]
 
-        imaging_plane_metadata = metadata_copy["Ophys"]["ImagingPlane"][plane_segmentation_index]
-        imaging_plane_name = imaging_plane_metadata["name"]
         imaging_plane = nwbfile.imaging_planes[imaging_plane_name]
-
         plane_segmentation_kwargs = deepcopy(plane_segmentation_metadata)
         plane_segmentation_kwargs.update(imaging_plane=imaging_plane)
         if mask_type is None:
@@ -812,7 +828,8 @@ def add_fluorescence_traces(
     segmentation_extractor: SegmentationExtractor,
     nwbfile: NWBFile,
     metadata: Optional[dict],
-    plane_index: int = 0,
+    plane_segmentation_name: Optional[str] = None,
+    plane_index: Optional[int] = None,  # TODO: to be removed
     iterator_options: Optional[dict] = None,
     compression_options: Optional[dict] = None,
 ) -> NWBFile:
@@ -829,8 +846,8 @@ def add_fluorescence_traces(
         The nwbfile to add the fluorescence traces to.
     metadata : dict
         The metadata for the fluorescence traces.
-    plane_index : int, default: 0
-        The index of the plane to add the fluorescence traces to.
+    plane_segmentation_name : str, optional
+        The name of the plane segmentation that identifies which plane to add the fluorescence traces to.
     iterator_options : dict, optional
     compression_options : dict, optional
 
@@ -847,6 +864,16 @@ def add_fluorescence_traces(
     default_metadata = get_default_segmentation_metadata()
     metadata_copy = dict_deep_update(default_metadata, metadata_copy, append_list=False)
 
+    if plane_index:
+        warn(
+            "Keyword argument 'plane_index' is deprecated and it will be removed on 2024-04-16. Use 'plane_segmentation_name' instead."
+        )
+        plane_segmentation_name = metadata_copy["Ophys"]["ImageSegmentation"]["plane_segmentations"][plane_index][
+            "name"
+        ]
+    plane_segmentation_name = (
+        plane_segmentation_name or default_metadata["Ophys"]["ImageSegmentation"]["plane_segmentations"][0]["name"]
+    )
     # df/F metadata
     df_over_f_metadata = metadata_copy["Ophys"]["DfOverF"]
     df_over_f_name = df_over_f_metadata["name"]
@@ -874,7 +901,7 @@ def add_fluorescence_traces(
         segmentation_extractor=segmentation_extractor,
         nwbfile=nwbfile,
         metadata=metadata_copy,
-        plane_index=plane_index,
+        plane_segmentation_name=plane_segmentation_name,
     )
 
     roi_response_series_kwargs = dict(rois=roi_table_region, unit="n.a.")
@@ -912,7 +939,6 @@ def add_fluorescence_traces(
         # The name of the roi_response_series is "RoiResponseSeries" for raw and df/F traces,
         # otherwise it is capitalized trace_name.
         trace_name = "RoiResponseSeries" if trace_name in ["raw", "dff"] else trace_name.capitalize()
-        trace_name = trace_name if plane_index == 0 else trace_name + f"_Plane{plane_index}"
 
         if trace_name in data_interface.roi_response_series:
             continue
@@ -920,8 +946,11 @@ def add_fluorescence_traces(
         data_interface_metadata = df_over_f_metadata if isinstance(data_interface, DfOverF) else fluorescence_metadata
         response_series_metadata = data_interface_metadata["roi_response_series"]
         trace_metadata = next(
-            trace_metadata for trace_metadata in response_series_metadata if trace_name == trace_metadata["name"]
+            (trace_metadata for trace_metadata in response_series_metadata if trace_name == trace_metadata["name"]),
+            None,
         )
+        if trace_metadata is None:
+            raise ValueError(f"Metadata for '{trace_name}' trace not found in {response_series_metadata}.")
 
         # Pop the rate from the metadata if irregular time series
         if "timestamps" in roi_response_series_kwargs and "rate" in trace_metadata:
@@ -945,25 +974,51 @@ def _create_roi_table_region(
     segmentation_extractor: SegmentationExtractor,
     nwbfile: NWBFile,
     metadata: dict,
-    plane_index: int,
+    plane_segmentation_name: Optional[str] = None,
+    plane_index: Optional[int] = None,
 ):
-    """Private method to create ROI table region."""
-    add_plane_segmentation(segmentation_extractor=segmentation_extractor, nwbfile=nwbfile, metadata=metadata)
+    """Private method to create ROI table region.
 
-    # Get plane segmentation from the image segmentation
+    Parameters
+    ----------
+    segmentation_extractor : SegmentationExtractor
+        The segmentation extractor to get the results from.
+    nwbfile : NWBFile
+        The NWBFile to add the plane segmentation to.
+    metadata : dict, optional
+        The metadata for the plane segmentation.
+    plane_segmentation_name : str, optional
+        The name of the plane segmentation that identifies which plane to add the ROI table region to.
+    """
     image_segmentation_metadata = metadata["Ophys"]["ImageSegmentation"]
+
+    if plane_index:
+        warn(
+            "Keyword argument 'plane_index' is deprecated and it will be removed on 2024-04-16. Use 'plane_segmentation_name' instead."
+        )
+        plane_segmentation_name = image_segmentation_metadata["plane_segmentations"][plane_index]["name"]
+
+    add_plane_segmentation(
+        segmentation_extractor=segmentation_extractor,
+        nwbfile=nwbfile,
+        metadata=metadata,
+        plane_segmentation_name=plane_segmentation_name,
+    )
+
     image_segmentation_name = image_segmentation_metadata["name"]
     ophys = get_module(nwbfile, "ophys")
     image_segmentation = ophys.get_data_interface(image_segmentation_name)
 
-    plane_segmentation_name = image_segmentation_metadata["plane_segmentations"][0]["name"]
+    # Get plane segmentation from the image segmentation
     plane_segmentation = image_segmentation.plane_segmentations[plane_segmentation_name]
 
     # Create a reference for ROIs from the plane segmentation
     id_list = list(plane_segmentation.id)
+
+    imaging_plane_name = plane_segmentation.imaging_plane.name
     roi_table_region = plane_segmentation.create_roi_table_region(
         region=[id_list.index(id) for id in segmentation_extractor.get_roi_ids()],
-        description=f"region for Imaging plane{plane_index}",
+        description=f"The ROIs for {imaging_plane_name}.",
     )
 
     return roi_table_region
@@ -1032,7 +1087,8 @@ def add_segmentation(
     segmentation_extractor: SegmentationExtractor,
     nwbfile: NWBFile,
     metadata: Optional[dict] = None,
-    plane_num: int = 0,
+    plane_segmentation_name: Optional[str] = None,
+    plane_num: Optional[int] = None,  # TODO: to be removed
     include_roi_centroids: bool = True,
     include_roi_acceptance: bool = True,
     mask_type: Optional[str] = "image",  # Literal["image", "pixel"]
@@ -1050,6 +1106,7 @@ def add_segmentation(
         segmentation_extractor=segmentation_extractor,
         nwbfile=nwbfile,
         metadata=metadata,
+        plane_segmentation_name=plane_segmentation_name,
         include_roi_centroids=include_roi_centroids,
         include_roi_acceptance=include_roi_acceptance,
         mask_type=mask_type,
@@ -1062,6 +1119,7 @@ def add_segmentation(
         segmentation_extractor=segmentation_extractor,
         nwbfile=nwbfile,
         metadata=metadata,
+        plane_segmentation_name=plane_segmentation_name,
         iterator_options=iterator_options,
         compression_options=compression_options,
     )

--- a/tests/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_ophys/test_tools_roiextractors.py
@@ -36,6 +36,7 @@ from neuroconv.tools.roiextractors import (
 from neuroconv.tools.roiextractors.imagingextractordatachunkiterator import (
     ImagingExtractorDataChunkIterator,
 )
+from neuroconv.tools.roiextractors.roiextractors import get_default_segmentation_metadata
 
 
 class TestAddDevices(unittest.TestCase):
@@ -345,7 +346,7 @@ def assert_masks_equal(mask: List[List[Tuple[int, int, int]]], expected_mask: Li
         assert_array_equal(mask[mask_ind], expected_mask[mask_ind])
 
 
-class TestAddPlaneSegmentation(unittest.TestCase):
+class TestAddPlaneSegmentation(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.num_rois = 10
@@ -395,6 +396,7 @@ class TestAddPlaneSegmentation(unittest.TestCase):
             segmentation_extractor=self.segmentation_extractor,
             nwbfile=self.nwbfile,
             metadata=self.metadata,
+            plane_segmentation_name=self.plane_segmentation_name,
         )
 
         image_segmentation = self.nwbfile.processing["ophys"].get(self.image_segmentation_name)
@@ -426,6 +428,7 @@ class TestAddPlaneSegmentation(unittest.TestCase):
             nwbfile=self.nwbfile,
             metadata=self.metadata,
             include_roi_centroids=False,
+            plane_segmentation_name=self.plane_segmentation_name,
         )
 
         image_segmentation = self.nwbfile.processing["ophys"].get(self.image_segmentation_name)
@@ -441,6 +444,7 @@ class TestAddPlaneSegmentation(unittest.TestCase):
             nwbfile=self.nwbfile,
             metadata=self.metadata,
             include_roi_acceptance=False,
+            plane_segmentation_name=self.plane_segmentation_name,
         )
 
         image_segmentation = self.nwbfile.processing["ophys"].get(self.image_segmentation_name)
@@ -496,6 +500,7 @@ class TestAddPlaneSegmentation(unittest.TestCase):
             segmentation_extractor=segmentation_extractor,
             nwbfile=self.nwbfile,
             metadata=self.metadata,
+            plane_segmentation_name=self.plane_segmentation_name,
         )
 
         image_segmentation = self.nwbfile.processing["ophys"].get(self.image_segmentation_name)
@@ -531,6 +536,7 @@ class TestAddPlaneSegmentation(unittest.TestCase):
             nwbfile=self.nwbfile,
             metadata=self.metadata,
             mask_type="pixel",
+            plane_segmentation_name=self.plane_segmentation_name,
         )
 
         image_segmentation = self.nwbfile.processing["ophys"].get(self.image_segmentation_name)
@@ -562,6 +568,7 @@ class TestAddPlaneSegmentation(unittest.TestCase):
             nwbfile=self.nwbfile,
             metadata=self.metadata,
             mask_type="voxel",
+            plane_segmentation_name=self.plane_segmentation_name,
         )
 
         image_segmentation = self.nwbfile.processing["ophys"].get(self.image_segmentation_name)
@@ -582,7 +589,11 @@ class TestAddPlaneSegmentation(unittest.TestCase):
         )
 
         add_plane_segmentation(
-            segmentation_extractor=segmentation_extractor, nwbfile=self.nwbfile, metadata=self.metadata, mask_type=None
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=self.nwbfile,
+            metadata=self.metadata,
+            mask_type=None,
+            plane_segmentation_name=self.plane_segmentation_name,
         )
 
         image_segmentation = self.nwbfile.processing["ophys"].get(self.image_segmentation_name)
@@ -620,6 +631,7 @@ class TestAddPlaneSegmentation(unittest.TestCase):
                 nwbfile=self.nwbfile,
                 metadata=self.metadata,
                 mask_type="voxel",
+                plane_segmentation_name=self.plane_segmentation_name,
             )
 
         image_segmentation = self.nwbfile.processing["ophys"].get(self.image_segmentation_name)
@@ -657,6 +669,7 @@ class TestAddPlaneSegmentation(unittest.TestCase):
                 nwbfile=self.nwbfile,
                 metadata=self.metadata,
                 mask_type="pixel",
+                plane_segmentation_name=self.plane_segmentation_name,
             )
 
         image_segmentation = self.nwbfile.processing["ophys"].get(self.image_segmentation_name)
@@ -675,6 +688,7 @@ class TestAddPlaneSegmentation(unittest.TestCase):
             segmentation_extractor=self.segmentation_extractor,
             nwbfile=self.nwbfile,
             metadata=self.metadata,
+            plane_segmentation_name=self.plane_segmentation_name,
         )
 
         self.plane_segmentation_metadata["description"] = "modified description"
@@ -683,6 +697,7 @@ class TestAddPlaneSegmentation(unittest.TestCase):
             segmentation_extractor=self.segmentation_extractor,
             nwbfile=self.nwbfile,
             metadata=self.metadata,
+            plane_segmentation_name=self.plane_segmentation_name,
         )
 
         image_segmentation = self.nwbfile.processing["ophys"].get(self.image_segmentation_name)
@@ -706,6 +721,7 @@ class TestAddPlaneSegmentation(unittest.TestCase):
             segmentation_extractor=self.segmentation_extractor,
             nwbfile=self.nwbfile,
             metadata=self.metadata,
+            plane_segmentation_name=first_plane_segmentation_name,
         )
 
         # Add second plane segmentation
@@ -717,6 +733,7 @@ class TestAddPlaneSegmentation(unittest.TestCase):
             segmentation_extractor=self.segmentation_extractor,
             nwbfile=self.nwbfile,
             metadata=self.metadata,
+            plane_segmentation_name=second_plane_segmentation_name,
         )
 
         image_segmentation = self.nwbfile.processing["ophys"].get(self.image_segmentation_name)
@@ -733,6 +750,20 @@ class TestAddPlaneSegmentation(unittest.TestCase):
 
         assert second_plane_segmentation.name == second_plane_segmentation_name
         assert second_plane_segmentation.description == second_plane_segmentation_description
+
+    def test_add_plane_segmentation_raises_when_name_not_found_in_metadata(self):
+        """Test adding a plane segmentation raises an error when the name is not found in the metadata."""
+        plane_segmentation_name = "plane_segmentation_non_existing_in_the_metadata"
+        with self.assertRaisesWith(
+            exc_type=ValueError,
+            exc_msg=f"Metadata for Plane Segmentation '{plane_segmentation_name}' not found in metadata['Ophys']['ImageSegmentation']['plane_segmentations'].",
+        ):
+            add_plane_segmentation(
+                segmentation_extractor=self.segmentation_extractor,
+                nwbfile=self.nwbfile,
+                metadata=self.metadata,
+                plane_segmentation_name=plane_segmentation_name,
+            )
 
 
 class TestAddFluorescenceTraces(unittest.TestCase):
@@ -1171,6 +1202,152 @@ class TestAddFluorescenceTraces(unittest.TestCase):
             self.assertEqual(roi_response_series[series_name].rate, None)
             self.assertEqual(roi_response_series[series_name].starting_time, None)
             assert_array_equal(roi_response_series[series_name].timestamps.data, times)
+
+    def test_add_fluorescence_traces_with_plane_segmentation_name_specified(self):
+        plane_segmentation_name = "plane_segmentation_name"
+        metadata = deepcopy(self.metadata)
+
+        add_fluorescence_traces(
+            segmentation_extractor=self.segmentation_extractor,
+            nwbfile=self.nwbfile,
+            metadata=metadata,
+            plane_segmentation_name=plane_segmentation_name,
+        )
+
+        ophys = get_module(self.nwbfile, "ophys")
+        image_segmentation = ophys.get("ImageSegmentation")
+
+        assert len(image_segmentation.plane_segmentations) == 1
+        assert plane_segmentation_name in image_segmentation.plane_segmentations
+
+
+class TestAddFluorescenceTracesMultiPlaneCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.num_rois_first_plane = 10
+        cls.num_rois_second_plane = 5
+        cls.num_frames = 20
+        cls.num_rows = 25
+        cls.num_columns = 20
+
+        cls.session_start_time = datetime.now().astimezone()
+
+        cls.metadata = get_default_segmentation_metadata()
+
+        cls.plane_segmentation_first_plane_name = "PlaneSegmentationFirstPlane"
+        cls.metadata["Ophys"]["ImageSegmentation"]["plane_segmentations"][0].update(
+            name=cls.plane_segmentation_first_plane_name
+        )
+
+        cls.fluorescence_name = "FluorescenceFirstPlane"
+        cls.df_over_f_name = "DfOverFFirstPlane"
+
+        cls.raw_roi_response_series_metadata = dict(
+            name="RoiResponseSeries",
+            description="raw fluorescence signal",
+        )
+
+        cls.dff_roi_response_series_metadata = dict(
+            name="RoiResponseSeries",
+            description="relative (df/f) fluorescence signal",
+        )
+
+        cls.deconvolved_roi_response_series_metadata = dict(
+            name="Deconvolved",
+            description="deconvolved fluorescence signal",
+        )
+
+        cls.neuropil_roi_response_series_metadata = dict(
+            name="Neuropil",
+            description="neuropil fluorescence signal",
+            unit="test_unit",
+        )
+
+        cls.metadata["Ophys"]["Fluorescence"].update(
+            name=cls.fluorescence_name,
+            roi_response_series=[
+                cls.raw_roi_response_series_metadata,
+                cls.deconvolved_roi_response_series_metadata,
+                cls.neuropil_roi_response_series_metadata,
+            ],
+        )
+        cls.metadata["Ophys"]["DfOverF"].update(
+            name=cls.df_over_f_name, roi_response_series=[cls.dff_roi_response_series_metadata]
+        )
+
+    def setUp(self):
+        self.segmentation_extractor_first_plane = generate_dummy_segmentation_extractor(
+            num_rois=self.num_rois_first_plane,
+            num_frames=self.num_frames,
+            num_rows=self.num_rows,
+            num_columns=self.num_columns,
+        )
+        self.segmentation_extractor_second_plane = generate_dummy_segmentation_extractor(
+            num_rois=self.num_rois_second_plane,
+            num_frames=self.num_frames,
+            num_rows=self.num_rows,
+            num_columns=self.num_columns,
+        )
+        self.nwbfile = NWBFile(
+            session_description="session_description",
+            identifier="file_id",
+            session_start_time=self.session_start_time,
+        )
+
+    def test_add_fluorescence_traces_for_two_plane_segmentations(self):
+        add_fluorescence_traces(
+            segmentation_extractor=self.segmentation_extractor_first_plane,
+            nwbfile=self.nwbfile,
+            metadata=self.metadata,
+            plane_segmentation_name=self.plane_segmentation_first_plane_name,
+        )
+
+        # Add second plane segmentation metadata
+        metadata = deepcopy(self.metadata)
+        second_imaging_plane_name = "ImagingPlaneSecondPlane"
+        metadata["Ophys"]["ImagingPlane"][0].update(name=second_imaging_plane_name)
+
+        second_plane_segmentation_name = "PlaneSegmentationSecondPlane"
+        metadata["Ophys"]["ImageSegmentation"]["plane_segmentations"][0].update(
+            name=second_plane_segmentation_name,
+            description="second plane segmentation description",
+            imaging_plane=second_imaging_plane_name,
+        )
+
+        fluorescence_second_plane_name = "FluorescenceSecondPlane"
+        metadata["Ophys"]["Fluorescence"].update(name=fluorescence_second_plane_name)
+        df_over_f_second_plane_name = "DfOverFSecondPlane"
+        metadata["Ophys"]["DfOverF"].update(name=df_over_f_second_plane_name)
+
+        add_fluorescence_traces(
+            segmentation_extractor=self.segmentation_extractor_second_plane,
+            nwbfile=self.nwbfile,
+            metadata=metadata,
+            plane_segmentation_name=second_plane_segmentation_name,
+        )
+
+        ophys = get_module(self.nwbfile, "ophys")
+        image_segmentation = ophys.get("ImageSegmentation")
+
+        self.assertEqual(len(image_segmentation.plane_segmentations), 2)
+        self.assertIn(self.plane_segmentation_first_plane_name, image_segmentation.plane_segmentations)
+        self.assertIn(second_plane_segmentation_name, image_segmentation.plane_segmentations)
+        second_plane_segmentation = image_segmentation.plane_segmentations[second_plane_segmentation_name]
+        self.assertEqual(second_plane_segmentation.name, second_plane_segmentation_name)
+        self.assertEqual(second_plane_segmentation.description, "second plane segmentation description")
+
+        fluorescence_first_plane = ophys.get(self.fluorescence_name)
+        self.assertEqual(fluorescence_first_plane.name, self.fluorescence_name)
+        self.assertEqual(len(fluorescence_first_plane.roi_response_series), 3)
+
+        fluorescence_second_plane = ophys.get(fluorescence_second_plane_name)
+        self.assertEqual(fluorescence_second_plane.name, fluorescence_second_plane_name)
+        self.assertEqual(len(fluorescence_second_plane.roi_response_series), 3)
+
+        self.assertEqual(
+            fluorescence_second_plane.roi_response_series["RoiResponseSeries"].data.maxshape,
+            (self.num_frames, self.num_rois_second_plane),
+        )
 
 
 class TestAddPhotonSeries(TestCase):


### PR DESCRIPTION
Related to #603

- Add keyword argument `plane_segmentation_name` to identify which `PlaneSegmentation` to add from ophys metadata
- Expose `plane_segmentation_name` at `BaseSegmentationExtractorInterface.add_to_nwbfile()` to support adding segmentation output from multiple planes
Related to #601 