### PR TITLE
change from using fparse to using parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Fixed GenericDataChunkIterator (in hdmf.py) in the case where the number of dimensions is 1 and the size in bytes is greater than the threshold of 1 GB. [PR #638](https://github.com/catalystneuro/neuroconv/pull/638)
 * Changed `np.floor` and `np.prod` usage to `math.floor` and `math.prod` in various files. [PR #638](https://github.com/catalystneuro/neuroconv/pull/638)
 
+### Improvements
+* Change metadata extraction library from `fparse` to `parse`. [PR #654](https://github.com/catalystneuro/neuroconv/pull/654)
+
 # v0.4.5
 
 ### Back-compatibility break

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -10,4 +10,4 @@ psutil>=5.8.0
 tqdm>=4.60.0
 dandi>=0.57.0
 pandas
-fparse
+parse>=1.20.0

--- a/src/neuroconv/tools/path_expansion.py
+++ b/src/neuroconv/tools/path_expansion.py
@@ -1,10 +1,11 @@
-"""Helpful classes for expanding file or folder paths on a system given a f-string rule for matching patterns."""
+"""Helpful classes for expanding file or folder paths on a system given an f-string rule for matching patterns."""
 import abc
 import os
+from datetime import date, datetime
 from pathlib import Path
 from typing import Dict, Iterable, List
 
-from fparse import parse
+from parse import parse
 from pydantic import DirectoryPath, FilePath
 
 from ..utils import DeepDict
@@ -81,6 +82,8 @@ class AbstractPathExpander(abc.ABC):
 
                     for meta_key, meta_val in metadata.items():
                         super_key = standard_metadata.get(meta_key, non_standard_super)
+                        if meta_key == "session_start_time" and isinstance(meta_val, date):
+                            meta_val = datetime(meta_val.year, meta_val.month, meta_val.day)
                         out[key]["metadata"][super_key][meta_key] = meta_val
 
         return list(dict(out).values())


### PR DESCRIPTION
Over the last week or so I worked with the new dev of the `parse` library to incorporate the datetime parsing into that library: https://github.com/r1chardj0n3s/parse/pull/165. This was the only feature that motivated the splinter of `fparse`, so we can now move our dependence back to `parse` with version >=1.20.0 and archive `fparse`.

There is one small difference in the `parse` implementation, which is that it infers whether the parsed value should be a `datetime`, a `date`, or a `time`. If no time information is present, `parse` returns a `date` object. NeuroConv expects a `datetime`, and I think PyNWB requires a `datetime` for the `session_start_time`, so for backwards compatibility and for better compatibility with PyNWB, I included a line that transforms `date`s to `datetime`s when extracting metadata.

I'd really like NWB to accept just a date value there, since the actual time is often missing and must be filled in with incorrect data. If https://github.com/NeurodataWithoutBorders/nwb-schema/pull/542 ever gets merged we can switch this back to returning dates when only date information is given. However I don't want that issue to hold up this one so I'd like to move forward with datetimes for now.