### PR TITLE
Make DANDI optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 ### Improvements
 * Change metadata extraction library from `fparse` to `parse`. [PR #654](https://github.com/catalystneuro/neuroconv/pull/654)
+* The `dandi` CLI/API is now an optional dependency; it is still required to use the `tool` function for automated upload. [PR #655](https://github.com/catalystneuro/neuroconv/pull/655)
+
+
 
 # v0.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Improvements
 * Change metadata extraction library from `fparse` to `parse`. [PR #654](https://github.com/catalystneuro/neuroconv/pull/654)
-* The `dandi` CLI/API is now an optional dependency; it is still required to use the `tool` function for automated upload. [PR #655](https://github.com/catalystneuro/neuroconv/pull/655)
+* The `dandi` CLI/API is now an optional dependency; it is still required to use the `tool` function for automated upload as well as the YAML-based NeuroConv CLI. [PR #655](https://github.com/catalystneuro/neuroconv/pull/655)
 
 
 

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -6,8 +6,9 @@ h5py>=3.9.0
 hdmf>=3.11.0
 hdmf_zarr>=0.4.0
 pynwb>=2.3.2;python_version>='3.8'
+nwbinspector>=0.4.31
+pydantic>=1.10.13,<2.0.0
 psutil>=5.8.0
 tqdm>=4.60.0
-dandi>=0.57.0
 pandas
 parse>=1.20.0

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     extras_require=extras_require,
     entry_points={
         "console_scripts": [
-            "neuroconv = neuroconv.tools.yaml_conversion_specification.yaml_conversion_specification:run_conversion_from_yaml_cli",
+            "neuroconv = neuroconv.tools._yaml_conversion_specification.yaml_conversion_specification:run_conversion_from_yaml_cli",
         ],
     },
     license="BSD-3-Clause",

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ with open(root / "requirements-testing.txt") as f:
 
 extras_require = defaultdict(list)
 extras_require["dandi"] = "dandi>=0.58.0"
+extras_require["full"].extend(extras_require["dandi"])
 
 extras_require.update(test=testing_suite_dependencies, docs=documentation_dependencies)
 for modality in ["ophys", "ecephys", "icephys", "behavior", "text"]:

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ with open(root / "requirements-testing.txt") as f:
     testing_suite_dependencies = f.readlines()
 
 extras_require = defaultdict(list)
+extras_require["dandi"] = "dandi>=0.58.0"
+
 extras_require.update(test=testing_suite_dependencies, docs=documentation_dependencies)
 for modality in ["ophys", "ecephys", "icephys", "behavior", "text"]:
     modality_path = root / "src" / "neuroconv" / "datainterfaces" / modality

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(root / "requirements-testing.txt") as f:
     testing_suite_dependencies = f.readlines()
 
 extras_require = defaultdict(list)
-extras_require["dandi"] = "dandi>=0.58.0"
+extras_require["dandi"].append("dandi>=0.58.0")
 extras_require["full"].extend(extras_require["dandi"])
 
 extras_require.update(test=testing_suite_dependencies, docs=documentation_dependencies)

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     extras_require=extras_require,
     entry_points={
         "console_scripts": [
-            "neuroconv = neuroconv.tools._yaml_conversion_specification.yaml_conversion_specification:run_conversion_from_yaml_cli",
+            "neuroconv = neuroconv.tools.yaml_conversion_specification._yaml_conversion_specification:run_conversion_from_yaml_cli",
         ],
     },
     license="BSD-3-Clause",

--- a/src/neuroconv/tools/__init__.py
+++ b/src/neuroconv/tools/__init__.py
@@ -1,3 +1,4 @@
+"""Collection of all helper functions that require at least one external dependency (some being optional as well)."""
 from .importing import get_package
 from .nwb_helpers import get_module
 from .path_expansion import LocalPathExpander

--- a/src/neuroconv/tools/data_transfers/__init__.py
+++ b/src/neuroconv/tools/data_transfers/__init__.py
@@ -1,0 +1,5 @@
+"""Collection of helper functions for assessing and performing automated data transfers."""
+from ._dandi import automatic_dandi_upload
+from ._globus import get_globus_dataset_content_sizes, transfer_globus_content
+from ._aws import estimate_s3_conversion_cost
+from ._helpers import estimate_total_conversion_runtime

--- a/src/neuroconv/tools/data_transfers/__init__.py
+++ b/src/neuroconv/tools/data_transfers/__init__.py
@@ -1,5 +1,5 @@
 """Collection of helper functions for assessing and performing automated data transfers."""
+from ._aws import estimate_s3_conversion_cost
 from ._dandi import automatic_dandi_upload
 from ._globus import get_globus_dataset_content_sizes, transfer_globus_content
-from ._aws import estimate_s3_conversion_cost
 from ._helpers import estimate_total_conversion_runtime

--- a/src/neuroconv/tools/data_transfers/_aws.py
+++ b/src/neuroconv/tools/data_transfers/_aws.py
@@ -1,0 +1,34 @@
+"""Collection of helper functions for assessing and performing automated data transfers related to AWS."""
+
+
+def estimate_s3_conversion_cost(
+    total_mb: float,
+    transfer_rate_mb: float = 20.0,
+    conversion_rate_mb: float = 17.0,
+    upload_rate_mb: float = 40.0,
+    compression_ratio: float = 1.7,
+):
+    """
+    Estimate potential cost of performing an entire conversion on S3 using full automation.
+
+    Parameters
+    ----------
+    total_mb: float
+        The total amount of data (in MB) that will be transferred, converted, and uploaded to dandi.
+    transfer_rate_mb : float, default: 20.0
+        Estimate of the transfer rate for the data.
+    conversion_rate_mb : float, default: 17.0
+        Estimate of the conversion rate for the data. Can vary widely depending on conversion options and type of data.
+        Figure of 17MB/s is based on extensive compression of high-volume, high-resolution ecephys.
+    upload_rate_mb : float, default: 40.0
+        Estimate of the upload rate of a single file to the DANDI Archive.
+    compression_ratio : float, default: 1.7
+        Estimate of the final average compression ratio for datasets in the file. Can vary widely.
+    """
+    c = 1 / compression_ratio  # compressed_size = total_size * c
+    total_mb_s = (
+        total_mb**2 / 2 * (1 / transfer_rate_mb + (2 * c + 1) / conversion_rate_mb + 2 * c**2 / upload_rate_mb)
+    )
+    cost_gb_m = 0.08 / 1e3  # $0.08 / GB Month
+    cost_mb_s = cost_gb_m / (1e3 * 2.628e6)  # assuming 30 day month; unsure how amazon weights shorter months?
+    return cost_mb_s * total_mb_s

--- a/src/neuroconv/tools/data_transfers/_dandi.py
+++ b/src/neuroconv/tools/data_transfers/_dandi.py
@@ -1,0 +1,118 @@
+"""Collection of helper functions for assessing and performing automated data transfers for the DANDI archive."""
+import os
+from pathlib import Path
+from shutil import rmtree
+from tempfile import mkdtemp
+from typing import Union
+from warnings import warn
+
+from pynwb import NWBHDF5IO
+
+from ..utils import FolderPathType, OptionalFolderPathType
+
+
+def automatic_dandi_upload(
+    dandiset_id: str,
+    nwb_folder_path: FolderPathType,
+    dandiset_folder_path: OptionalFolderPathType = None,
+    version: str = "draft",
+    staging: bool = False,
+    cleanup: bool = False,
+    number_of_jobs: Union[int, None] = None,
+    number_of_threads: Union[int, None] = None,
+):
+    """
+    Fully automated upload of NWBFiles to a DANDISet.
+
+    Requires an API token set as an envrinment variable named DANDI_API_KEY.
+
+    To set this in your bash terminal in Linux or MacOS, run
+        export DANDI_API_KEY=...
+    or in Windows
+        set DANDI_API_KEY=...
+
+    DO NOT STORE THIS IN ANY PUBLICLY SHARED CODE.
+
+    Parameters
+    ----------
+    dandiset_id : str
+        Six-digit string identifier for the DANDISet the NWBFiles will be uploaded to.
+    nwb_folder_path : folder path
+        Folder containing the NWBFiles to be uploaded.
+    dandiset_folder_path : folder path, optional
+        A separate folder location within which to download the dandiset.
+        Used in cases where you do not have write permissions for the parent of the 'nwb_folder_path' directory.
+        Default behavior downloads the DANDISet to a folder adjacent to the 'nwb_folder_path'.
+    version : {None, "draft", "version"}
+        The default is "draft".
+    staging : bool, default: False
+        Is the DANDISet hosted on the staging server? This is mostly for testing purposes.
+        The default is False.
+    cleanup : bool, default: False
+        Whether to remove the dandiset folder path and nwb_folder_path.
+        Defaults to False.
+    number_of_jobs : int, optional
+        The number of jobs to use in the DANDI upload process.
+    number_of_threads : int, optional
+        The number of threads to use in the DANDI upload process.
+    """
+    from dandi.download import download as dandi_download
+    from dandi.organize import organize as dandi_organize
+    from dandi.upload import upload as dandi_upload
+
+    assert os.getenv("DANDI_API_KEY"), (
+        "Unable to find environment variable 'DANDI_API_KEY'. "
+        "Please retrieve your token from DANDI and set this environment variable."
+    )
+
+    dandiset_folder_path = (
+        Path(mkdtemp(dir=nwb_folder_path.parent)) if dandiset_folder_path is None else dandiset_folder_path
+    )
+    dandiset_path = dandiset_folder_path / dandiset_id
+    # Odd big of logic upstream: https://github.com/dandi/dandi-cli/blob/master/dandi/cli/cmd_upload.py#L92-L96
+    if number_of_threads is not None and number_of_threads > 1 and number_of_jobs is None:
+        number_of_jobs = -1
+
+    url_base = "https://gui-staging.dandiarchive.org" if staging else "https://dandiarchive.org"
+    dandiset_url = f"{url_base}/dandiset/{dandiset_id}/{version}"
+    dandi_download(urls=dandiset_url, output_dir=str(dandiset_folder_path), get_metadata=True, get_assets=False)
+    assert dandiset_path.exists(), "DANDI download failed!"
+
+    # TODO: need PR on DANDI to expose number of jobs
+    dandi_organize(
+        paths=str(nwb_folder_path), dandiset_path=str(dandiset_path), devel_debug=True if number_of_jobs == 1 else False
+    )
+    organized_nwbfiles = dandiset_path.rglob("*.nwb")
+
+    # DANDI has yet to implement forcing of session_id inclusion in organize step
+    # This manually enforces it when only a single session per subject is organized
+    for organized_nwbfile in organized_nwbfiles:
+        if "ses" not in organized_nwbfile.stem:
+            with NWBHDF5IO(path=organized_nwbfile, mode="r") as io:
+                nwbfile = io.read()
+                session_id = nwbfile.session_id
+            dandi_stem = organized_nwbfile.stem
+            dandi_stem_split = dandi_stem.split("_")
+            dandi_stem_split.insert(1, f"ses-{session_id}")
+            corrected_name = "_".join(dandi_stem_split) + ".nwb"
+            organized_nwbfile.rename(organized_nwbfile.parent / corrected_name)
+    organized_nwbfiles = dandiset_path.rglob("*.nwb")
+    # The above block can be removed once they add the feature
+
+    assert len(list(dandiset_path.iterdir())) > 1, "DANDI organize failed!"
+
+    dandi_instance = "dandi-staging" if staging else "dandi"  # Test
+    dandi_upload(
+        paths=[str(x) for x in organized_nwbfiles],
+        dandi_instance=dandi_instance,
+        jobs=number_of_jobs,
+        jobs_per_file=number_of_threads,
+    )
+
+    # Cleanup should be confirmed manually; Windows especially can complain
+    if cleanup:
+        try:
+            rmtree(path=dandiset_folder_path)
+            rmtree(path=nwb_folder_path)
+        except PermissionError:  # pragma: no cover
+            warn("Unable to clean up source files and dandiset! Please manually delete them.")

--- a/src/neuroconv/tools/data_transfers/_dandi.py
+++ b/src/neuroconv/tools/data_transfers/_dandi.py
@@ -8,7 +8,7 @@ from warnings import warn
 
 from pynwb import NWBHDF5IO
 
-from ..utils import FolderPathType, OptionalFolderPathType
+from ...utils import FolderPathType, OptionalFolderPathType
 
 
 def automatic_dandi_upload(

--- a/src/neuroconv/tools/data_transfers/_globus.py
+++ b/src/neuroconv/tools/data_transfers/_globus.py
@@ -1,29 +1,17 @@
 """Collection of helper functions for assessing and performing automated data transfers."""
 import json
-import os
 import re
 from pathlib import Path
-from shutil import rmtree
-from tempfile import mkdtemp
 from time import sleep, time
-from typing import Dict, List, Optional, Tuple, Union
-from warnings import warn
+from typing import Dict, List, Tuple, Union
 
-from dandi.download import download as dandi_download
-from dandi.organize import organize as dandi_organize
-from dandi.upload import upload as dandi_upload
-from pynwb import NWBHDF5IO
+from nwbinspector.utils import is_module_installed
+from pydantic import DirectoryPath
 from tqdm import tqdm
 
 from .processes import deploy_process
-from ..utils import FolderPathType, OptionalFolderPathType
 
-try:  # pragma: no cover
-    import globus_cli
-
-    HAVE_GLOBUS = True
-except ModuleNotFoundError:
-    HAVE_GLOBUS = False
+HAVE_GLOBUS = is_module_installed(module_name="globus_cli")
 
 
 def get_globus_dataset_content_sizes(
@@ -50,7 +38,7 @@ def transfer_globus_content(
     source_endpoint_id: str,
     source_files: Union[str, List[List[str]]],
     destination_endpoint_id: str,
-    destination_folder: FolderPathType,
+    destination_folder: DirectoryPath,
     display_progress: bool = True,
     progress_update_rate: float = 60.0,
     progress_update_timeout: float = 600.0,
@@ -203,167 +191,3 @@ def transfer_globus_content(
         progress_update_timeout=progress_update_timeout,
     )
     return success, list(task_total_sizes)
-
-
-def estimate_total_conversion_runtime(
-    total_mb: float,
-    transfer_rate_mb: float = 20.0,
-    conversion_rate_mb: float = 17.0,
-    upload_rate_mb: float = 40,
-    compression_ratio: float = 1.7,
-):
-    """
-    Estimate how long the combined process of data transfer, conversion, and upload is expected to take.
-
-    Parameters
-    ----------
-    total_mb: float
-        The total amount of data (in MB) that will be transferred, converted, and uploaded to dandi.
-    transfer_rate_mb : float, default: 20.0
-        Estimate of the transfer rate for the data.
-    conversion_rate_mb : float, default: 17.0
-        Estimate of the conversion rate for the data. Can vary widely depending on conversion options and type of data.
-        Figure of 17MB/s is based on extensive compression of high-volume, high-resolution ecephys.
-    upload_rate_mb : float, default: 40.0
-        Estimate of the upload rate of a single file to the DANDI archive.
-    compression_ratio : float, default: 1.7
-        Estimate of the final average compression ratio for datasets in the file. Can vary widely.
-    """
-    c = 1 / compression_ratio  # compressed_size = total_size * c
-    return total_mb * (1 / transfer_rate_mb + 1 / conversion_rate_mb + c / upload_rate_mb)
-
-
-def estimate_s3_conversion_cost(
-    total_mb: float,
-    transfer_rate_mb: float = 20.0,
-    conversion_rate_mb: float = 17.0,
-    upload_rate_mb: float = 40.0,
-    compression_ratio: float = 1.7,
-):
-    """
-    Estimate potential cost of performing an entire conversion on S3 using full automation.
-
-    Parameters
-    ----------
-    total_mb: float
-        The total amount of data (in MB) that will be transferred, converted, and uploaded to dandi.
-    transfer_rate_mb : float, default: 20.0
-        Estimate of the transfer rate for the data.
-    conversion_rate_mb : float, default: 17.0
-        Estimate of the conversion rate for the data. Can vary widely depending on conversion options and type of data.
-        Figure of 17MB/s is based on extensive compression of high-volume, high-resolution ecephys.
-    upload_rate_mb : float, default: 40.0
-        Estimate of the upload rate of a single file to the DANDI Archive.
-    compression_ratio : float, default: 1.7
-        Estimate of the final average compression ratio for datasets in the file. Can vary widely.
-    """
-    c = 1 / compression_ratio  # compressed_size = total_size * c
-    total_mb_s = (
-        total_mb**2 / 2 * (1 / transfer_rate_mb + (2 * c + 1) / conversion_rate_mb + 2 * c**2 / upload_rate_mb)
-    )
-    cost_gb_m = 0.08 / 1e3  # $0.08 / GB Month
-    cost_mb_s = cost_gb_m / (1e3 * 2.628e6)  # assuming 30 day month; unsure how amazon weights shorter months?
-    return cost_mb_s * total_mb_s
-
-
-def automatic_dandi_upload(
-    dandiset_id: str,
-    nwb_folder_path: FolderPathType,
-    dandiset_folder_path: OptionalFolderPathType = None,
-    version: str = "draft",
-    staging: bool = False,
-    cleanup: bool = False,
-    number_of_jobs: Optional[int] = None,
-    number_of_threads: Optional[int] = None,
-):
-    """
-    Fully automated upload of NWBFiles to a DANDISet.
-
-    Requires an API token set as an envrinment variable named DANDI_API_KEY.
-
-    To set this in your bash terminal in Linux or MacOS, run
-        export DANDI_API_KEY=...
-    or in Windows
-        set DANDI_API_KEY=...
-
-    DO NOT STORE THIS IN ANY PUBLICLY SHARED CODE.
-
-    Parameters
-    ----------
-    dandiset_id : str
-        Six-digit string identifier for the DANDISet the NWBFiles will be uploaded to.
-    nwb_folder_path : folder path
-        Folder containing the NWBFiles to be uploaded.
-    dandiset_folder_path : folder path, optional
-        A separate folder location within which to download the dandiset.
-        Used in cases where you do not have write permissions for the parent of the 'nwb_folder_path' directory.
-        Default behavior downloads the DANDISet to a folder adjacent to the 'nwb_folder_path'.
-    version : {None, "draft", "version"}
-        The default is "draft".
-    staging : bool, default: False
-        Is the DANDISet hosted on the staging server? This is mostly for testing purposes.
-        The default is False.
-    cleanup : bool, default: False
-        Whether to remove the dandiset folder path and nwb_folder_path.
-        Defaults to False.
-    number_of_jobs : int, optional
-        The number of jobs to use in the DANDI upload process.
-    number_of_threads : int, optional
-        The number of threads to use in the DANDI upload process.
-    """
-    assert os.getenv("DANDI_API_KEY"), (
-        "Unable to find environment variable 'DANDI_API_KEY'. "
-        "Please retrieve your token from DANDI and set this environment variable."
-    )
-
-    dandiset_folder_path = (
-        Path(mkdtemp(dir=nwb_folder_path.parent)) if dandiset_folder_path is None else dandiset_folder_path
-    )
-    dandiset_path = dandiset_folder_path / dandiset_id
-    # Odd big of logic upstream: https://github.com/dandi/dandi-cli/blob/master/dandi/cli/cmd_upload.py#L92-L96
-    if number_of_threads is not None and number_of_threads > 1 and number_of_jobs is None:
-        number_of_jobs = -1
-
-    url_base = "https://gui-staging.dandiarchive.org" if staging else "https://dandiarchive.org"
-    dandiset_url = f"{url_base}/dandiset/{dandiset_id}/{version}"
-    dandi_download(urls=dandiset_url, output_dir=str(dandiset_folder_path), get_metadata=True, get_assets=False)
-    assert dandiset_path.exists(), "DANDI download failed!"
-
-    # TODO: need PR on DANDI to expose number of jobs
-    dandi_organize(
-        paths=str(nwb_folder_path), dandiset_path=str(dandiset_path), devel_debug=True if number_of_jobs == 1 else False
-    )
-    organized_nwbfiles = dandiset_path.rglob("*.nwb")
-
-    # DANDI has yet to implement forcing of session_id inclusion in organize step
-    # This manually enforces it when only a single session per subject is organized
-    for organized_nwbfile in organized_nwbfiles:
-        if "ses" not in organized_nwbfile.stem:
-            with NWBHDF5IO(path=organized_nwbfile, mode="r") as io:
-                nwbfile = io.read()
-                session_id = nwbfile.session_id
-            dandi_stem = organized_nwbfile.stem
-            dandi_stem_split = dandi_stem.split("_")
-            dandi_stem_split.insert(1, f"ses-{session_id}")
-            corrected_name = "_".join(dandi_stem_split) + ".nwb"
-            organized_nwbfile.rename(organized_nwbfile.parent / corrected_name)
-    organized_nwbfiles = dandiset_path.rglob("*.nwb")
-    # The above block can be removed once they add the feature
-
-    assert len(list(dandiset_path.iterdir())) > 1, "DANDI organize failed!"
-
-    dandi_instance = "dandi-staging" if staging else "dandi"  # Test
-    dandi_upload(
-        paths=[str(x) for x in organized_nwbfiles],
-        dandi_instance=dandi_instance,
-        jobs=number_of_jobs,
-        jobs_per_file=number_of_threads,
-    )
-
-    # Cleanup should be confirmed manually; Windows especially can complain
-    if cleanup:
-        try:
-            rmtree(path=dandiset_folder_path)
-            rmtree(path=nwb_folder_path)
-        except PermissionError:  # pragma: no cover
-            warn("Unable to clean up source files and dandiset! Please manually delete them.")

--- a/src/neuroconv/tools/data_transfers/_globus.py
+++ b/src/neuroconv/tools/data_transfers/_globus.py
@@ -9,7 +9,7 @@ from nwbinspector.utils import is_module_installed
 from pydantic import DirectoryPath
 from tqdm import tqdm
 
-from .processes import deploy_process
+from ..processes import deploy_process
 
 HAVE_GLOBUS = is_module_installed(module_name="globus_cli")
 

--- a/src/neuroconv/tools/data_transfers/_helpers.py
+++ b/src/neuroconv/tools/data_transfers/_helpers.py
@@ -1,0 +1,29 @@
+"""Collection of helper functions for assessing automated data transfers."""
+
+
+def estimate_total_conversion_runtime(
+    total_mb: float,
+    transfer_rate_mb: float = 20.0,
+    conversion_rate_mb: float = 17.0,
+    upload_rate_mb: float = 40,
+    compression_ratio: float = 1.7,
+):
+    """
+    Estimate how long the combined process of data transfer, conversion, and upload is expected to take.
+
+    Parameters
+    ----------
+    total_mb: float
+        The total amount of data (in MB) that will be transferred, converted, and uploaded to dandi.
+    transfer_rate_mb : float, default: 20.0
+        Estimate of the transfer rate for the data.
+    conversion_rate_mb : float, default: 17.0
+        Estimate of the conversion rate for the data. Can vary widely depending on conversion options and type of data.
+        Figure of 17MB/s is based on extensive compression of high-volume, high-resolution ecephys.
+    upload_rate_mb : float, default: 40.0
+        Estimate of the upload rate of a single file to the DANDI archive.
+    compression_ratio : float, default: 1.7
+        Estimate of the final average compression ratio for datasets in the file. Can vary widely.
+    """
+    c = 1 / compression_ratio  # compressed_size = total_size * c
+    return total_mb * (1 / transfer_rate_mb + 1 / conversion_rate_mb + c / upload_rate_mb)

--- a/src/neuroconv/tools/yaml_conversion_specification/__init__.py
+++ b/src/neuroconv/tools/yaml_conversion_specification/__init__.py
@@ -1,1 +1,1 @@
-from .yaml_conversion_specification import run_conversion_from_yaml
+from ._yaml_conversion_specification import run_conversion_from_yaml

--- a/src/neuroconv/tools/yaml_conversion_specification/_yaml_conversion_specification.py
+++ b/src/neuroconv/tools/yaml_conversion_specification/_yaml_conversion_specification.py
@@ -4,8 +4,6 @@ from pathlib import Path
 from typing import Optional
 
 import click
-from dandi.metadata import _get_pynwb_metadata
-from dandi.organize import create_unique_filenames_from_metadata
 from jsonschema import RefResolver, validate
 
 from ...nwbconverter import NWBConverter
@@ -69,6 +67,8 @@ def run_conversion_from_yaml(
         If True, replaces any existing NWBFile at the nwbfile_path location, if save_to_file is True.
         If False, appends the existing NWBFile at the nwbfile_path location, if save_to_file is True.
     """
+    from dandi.metadata import _get_pynwb_metadata
+    from dandi.organize import create_unique_filenames_from_metadata
 
     if data_folder_path is None:
         data_folder_path = Path(specification_file_path).parent


### PR DESCRIPTION
fix #651 

While I was poking around those helper functions, I reorganized distinct flavor of the data transfer tools into the same style as the backend/dataset config

Note that I'm thinking more and more how we might want to switch to using pyproject.toml soon to avoid implicit magic in our import structure