### PR TITLE
Fix number_of_jobs parsing

### DIFF
--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -56,7 +56,7 @@ jobs:
 
   run-doctests-only:
     needs: assess-file-changes
-    if: ${{ needs.assess-file-changes.outputs.CONVERSION_GALLERY_CHANGED == 'true' && needs.assess-file-changes.outputs.SOURCE_CHANGED != 'true' }}
+    if: ${{ needs.assess-file-changes.outputs.CONVERSION_GALLERY_CHANGED == 'true' || needs.assess-file-changes.outputs.SOURCE_CHANGED != 'true' }}
     uses: catalystneuro/neuroconv/.github/workflows/doctests.yml@main
 
   check-final-status:

--- a/src/neuroconv/tools/data_transfers.py
+++ b/src/neuroconv/tools/data_transfers.py
@@ -321,8 +321,8 @@ def automatic_dandi_upload(
     )
     dandiset_path = dandiset_folder_path / dandiset_id
     # Odd big of logic upstream: https://github.com/dandi/dandi-cli/blob/master/dandi/cli/cmd_upload.py#L92-L96
-    if number_of_threads is not None and number_of_threads > 1 and jobs is None:
-        jobs = -1
+    if number_of_threads is not None and number_of_threads > 1 and number_of_jobs is None:
+        number_of_jobs = -1
 
     url_base = "https://gui-staging.dandiarchive.org" if staging else "https://dandiarchive.org"
     dandiset_url = f"{url_base}/dandiset/{dandiset_id}/{version}"


### PR DESCRIPTION
Replaced `jobs` with the correct variable (`number_of_jobs`) when parsing the user's selection of job count from the GUIDE.