### PR TITLE
Modify the filtering of traces to also filter out traces with empty values

### DIFF
--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -903,7 +903,9 @@ def add_fluorescence_traces(
     traces_to_add = segmentation_extractor.get_traces_dict()
 
     # Filter empty data
-    traces_to_add = {trace_name: trace for trace_name, trace in traces_to_add.items() if trace is not None}
+    traces_to_add = {
+        trace_name: trace for trace_name, trace in traces_to_add.items() if trace is not None and trace.size
+    }
     # Filter all zero data
     # traces_to_add = {
     #     trace_name: trace for trace_name, trace in traces_to_add.items() if any(x != 0 for x in np.ravel(trace))

--- a/tests/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_ophys/test_tools_roiextractors.py
@@ -989,6 +989,23 @@ class TestAddFluorescenceTraces(unittest.TestCase):
 
         self.assertEqual(len(roi_response_series), 2)
 
+    def test_add_fluorescence_one_of_the_traces_is_empty(self):
+        """Test that roi response series with empty values are not added to the nwbfile."""
+
+        self.segmentation_extractor._roi_response_deconvolved = np.empty((self.num_frames, 0))
+
+        add_fluorescence_traces(
+            segmentation_extractor=self.segmentation_extractor,
+            nwbfile=self.nwbfile,
+            metadata=self.metadata,
+        )
+
+        ophys = get_module(self.nwbfile, "ophys")
+        roi_response_series = ophys.get(self.fluorescence_name).roi_response_series
+
+        assert "Deconvolved" not in roi_response_series
+        self.assertEqual(len(roi_response_series), 2)
+
     def test_add_fluorescence_one_of_the_traces_is_all_zeros(self):
         """Test that roi response series with all zero values are not added to the
         nwbfile."""


### PR DESCRIPTION
as seen with the Pinto lab, traces from a second channel can be "empty"