### PR TITLE
Change `Fluorescence`/`DFOverF` metadata schema for RoiResponseSeries from `array` type to `object`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 * Added Pydantic data models of `BackendConfiguration` for both HDF5 and Zarr datasets (container/mapper of all the `DatasetConfiguration`s for a particular file). [PR #568](https://github.com/catalystneuro/neuroconv/pull/568)
+* Changed the metadata schema for `Fluorescence` and `DfOverF` where the traces metadata can be provided as a dict instead of a list of dicts.
+  The name of the plane segmentation is used to determine which traces to add to the `Fluorescence` and `DfOverF` containers. [PR #632](https://github.com/catalystneuro/neuroconv/pull/632)
 
 
 

--- a/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
@@ -38,13 +38,20 @@ class BaseSegmentationExtractorInterface(BaseExtractorInterface):
         metadata_schema["properties"]["Ophys"]["properties"]["ImagingPlane"].update(type="array")
         metadata_schema["properties"]["Ophys"]["properties"]["TwoPhotonSeries"].update(type="array")
 
-        metadata_schema["properties"]["Ophys"]["properties"]["Fluorescence"]["properties"]["roi_response_series"][
-            "items"
-        ]["required"] = list()
-        metadata_schema["properties"]["Ophys"]["properties"]["ImageSegmentation"]["additionalProperties"] = True
-        metadata_schema["properties"]["Ophys"]["properties"]["Fluorescence"]["properties"]["roi_response_series"].pop(
-            "maxItems"
+        metadata_schema["properties"]["Ophys"]["properties"]["Fluorescence"].update(required=["name"])
+        metadata_schema["properties"]["Ophys"]["properties"]["Fluorescence"].pop("additionalProperties")
+        roi_response_series_schema = metadata_schema["properties"]["Ophys"]["properties"]["Fluorescence"][
+            "properties"
+        ].pop("roi_response_series")
+
+        roi_response_series_schema.pop("maxItems")
+        roi_response_series_schema["items"].update(required=list())
+        metadata_schema["properties"]["Ophys"]["properties"]["Fluorescence"]["properties"].update(
+            patternProperties={"^[a-zA-Z0-9]+$": roi_response_series_schema}
         )
+
+        metadata_schema["properties"]["Ophys"]["properties"]["ImageSegmentation"]["additionalProperties"] = True
+
         metadata_schema["properties"]["Ophys"]["properties"]["DfOverF"] = metadata_schema["properties"]["Ophys"][
             "properties"
         ]["Fluorescence"]

--- a/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
@@ -46,8 +46,11 @@ class BaseSegmentationExtractorInterface(BaseExtractorInterface):
 
         roi_response_series_schema.pop("maxItems")
         roi_response_series_schema["items"].update(required=list())
+        roi_response_series_per_plane_schema = dict(
+            type="object", patternProperties={"^[a-zA-Z0-9]+$": roi_response_series_schema}
+        )
         metadata_schema["properties"]["Ophys"]["properties"]["Fluorescence"]["properties"].update(
-            patternProperties={"^[a-zA-Z0-9]+$": roi_response_series_schema}
+            patternProperties={"^[a-zA-Z0-9]+$": roi_response_series_per_plane_schema}
         )
 
         metadata_schema["properties"]["Ophys"]["properties"]["ImageSegmentation"]["additionalProperties"] = True

--- a/src/neuroconv/schemas/metadata_schema.json
+++ b/src/neuroconv/schemas/metadata_schema.json
@@ -166,10 +166,11 @@
           "required": ["name"],
           "properties": {
             "name": {"type": "string", "default": "DfOverF"},
-            "roi_response_series": {
-              "type": "array",
-              "title": "ROI response series",
-              "items": {"$ref":  "#/definitions/RoiResponseSeries"}
+            "patternProperties": {
+              "^[a-zA-Z0-9]+$": {
+                "type": "object",
+                "title": "ROI response series",
+                "properties": {"$ref":  "#/definitions/RoiResponseSeries"}
             }
           }
         },
@@ -178,10 +179,12 @@
           "required": ["name"],
           "properties": {
             "name": {"type": "string", "default": "Fluorescence"},
-            "roi_response_series": {
-              "type": "array",
-              "title": "ROI response series",
-              "items": {"$ref":  "#/definitions/RoiResponseSeries"}
+            "patternProperties": {
+              "^[a-zA-Z0-9]+$": {
+                "type": "object",
+                "title": "ROI response series",
+                "properties": {"$ref":  "#/definitions/RoiResponseSeries"}
+              }
             }
           }
         },

--- a/src/neuroconv/schemas/metadata_schema.json
+++ b/src/neuroconv/schemas/metadata_schema.json
@@ -169,8 +169,14 @@
             "patternProperties": {
               "^[a-zA-Z0-9]+$": {
                 "type": "object",
-                "title": "ROI response series",
-                "properties": {"$ref":  "#/definitions/RoiResponseSeries"}
+                "patternProperties":{
+                  "^[a-zA-Z0-9]+$": {
+                    "type": "object",
+                    "title": "ROI response series",
+                    "properties": {"$ref":  "#/definitions/RoiResponseSeries"}
+                  }
+                }
+              }
             }
           }
         },
@@ -182,8 +188,13 @@
             "patternProperties": {
               "^[a-zA-Z0-9]+$": {
                 "type": "object",
-                "title": "ROI response series",
-                "properties": {"$ref":  "#/definitions/RoiResponseSeries"}
+                "patternProperties":{
+                  "^[a-zA-Z0-9]+$": {
+                    "type": "object",
+                    "title": "ROI response series",
+                    "properties": {"$ref":  "#/definitions/RoiResponseSeries"}
+                  }
+                }
               }
             }
           }

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -83,7 +83,7 @@ def get_default_segmentation_metadata() -> DeepDict:
 
     default_fluorescence = dict(
         name="Fluorescence",
-        roi_response_series=[default_fluorescence_roi_response_series],
+        raw=default_fluorescence_roi_response_series,
     )
 
     default_dff_roi_response_series = dict(
@@ -94,7 +94,7 @@ def get_default_segmentation_metadata() -> DeepDict:
 
     default_df_over_f = dict(
         name="DfOverF",
-        roi_response_series=[default_dff_roi_response_series],
+        dff=default_dff_roi_response_series,
     )
 
     default_image_segmentation = dict(
@@ -650,12 +650,13 @@ def get_nwb_segmentation_metadata(sgmextractor: SegmentationExtractor) -> dict:
                 )
             )
     for trace_name, trace_data in sgmextractor.get_traces_dict().items():
+        # raw traces have already default name ("RoiResponseSeries")
+        if trace_name in ["raw", "dff"]:
+            continue
         if trace_data is not None and len(trace_data.shape) != 0:
-            metadata["Ophys"]["Fluorescence"]["roi_response_series"].append(
-                dict(
-                    name=trace_name.capitalize(),
-                    description=f"description of {trace_name} traces",
-                )
+            metadata["Ophys"]["Fluorescence"][trace_name] = dict(
+                name=trace_name.capitalize(),
+                description=f"description of {trace_name} traces",
             )
 
     return metadata

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -945,23 +945,16 @@ def add_fluorescence_traces(
     for trace_name, trace in traces_to_add.items():
         # Decide which data interface to use based on the trace name
         data_interface = trace_to_data_interface[trace_name]
-        # Extract the response series metadata
-        # The name of the roi_response_series is "RoiResponseSeries" for raw and df/F traces,
-        # otherwise it is capitalized trace_name.
-        trace_name = "RoiResponseSeries" if trace_name in ["raw", "dff"] else trace_name.capitalize()
-
-        if trace_name in data_interface.roi_response_series:
-            continue
-
         data_interface_metadata = df_over_f_metadata if isinstance(data_interface, DfOverF) else fluorescence_metadata
-        response_series_metadata = data_interface_metadata["roi_response_series"]
-        trace_metadata = next(
-            (trace_metadata for trace_metadata in response_series_metadata if trace_name == trace_metadata["name"]),
-            None,
-        )
+        # Extract the response series metadata
+        # the name of the trace is retrieved from the metadata, no need to override it here
+        # trace_name = "RoiResponseSeries" if trace_name in ["raw", "dff"] else trace_name.capitalize()
+        trace_metadata = data_interface_metadata.get(trace_name, None)
         if trace_metadata is None:
-            raise ValueError(f"Metadata for '{trace_name}' trace not found in {response_series_metadata}.")
+            raise ValueError(f"Metadata for '{trace_name}' trace not found in {data_interface_metadata}.")
 
+        if trace_metadata["name"] in data_interface.roi_response_series:
+            continue
         # Pop the rate from the metadata if irregular time series
         if "timestamps" in roi_response_series_kwargs and "rate" in trace_metadata:
             trace_metadata.pop("rate")

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -118,8 +118,8 @@ def get_default_segmentation_metadata() -> DeepDict:
 
     metadata["Ophys"].update(
         dict(
-            Fluorescence=default_fluorescence,
-            DfOverF=default_df_over_f,
+            Fluorescence=dict(PlaneSegmentation=default_fluorescence),
+            DfOverF=dict(PlaneSegmentation=default_df_over_f),
             ImageSegmentation=default_image_segmentation,
             SegmentationImages=default_segmentation_images,
         ),
@@ -885,11 +885,11 @@ def add_fluorescence_traces(
         plane_segmentation_name or default_metadata["Ophys"]["ImageSegmentation"]["plane_segmentations"][0]["name"]
     )
     # df/F metadata
-    df_over_f_metadata = metadata_copy["Ophys"]["DfOverF"]
+    df_over_f_metadata = metadata_copy["Ophys"]["DfOverF"][plane_segmentation_name]
     df_over_f_name = df_over_f_metadata["name"]
 
     # Fluorescence traces metadata
-    fluorescence_metadata = metadata_copy["Ophys"]["Fluorescence"]
+    fluorescence_metadata = metadata_copy["Ophys"]["Fluorescence"][plane_segmentation_name]
     fluorescence_name = fluorescence_metadata["name"]
 
     # Get traces from the segmentation extractor

--- a/tests/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_ophys/test_tools_roiextractors.py
@@ -821,17 +821,21 @@ class TestAddFluorescenceTraces(unittest.TestCase):
 
         fluorescence_metadata = dict(
             Fluorescence=dict(
-                name=self.fluorescence_name,
-                raw=self.raw_roi_response_series_metadata,
-                deconvolved=self.deconvolved_roi_response_series_metadata,
-                neuropil=self.neuropil_roi_response_series_metadata,
+                PlaneSegmentation=dict(
+                    name=self.fluorescence_name,
+                    raw=self.raw_roi_response_series_metadata,
+                    deconvolved=self.deconvolved_roi_response_series_metadata,
+                    neuropil=self.neuropil_roi_response_series_metadata,
+                )
             )
         )
 
         dff_metadata = dict(
             DfOverF=dict(
-                name=self.df_over_f_name,
-                dff=self.dff_roi_response_series_metadata,
+                PlaneSegmentation=dict(
+                    name=self.df_over_f_name,
+                    dff=self.dff_roi_response_series_metadata,
+                )
             )
         )
 
@@ -1269,14 +1273,22 @@ class TestAddFluorescenceTracesMultiPlaneCase(unittest.TestCase):
         )
 
         cls.metadata["Ophys"]["Fluorescence"].update(
-            name=cls.fluorescence_name,
-            raw=cls.raw_roi_response_series_metadata,
-            deconvolved=cls.deconvolved_roi_response_series_metadata,
-            neuropil=cls.neuropil_roi_response_series_metadata,
+            {
+                cls.plane_segmentation_first_plane_name: dict(
+                    name=cls.fluorescence_name,
+                    raw=cls.raw_roi_response_series_metadata,
+                    deconvolved=cls.deconvolved_roi_response_series_metadata,
+                    neuropil=cls.neuropil_roi_response_series_metadata,
+                )
+            }
         )
         cls.metadata["Ophys"]["DfOverF"].update(
-            name=cls.df_over_f_name,
-            dff=cls.dff_roi_response_series_metadata,
+            {
+                cls.plane_segmentation_first_plane_name: dict(
+                    name=cls.df_over_f_name,
+                    dff=cls.dff_roi_response_series_metadata,
+                )
+            }
         )
 
     def setUp(self):
@@ -1318,10 +1330,21 @@ class TestAddFluorescenceTracesMultiPlaneCase(unittest.TestCase):
             imaging_plane=second_imaging_plane_name,
         )
 
-        metadata["Ophys"]["Fluorescence"]["raw"].update(name="RoiResponseSeriesSecondPlane")
-        metadata["Ophys"]["Fluorescence"]["deconvolved"].update(name="DeconvolvedSecondPlane")
-        metadata["Ophys"]["Fluorescence"]["neuropil"].update(name="NeuropilSecondPlane")
-        metadata["Ophys"]["DfOverF"]["dff"].update(name="RoiResponseSeriesSecondPlane")
+        metadata["Ophys"]["Fluorescence"][second_plane_segmentation_name] = deepcopy(
+            metadata["Ophys"]["Fluorescence"][self.plane_segmentation_first_plane_name]
+        )
+        metadata["Ophys"]["DfOverF"][second_plane_segmentation_name] = deepcopy(
+            metadata["Ophys"]["DfOverF"][self.plane_segmentation_first_plane_name]
+        )
+
+        metadata["Ophys"]["Fluorescence"][second_plane_segmentation_name]["raw"].update(
+            name="RoiResponseSeriesSecondPlane"
+        )
+        metadata["Ophys"]["Fluorescence"][second_plane_segmentation_name]["deconvolved"].update(
+            name="DeconvolvedSecondPlane"
+        )
+        metadata["Ophys"]["Fluorescence"][second_plane_segmentation_name]["neuropil"].update(name="NeuropilSecondPlane")
+        metadata["Ophys"]["DfOverF"][second_plane_segmentation_name]["dff"].update(name="RoiResponseSeriesSecondPlane")
 
         add_fluorescence_traces(
             segmentation_extractor=self.segmentation_extractor_second_plane,

--- a/tests/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_ophys/test_tools_roiextractors.py
@@ -1166,8 +1166,8 @@ class TestAddFluorescenceTraces(unittest.TestCase):
         segmentation_extractor.set_times(times)
 
         metadata = deepcopy(self.metadata)
-        metadata["Ophys"]["Fluorescence"]["raw"].update(rate=1.23)
-        metadata["Ophys"]["DfOverF"]["dff"].update(rate=1.23)
+        metadata["Ophys"]["Fluorescence"]["PlaneSegmentation"]["raw"].update(rate=1.23)
+        metadata["Ophys"]["DfOverF"]["PlaneSegmentation"]["dff"].update(rate=1.23)
 
         add_fluorescence_traces(
             segmentation_extractor=segmentation_extractor,
@@ -1194,7 +1194,7 @@ class TestAddFluorescenceTraces(unittest.TestCase):
         segmentation_extractor.set_times(times)
 
         metadata = deepcopy(self.metadata)
-        metadata["Ophys"]["Fluorescence"]["raw"].update(rate=1.23)
+        metadata["Ophys"]["Fluorescence"]["PlaneSegmentation"]["raw"].update(rate=1.23)
 
         add_fluorescence_traces(
             segmentation_extractor=segmentation_extractor,
@@ -1215,6 +1215,10 @@ class TestAddFluorescenceTraces(unittest.TestCase):
         metadata = dict_deep_update(metadata, self.metadata)
 
         metadata["Ophys"]["ImageSegmentation"]["plane_segmentations"][0].update(name=plane_segmentation_name)
+        metadata["Ophys"]["Fluorescence"][plane_segmentation_name] = metadata["Ophys"]["Fluorescence"].pop(
+            "PlaneSegmentation"
+        )
+        metadata["Ophys"]["DfOverF"][plane_segmentation_name] = metadata["Ophys"]["DfOverF"].pop("PlaneSegmentation")
 
         add_fluorescence_traces(
             segmentation_extractor=self.segmentation_extractor,


### PR DESCRIPTION
Final piece for #601 
Resolve https://github.com/catalystneuro/neuroconv/issues/603

Changes the current metadata schema for `Fluorescence` and `DfOverF` 
- the name of the plane segmentation is used to identify which traces are added to the file. 
- the name of the traces can be changed in the inner schema for the response series metadata (see example below)

Example metadata structure:
```
dict(
    Ophys=dict(
        Fluorescence=dict(
            name="Fluorescence",
            PlaneSegmentationChan1Plane0=dict(
                # raw, deconvolved, neuropil as returned from extractor.get_traces_dict()
                # the "name" determines what the trace will be named in the nwb file in Fluorescence.roi_response_series
                raw=dict(name="RoiResponseSeriesChan1Plane0", description="raw fluorescence signal"),
                deconvolved=dict(name="DeconvolvedChan1Plane0", description="deconvolved fluorescence signal"),
                neuropil=dict(name="NeuropilChan1Plane0", description="neuropil fluorescence signal"),
            ),
            PlaneSegmentationChan1Plane1=dict(
                raw=dict(name="RoiResponseSeriesChan1Plane0", description="raw fluorescence signal"),
                deconvolved=dict(name="DeconvolvedChan1Plane0", description="deconvolved fluorescence signal"),
                neuropil=dict(name="NeuropilChan1Plane0", description="neuropil fluorescence signal"),
            ),
        ),
        DfOverF =dict(
            name="DfOverF"
            PlaneSegmentationChan1Plane0=dict(
                dff=dict(name="RoiResponseSeriesChan1Plane0", description="Array of df/F traces."),
            ),
            PlaneSegmentationChan1Plane1=dict(
                dff=dict(name="RoiResponseSeriesChan1Plane0", description="Array of df/F traces."),
            ),
        ),
    )
)

```