### PR TITLE
Fix GenericDataChunkIterator for large arrays (affects .wav conversion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixes
 * Fixed GenericDataChunkIterator (in hdmf.py) in the case where the number of dimensions is 1 and the size in bytes is greater than the threshold of 1 GB. [PR #638](https://github.com/catalystneuro/neuroconv/pull/638)
-* changed np.floor/np.prod to math.floor/math.prod in various files
+* Changed `np.floor` and `np.prod` usage to `math.floor` and `math.prod` in various files. [PR #638](https://github.com/catalystneuro/neuroconv/pull/638)
 
 # v0.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Features
 * Added Pydantic data models of `BackendConfiguration` for both HDF5 and Zarr datasets (container/mapper of all the `DatasetConfiguration`s for a particular file). [PR #568](https://github.com/catalystneuro/neuroconv/pull/568)
 
-
+### Fixes
+* Fixed GenericDataChunkIterator (in hdmf.py) in the case where the number of dimensions is 1 and the size in bytes is greater than the threshold of 1 GB.
 
 # v0.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Added Pydantic data models of `BackendConfiguration` for both HDF5 and Zarr datasets (container/mapper of all the `DatasetConfiguration`s for a particular file). [PR #568](https://github.com/catalystneuro/neuroconv/pull/568)
 
 ### Fixes
-* Fixed GenericDataChunkIterator (in hdmf.py) in the case where the number of dimensions is 1 and the size in bytes is greater than the threshold of 1 GB.
+* Fixed GenericDataChunkIterator (in hdmf.py) in the case where the number of dimensions is 1 and the size in bytes is greater than the threshold of 1 GB. [PR #638](https://github.com/catalystneuro/neuroconv/pull/638)
 
 # v0.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixes
 * Fixed GenericDataChunkIterator (in hdmf.py) in the case where the number of dimensions is 1 and the size in bytes is greater than the threshold of 1 GB. [PR #638](https://github.com/catalystneuro/neuroconv/pull/638)
+* changed np.floor/np.prod to math.floor/math.prod in various files
 
 # v0.4.5
 

--- a/src/neuroconv/datainterfaces/behavior/video/video_utils.py
+++ b/src/neuroconv/datainterfaces/behavior/video/video_utils.py
@@ -1,5 +1,5 @@
-from typing import Optional, Tuple
 import math
+from typing import Optional, Tuple
 
 import numpy as np
 from hdmf.data_utils import GenericDataChunkIterator

--- a/src/neuroconv/datainterfaces/behavior/video/video_utils.py
+++ b/src/neuroconv/datainterfaces/behavior/video/video_utils.py
@@ -1,4 +1,5 @@
 from typing import Optional, Tuple
+import math
 
 import numpy as np
 from hdmf.data_utils import GenericDataChunkIterator
@@ -206,13 +207,13 @@ class VideoDataChunkIterator(GenericDataChunkIterator):
     @staticmethod
     def _scale_shape_to_size(size_mb, shape, size, max_shape):
         """Given the shape and size of array, return shape that will fit size_mb."""
-        k = np.floor((size_mb / size) ** (1 / len(shape)))
+        k = math.floor((size_mb / size) ** (1 / len(shape)))
         return tuple([min(max(int(x), shape[j]), max_shape[j]) for j, x in enumerate(k * np.array(shape))])
 
     def _get_frame_details(self):
         """Get frame shape and size in MB"""
         frame_shape = (1, *self.video_capture_ob.get_frame_shape())
-        min_frame_size_mb = (np.prod(frame_shape) * self._get_dtype().itemsize) / 1e6
+        min_frame_size_mb = (math.prod(frame_shape) * self._get_dtype().itemsize) / 1e6
         return min_frame_size_mb, frame_shape
 
     def _get_data(self, selection: Tuple[slice]) -> np.ndarray:

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -1,6 +1,6 @@
 """Collection of modifications of HDMF functions that are to be tested/used on this repo until propagation upstream."""
-from typing import Tuple
 import math
+from typing import Tuple
 
 import numpy as np
 from hdmf.data_utils import GenericDataChunkIterator as HDMFGenericDataChunkIterator

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -39,7 +39,7 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
         if min(axis_sizes_bytes) > target_buffer_bytes:
             k1 = np.floor((target_buffer_bytes / chunk_bytes) ** 0.5)
             for axis in [smallest_chunk_axis, second_smallest_chunk_axis]:
-                if axis >= 0: # second_small_chunk_axis may be -1 if there is only one axis
+                if axis >= 0:  # second_small_chunk_axis may be -1 if there is only one axis
                     sub_square_buffer_shape[axis] = k1 * sub_square_buffer_shape[axis]
             return tuple(sub_square_buffer_shape)
 

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -31,7 +31,7 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
             # If the smallest full axis does not fit within the buffer size, form a square along the two smallest axes
             sub_square_buffer_shape = np.array(self.chunk_shape)
             if min(axis_sizes_bytes) > target_buffer_bytes:
-                k1 = np.floor((target_buffer_bytes / chunk_bytes) ** 0.5)
+                k1 = int(np.floor((target_buffer_bytes / chunk_bytes) ** 0.5))
                 for axis in [smallest_chunk_axis, second_smallest_chunk_axis]:
                     sub_square_buffer_shape[axis] = k1 * sub_square_buffer_shape[axis]
                 return tuple(sub_square_buffer_shape)
@@ -39,7 +39,7 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
             smallest_chunk_axis = 0
             # Handle the case where the single axis is too large to fit in the buffer
             if axis_sizes_bytes[0] > target_buffer_bytes:
-                k1 = np.floor(target_buffer_bytes / chunk_bytes)
+                k1 = int(np.floor(target_buffer_bytes / chunk_bytes))
                 return tuple(
                     [
                         k1 * self.chunk_shape[0],
@@ -50,7 +50,7 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
 
         # Original one-shot estimation has good performance for certain shapes
         chunk_to_buffer_ratio = buffer_gb * 1e9 / chunk_bytes
-        chunk_scaling_factor = np.floor(chunk_to_buffer_ratio ** (1 / num_axes))
+        chunk_scaling_factor = int(np.floor(chunk_to_buffer_ratio ** (1 / num_axes)))
         unpadded_buffer_shape = [
             np.clip(a=int(x), a_min=self.chunk_shape[j], a_max=self.maxshape[j])
             for j, x in enumerate(chunk_scaling_factor * np.array(self.chunk_shape))
@@ -74,7 +74,7 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
                 buffer_bytes *= chunks_on_axis
                 padded_buffer_shape[axis] = self.maxshape[axis]
             else:  # Found an axis that is too large to use with the rest of the buffer; calculate how much can be used
-                k3 = np.floor(target_buffer_bytes / buffer_bytes)
+                k3 = int(np.floor(target_buffer_bytes / buffer_bytes))
                 padded_buffer_shape[axis] *= k3
                 break
         padded_buffer_bytes = np.prod(padded_buffer_shape) * self.dtype.itemsize

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -41,7 +41,11 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
             # Handle the case where the single axis is too large to fit in the buffer
             if axis_sizes_bytes[0] > target_buffer_bytes:
                 k1 = np.floor(target_buffer_bytes / chunk_bytes)
-                return tuple([k1 * self.chunk_shape[0],])
+                return tuple(
+                    [
+                        k1 * self.chunk_shape[0],
+                    ]
+                )
         else:
             raise ValueError(f"num_axes ({num_axes}) is less than one!")
 

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -37,7 +37,6 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
                 return tuple(sub_square_buffer_shape)
         elif num_axes == 1:
             smallest_chunk_axis = 0
-            second_smallest_chunk_axis = -1
             # Handle the case where the single axis is too large to fit in the buffer
             if axis_sizes_bytes[0] > target_buffer_bytes:
                 k1 = np.floor(target_buffer_bytes / chunk_bytes)

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -25,7 +25,13 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
 
         buffer_bytes = chunk_bytes
         axis_sizes_bytes = maxshape * self.dtype.itemsize
-        smallest_chunk_axis, second_smallest_chunk_axis, *_ = np.argsort(self.chunk_shape)
+        if num_axes > 1:
+            smallest_chunk_axis, second_smallest_chunk_axis, *_ = np.argsort(self.chunk_shape)
+        elif num_axes == 1:
+            smallest_chunk_axis = 0
+            second_smallest_chunk_axis = -1
+        else:
+            raise ValueError(f"num_axes ({num_axes}) is less than one!")
         target_buffer_bytes = buffer_gb * 1e9
 
         # If the smallest full axis does not fit within the buffer size, form a square along the two smallest axes
@@ -33,7 +39,8 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
         if min(axis_sizes_bytes) > target_buffer_bytes:
             k1 = np.floor((target_buffer_bytes / chunk_bytes) ** 0.5)
             for axis in [smallest_chunk_axis, second_smallest_chunk_axis]:
-                sub_square_buffer_shape[axis] = k1 * sub_square_buffer_shape[axis]
+                if axis >= 0: # second_small_chunk_axis may be -1 if there is only one axis
+                    sub_square_buffer_shape[axis] = k1 * sub_square_buffer_shape[axis]
             return tuple(sub_square_buffer_shape)
 
         # Original one-shot estimation has good performance for certain shapes

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -1,5 +1,6 @@
 """Collection of modifications of HDMF functions that are to be tested/used on this repo until propagation upstream."""
 from typing import Tuple
+import math
 
 import numpy as np
 from hdmf.data_utils import GenericDataChunkIterator as HDMFGenericDataChunkIterator
@@ -8,7 +9,7 @@ from hdmf.data_utils import GenericDataChunkIterator as HDMFGenericDataChunkIter
 class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
     def _get_default_buffer_shape(self, buffer_gb: float = 1.0) -> Tuple[int]:
         num_axes = len(self.maxshape)
-        chunk_bytes = np.prod(self.chunk_shape) * self.dtype.itemsize
+        chunk_bytes = math.prod(self.chunk_shape) * self.dtype.itemsize
         assert buffer_gb > 0, f"buffer_gb ({buffer_gb}) must be greater than zero!"
         assert (
             buffer_gb >= chunk_bytes / 1e9
@@ -20,7 +21,7 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
         maxshape = np.array(self.maxshape)
 
         # Early termination condition
-        if np.prod(maxshape) * self.dtype.itemsize / 1e9 < buffer_gb:
+        if math.prod(maxshape) * self.dtype.itemsize / 1e9 < buffer_gb:
             return tuple(self.maxshape)
 
         buffer_bytes = chunk_bytes
@@ -31,7 +32,7 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
             # If the smallest full axis does not fit within the buffer size, form a square along the two smallest axes
             sub_square_buffer_shape = np.array(self.chunk_shape)
             if min(axis_sizes_bytes) > target_buffer_bytes:
-                k1 = int(np.floor((target_buffer_bytes / chunk_bytes) ** 0.5))
+                k1 = math.floor((target_buffer_bytes / chunk_bytes) ** 0.5)
                 for axis in [smallest_chunk_axis, second_smallest_chunk_axis]:
                     sub_square_buffer_shape[axis] = k1 * sub_square_buffer_shape[axis]
                 return tuple(sub_square_buffer_shape)
@@ -39,7 +40,7 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
             smallest_chunk_axis = 0
             # Handle the case where the single axis is too large to fit in the buffer
             if axis_sizes_bytes[0] > target_buffer_bytes:
-                k1 = int(np.floor(target_buffer_bytes / chunk_bytes))
+                k1 = math.floor(target_buffer_bytes / chunk_bytes)
                 return tuple(
                     [
                         k1 * self.chunk_shape[0],
@@ -50,13 +51,13 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
 
         # Original one-shot estimation has good performance for certain shapes
         chunk_to_buffer_ratio = buffer_gb * 1e9 / chunk_bytes
-        chunk_scaling_factor = int(np.floor(chunk_to_buffer_ratio ** (1 / num_axes)))
+        chunk_scaling_factor = math.floor(chunk_to_buffer_ratio ** (1 / num_axes))
         unpadded_buffer_shape = [
             np.clip(a=int(x), a_min=self.chunk_shape[j], a_max=self.maxshape[j])
             for j, x in enumerate(chunk_scaling_factor * np.array(self.chunk_shape))
         ]
 
-        unpadded_buffer_bytes = np.prod(unpadded_buffer_shape) * self.dtype.itemsize
+        unpadded_buffer_bytes = math.prod(unpadded_buffer_shape) * self.dtype.itemsize
 
         # Method that starts by filling the smallest axis completely or calculates best partial fill
         padded_buffer_shape = np.array(self.chunk_shape)
@@ -74,10 +75,10 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
                 buffer_bytes *= chunks_on_axis
                 padded_buffer_shape[axis] = self.maxshape[axis]
             else:  # Found an axis that is too large to use with the rest of the buffer; calculate how much can be used
-                k3 = int(np.floor(target_buffer_bytes / buffer_bytes))
+                k3 = int(math.floor(target_buffer_bytes / buffer_bytes))
                 padded_buffer_shape[axis] *= k3
                 break
-        padded_buffer_bytes = np.prod(padded_buffer_shape) * self.dtype.itemsize
+        padded_buffer_bytes = math.prod(padded_buffer_shape) * self.dtype.itemsize
 
         if padded_buffer_bytes >= unpadded_buffer_bytes:
             return tuple(padded_buffer_shape)

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -75,7 +75,7 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
                 buffer_bytes *= chunks_on_axis
                 padded_buffer_shape[axis] = self.maxshape[axis]
             else:  # Found an axis that is too large to use with the rest of the buffer; calculate how much can be used
-                k3 = int(math.floor(target_buffer_bytes / buffer_bytes))
+                k3 = math.floor(target_buffer_bytes / buffer_bytes)
                 padded_buffer_shape[axis] *= k3
                 break
         padded_buffer_bytes = math.prod(padded_buffer_shape) * self.dtype.itemsize

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -1,5 +1,6 @@
 """General purpose iterator for all ImagingExtractor data."""
 from typing import Optional, Tuple
+import math
 
 import numpy as np
 from hdmf.data_utils import GenericDataChunkIterator
@@ -88,7 +89,7 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
 
         image_size = self._get_maxshape()[1:]
         min_buffer_shape = tuple([chunk_shape[0]]) + image_size
-        scaling_factor = np.floor((buffer_gb * 1e9 / (np.prod(min_buffer_shape) * self._get_dtype().itemsize)))
+        scaling_factor = math.floor((buffer_gb * 1e9 / (math.prod(min_buffer_shape) * self._get_dtype().itemsize)))
         max_buffer_shape = tuple([int(scaling_factor * min_buffer_shape[0])]) + image_size
         scaled_buffer_shape = tuple(
             [

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -1,6 +1,6 @@
 """General purpose iterator for all ImagingExtractor data."""
-from typing import Optional, Tuple
 import math
+from typing import Optional, Tuple
 
 import numpy as np
 from hdmf.data_utils import GenericDataChunkIterator

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -1,8 +1,8 @@
+import math
 from collections import defaultdict
 from copy import deepcopy
 from typing import Literal, Optional
 from warnings import warn
-import math
 
 import numpy as np
 import psutil

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from copy import deepcopy
 from typing import Literal, Optional
 from warnings import warn
+import math
 
 import numpy as np
 import psutil
@@ -463,7 +464,7 @@ def check_if_imaging_fits_into_memory(imaging: ImagingExtractor) -> None:
     image_size = imaging.get_image_size()
     num_frames = imaging.get_num_frames()
 
-    traces_size_in_bytes = num_frames * np.prod(image_size) * element_size_in_bytes
+    traces_size_in_bytes = num_frames * math.prod(image_size) * element_size_in_bytes
     available_memory_in_bytes = psutil.virtual_memory().available
 
     if traces_size_in_bytes > available_memory_in_bytes:

--- a/src/neuroconv/tools/testing/mock_ttl_signals.py
+++ b/src/neuroconv/tools/testing/mock_ttl_signals.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Optional, Union
+import math
 
 import numpy as np
 from numpy.typing import DTypeLike
@@ -84,7 +85,7 @@ def generate_mock_ttl_signal(
 
     if np.issubdtype(dtype, np.unsignedinteger):
         # If data type is an unsigned integer, increment the signed default values by the midpoint of the unsigned range
-        shift = np.floor(np.iinfo(dtype).max / 2).astype(int)
+        shift = math.floor(np.iinfo(dtype).max / 2).astype(int)
         baseline_mean_int16_default += shift
         signal_mean_int16_default += shift
 
@@ -271,7 +272,7 @@ def regenerate_test_cases(folder_path: FolderPathType, regenerate_reference_imag
         if regenerate_reference_images:
             fig.add_trace(
                 go.Scatter(y=time_series_data, text=time_series_name),
-                row=np.floor(plot_index / num_cols).astype(int) + 1,
+                row=math.floor(plot_index / num_cols).astype(int) + 1,
                 col=int(plot_index % num_cols) + 1,
             )
             plot_index += 1

--- a/src/neuroconv/tools/testing/mock_ttl_signals.py
+++ b/src/neuroconv/tools/testing/mock_ttl_signals.py
@@ -85,7 +85,7 @@ def generate_mock_ttl_signal(
 
     if np.issubdtype(dtype, np.unsignedinteger):
         # If data type is an unsigned integer, increment the signed default values by the midpoint of the unsigned range
-        shift = math.floor(np.iinfo(dtype).max / 2).astype(int)
+        shift = math.floor(np.iinfo(dtype).max / 2)
         baseline_mean_int16_default += shift
         signal_mean_int16_default += shift
 

--- a/src/neuroconv/tools/testing/mock_ttl_signals.py
+++ b/src/neuroconv/tools/testing/mock_ttl_signals.py
@@ -272,7 +272,7 @@ def regenerate_test_cases(folder_path: FolderPathType, regenerate_reference_imag
         if regenerate_reference_images:
             fig.add_trace(
                 go.Scatter(y=time_series_data, text=time_series_name),
-                row=math.floor(plot_index / num_cols).astype(int) + 1,
+                row=math.floor(plot_index / num_cols) + 1,
                 col=int(plot_index % num_cols) + 1,
             )
             plot_index += 1

--- a/src/neuroconv/tools/testing/mock_ttl_signals.py
+++ b/src/neuroconv/tools/testing/mock_ttl_signals.py
@@ -1,6 +1,6 @@
+import math
 from pathlib import Path
 from typing import Optional, Union
-import math
 
 import numpy as np
 from numpy.typing import DTypeLike

--- a/tests/test_behavior/test_audio_interface.py
+++ b/tests/test_behavior/test_audio_interface.py
@@ -202,11 +202,13 @@ On instance['Audio']['write_as']:
         self.nwb_converter.run_conversion(
             nwbfile_path=nwbfile_path,
             metadata=self.metadata,
-            conversion_options=dict(Audio=dict(
-                iterator_options=dict(
-                    buffer_gb=1e7 / 1e9,
+            conversion_options=dict(
+                Audio=dict(
+                    iterator_options=dict(
+                        buffer_gb=1e7 / 1e9,
+                    )
                 )
-            )), # use a low buffer_gb so we can test the full GenericDataChunkIterator
+            ),  # use a low buffer_gb so we can test the full GenericDataChunkIterator
         )
 
         with NWBHDF5IO(path=nwbfile_path, mode="r") as io:

--- a/tests/test_behavior/test_audio_interface.py
+++ b/tests/test_behavior/test_audio_interface.py
@@ -42,7 +42,7 @@ class TestAudioInterface(AudioInterfaceTestMixin, TestCase):
     @classmethod
     def setUpClass(cls):
         cls.session_start_time = datetime.now(tz=gettz(name="US/Pacific"))
-        cls.num_frames = 10000
+        cls.num_frames = int(1e7)
         cls.num_audio_files = 3
         cls.sampling_rate = 500
         cls.aligned_segment_starting_times = [0.0, 20.0, 40.0]
@@ -199,7 +199,15 @@ On instance['Audio']['write_as']:
         audio_test_data = [read(filename=file_path, mmap=True)[1] for file_path in file_paths]
 
         nwbfile_path = str(self.test_dir / "audio_test_data.nwb")
-        self.nwb_converter.run_conversion(nwbfile_path=nwbfile_path, metadata=self.metadata)
+        self.nwb_converter.run_conversion(
+            nwbfile_path=nwbfile_path,
+            metadata=self.metadata,
+            conversion_options=dict(Audio=dict(
+                iterator_options=dict(
+                    buffer_gb=1e7 / 1e9,
+                )
+            )), # use a low buffer_gb so we can test the full GenericDataChunkIterator
+        )
 
         with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
             nwbfile = io.read()

--- a/tests/test_behavior/test_video_utils.py
+++ b/tests/test_behavior/test_video_utils.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import unittest
 from datetime import datetime
+import math
 
 import numpy as np
 from hdmf.backends.hdf5.h5_utils import H5DataIO
@@ -204,7 +205,7 @@ class TestVideoInterface(unittest.TestCase):
             )
 
     def test_small_buffer_size(self):
-        frame_size_mb = np.prod(self.frame_shape) / 1e6
+        frame_size_mb = math.prod(self.frame_shape) / 1e6
         buffer_size = frame_size_mb / 1e3 / 2
         video_file = self.create_video(self.fps, self.frame_shape, self.number_of_frames)
         with self.assertRaises(AssertionError):

--- a/tests/test_behavior/test_video_utils.py
+++ b/tests/test_behavior/test_video_utils.py
@@ -1,8 +1,8 @@
+import math
 import os
 import tempfile
 import unittest
 from datetime import datetime
-import math
 
 import numpy as np
 from hdmf.backends.hdf5.h5_utils import H5DataIO

--- a/tests/test_ophys/test_imagingextractordatachunkiterator.py
+++ b/tests/test_ophys/test_imagingextractordatachunkiterator.py
@@ -1,4 +1,5 @@
 import math
+
 import numpy as np
 from hdmf.testing import TestCase
 from numpy.testing import assert_array_equal

--- a/tests/test_ophys/test_imagingextractordatachunkiterator.py
+++ b/tests/test_ophys/test_imagingextractordatachunkiterator.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 from hdmf.testing import TestCase
 from numpy.testing import assert_array_equal
@@ -157,7 +158,7 @@ class TestImagingExtractorDataChunkIterator(TestCase):
         )
 
         if buffer_gb is not None:
-            assert ((np.prod(dci.buffer_shape) * self.imaging_extractor.get_dtype().itemsize) / 1e9) <= buffer_gb
+            assert ((math.prod(dci.buffer_shape) * self.imaging_extractor.get_dtype().itemsize) / 1e9) <= buffer_gb
 
         data_chunks = np.zeros(dci.maxshape)
         for data_chunk in dci:

--- a/tests/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_ophys/test_tools_roiextractors.py
@@ -1,10 +1,10 @@
+import math
 import unittest
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from tempfile import mkdtemp
 from types import MethodType
-import math
 from typing import List, Literal, Optional, Tuple
 from unittest.mock import Mock
 

--- a/tests/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_ophys/test_tools_roiextractors.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from tempfile import mkdtemp
 from types import MethodType
+import math
 from typing import List, Literal, Optional, Tuple
 from unittest.mock import Mock
 
@@ -1469,7 +1470,7 @@ class TestAddPhotonSeries(TestCase):
         available_memory_in_bytes = psutil.virtual_memory().available
 
         excess = 1.5  # Of what is available in memory
-        num_frames_to_overflow = (available_memory_in_bytes * excess) / (element_size_in_bytes * np.prod(image_size))
+        num_frames_to_overflow = (available_memory_in_bytes * excess) / (element_size_in_bytes * math.prod(image_size))
 
         # Mock recording extractor with as much frames as necessary to overflow memory
         mock_imaging = Mock()


### PR DESCRIPTION
This is a better alternative to https://github.com/catalystneuro/neuroconv/pull/636 as it fixes a more fundamental issue.

The previous version of GenericDataChunkIterator raises an exception in the case where
* The array has only one dimension and
* The array is large enough to not satisfy the early termination condition

This issue was not being picked up by the tests because the simulated .wav files are not nearly large enough to get passed the early termination condition.

The problematic line was

```
smallest_chunk_axis, second_smallest_chunk_axis, *_ = np.argsort(self.chunk_shape)
```

because in the case of a 1D array, there is no second smallest chunk axis. So with this PR, this case is handled separately.

In terms of verifying that this works properly, I temporarily removed the early termination condition and the tests passed (the sample .wav files are single channel). I'm not sure how to put in a proper test though because I don't think we want >1GB test files, and it wouldn't be easy to lower the buffer_gb threshold just for the test.