### PR TITLE
Fix audio conversion in case of single-channel .wav

### DIFF
--- a/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
@@ -208,7 +208,9 @@ class AudioInterface(BaseTemporalAlignmentInterface):
         for file_index, (acoustic_waveform_series_metadata, file_path) in enumerate(zip(audio_metadata, file_paths)):
             sampling_rate, acoustic_series = scipy.io.wavfile.read(filename=file_path, mmap=True)
             if len(acoustic_series.shape) == 1:
-                acoustic_series = acoustic_series[:, np.newaxis]  # add_acoustic_waveform_series() below expects a 2D array
+                acoustic_series = acoustic_series[
+                    :, np.newaxis
+                ]  # add_acoustic_waveform_series() below expects a 2D array
 
             if stub_test:
                 acoustic_series = acoustic_series[:stub_frames]

--- a/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
@@ -207,6 +207,8 @@ class AudioInterface(BaseTemporalAlignmentInterface):
 
         for file_index, (acoustic_waveform_series_metadata, file_path) in enumerate(zip(audio_metadata, file_paths)):
             sampling_rate, acoustic_series = scipy.io.wavfile.read(filename=file_path, mmap=True)
+            if len(acoustic_series.shape) == 1:
+                acoustic_series = acoustic_series[:, np.newaxis]  # add_acoustic_waveform_series() below expects a 2D array
 
             if stub_test:
                 acoustic_series = acoustic_series[:stub_frames]


### PR DESCRIPTION
I tried converting a .wav file to .nwb based on this example: https://neuroconv.readthedocs.io/en/main/conversion_examples_gallery/behavior/audio.html

and got this error

```
Traceback (most recent call last):
  File "/mnt/ceph/users/magland/dandi_upload/prepare_ralph_av/prepare_ralph_av.py", line 18, in <module>
    interface.run_conversion(nwbfile_path=path_to_save_nwbfile, metadata=metadata)
  File "/mnt/home/magland/miniconda3/envs/dev/lib/python3.10/site-packages/neuroconv/basedatainterface.py", line 99, in run_conversion
    self.add_to_nwbfile(nwbfile_out, metadata=metadata, **conversion_options)
  File "/mnt/home/magland/miniconda3/envs/dev/lib/python3.10/site-packages/neuroconv/datainterfaces/behavior/audio/audiointerface.py", line 214, in add_to_nwbfile
    add_acoustic_waveform_series(
  File "/mnt/home/magland/miniconda3/envs/dev/lib/python3.10/site-packages/neuroconv/tools/audio/audio.py", line 71, in add_acoustic_waveform_series
    data=H5DataIO(SliceableDataChunkIterator(data=acoustic_series, **iterator_options), **compression_options),
  File "/mnt/home/magland/miniconda3/envs/dev/lib/python3.10/site-packages/neuroconv/tools/hdmf.py", line 83, in __init__
    super().__init__(**kwargs)
  File "/mnt/home/magland/miniconda3/envs/dev/lib/python3.10/site-packages/hdmf/utils.py", line 664, in func_call
    return func(args[0], **pargs)
  File "/mnt/home/magland/miniconda3/envs/dev/lib/python3.10/site-packages/hdmf/data_utils.py", line 220, in __init__
    self.buffer_shape = buffer_shape or self._get_default_buffer_shape(buffer_gb=buffer_gb)
  File "/mnt/home/magland/miniconda3/envs/dev/lib/python3.10/site-packages/neuroconv/tools/hdmf.py", line 28, in _get_default_buffer_shape
    smallest_chunk_axis, second_smallest_chunk_axis, *_ = np.argsort(self.chunk_shape)
ValueError: not enough values to unpack (expected at least 2, got 1)
```

Did some troubleshooting and found

```
Sampling rate: 192000 Hz
Acoustic series shape: (979200000,)
```

Seems like neuroconv is expecting acoustic_series to have more than 1 dimension.

I added these lines and the conversion then seemed to work.