### PR TITLE
Refactor dataset configuration code as constructors 

### DIFF
--- a/src/neuroconv/tools/nwb_helpers/_models/_base_models.py
+++ b/src/neuroconv/tools/nwb_helpers/_models/_base_models.py
@@ -6,8 +6,50 @@ from typing import Any, Dict, Literal, Tuple, Type, Union
 import h5py
 import numcodecs
 import numpy as np
+import zarr
+from hdmf import Container
 from hdmf.container import DataIO
+from hdmf.data_utils import DataChunkIterator, DataIO, GenericDataChunkIterator
+from hdmf.utils import get_data_shape
 from pydantic import BaseModel, Field, root_validator
+from pynwb import NWBHDF5IO, NWBFile
+
+from ...hdmf import SliceableDataChunkIterator
+
+
+def _find_location_in_memory_nwbfile(current_location: str, neurodata_object: Container) -> str:
+    """
+    Method for determining the location of a neurodata object within an in-memory NWBFile object.
+
+    Distinct from methods from other packages, such as the NWB Inspector, which rely on such files being read from disk.
+    """
+    parent = neurodata_object.parent
+    if isinstance(parent, NWBFile):
+        # Items in defined top-level places like acquisition, intervals, etc. do not act as 'containers'
+        # in that they do not set the `.parent` attribute; ask if object is in their in-memory dictionaries instead
+        for parent_field_name, parent_field_value in parent.fields.items():
+            if isinstance(parent_field_value, dict) and neurodata_object.name in parent_field_value:
+                return parent_field_name + "/" + neurodata_object.name + "/" + current_location
+        return neurodata_object.name + "/" + current_location
+    return _find_location_in_memory_nwbfile(
+        current_location=neurodata_object.name + "/" + current_location, neurodata_object=parent
+    )
+
+
+def _infer_dtype_using_data_chunk_iterator(candidate_dataset: Union[h5py.Dataset, zarr.Array]):
+    """
+    The DataChunkIterator has one of the best generic dtype inference, though logic is hard to peel out of it.
+
+    It can fail in rare cases but not essential to our default configuration
+    """
+    try:
+        data_type = DataChunkIterator(candidate_dataset).dtype
+        return data_type
+    except Exception as exception:
+        if str(exception) != "Data type could not be determined. Please specify dtype in DataChunkIterator init.":
+            raise exception
+        else:
+            return np.dtype("object")
 
 
 class DatasetInfo(BaseModel):
@@ -60,6 +102,22 @@ class DatasetInfo(BaseModel):
         dataset_name = location.split("/")[-1]
         values.update(dataset_name=dataset_name)
         super().__init__(**values)
+
+    @classmethod
+    def from_neurodata_object(cls, neurodata_object: Container, field_name: str) -> "DatasetInfo":
+        location = _find_location_in_memory_nwbfile(current_location=field_name, neurodata_object=neurodata_object)
+        candidate_dataset = getattr(neurodata_object, field_name)
+
+        full_shape = get_data_shape(data=candidate_dataset)
+        dtype = _infer_dtype_using_data_chunk_iterator(candidate_dataset=candidate_dataset)
+
+        return cls(
+            object_id=neurodata_object.object_id,
+            object_name=neurodata_object.name,
+            location=location,
+            full_shape=full_shape,
+            dtype=dtype,
+        )
 
 
 class DatasetIOConfiguration(BaseModel, ABC):
@@ -181,6 +239,31 @@ class DatasetIOConfiguration(BaseModel, ABC):
         Fetch the properly structured dictionary of input arguments to be passed directly into a H5DataIO or ZarrDataIO.
         """
         raise NotImplementedError
+
+    @classmethod
+    def from_neurodata_object(cls, neurodata_object: Container, field_name: str) -> "DatasetIOConfiguration":
+        candidate_dataset = getattr(neurodata_object, field_name)
+
+        dataset_info = DatasetInfo.from_neurodata_object(neurodata_object=neurodata_object, field_name=field_name)
+
+        dtype = dataset_info.dtype
+        full_shape = dataset_info.full_shape
+
+        if isinstance(candidate_dataset, GenericDataChunkIterator):
+            chunk_shape = candidate_dataset.chunk_shape
+            buffer_shape = candidate_dataset.buffer_shape
+        elif dtype != "unknown":
+            # TODO: eventually replace this with staticmethods on hdmf.data_utils.GenericDataChunkIterator
+            chunk_shape = SliceableDataChunkIterator.estimate_default_chunk_shape(
+                chunk_mb=10.0, maxshape=full_shape, dtype=np.dtype(dtype)
+            )
+            buffer_shape = SliceableDataChunkIterator.estimate_default_buffer_shape(
+                buffer_gb=0.5, chunk_shape=chunk_shape, maxshape=full_shape, dtype=np.dtype(dtype)
+            )
+        else:
+            pass
+
+        return cls(dataset_info=dataset_info, chunk_shape=chunk_shape, buffer_shape=buffer_shape)
 
 
 class BackendConfiguration(BaseModel):


### PR DESCRIPTION
As discussed in https://github.com/catalystneuro/neuroconv/pull/569

https://github.com/catalystneuro/neuroconv/pull/569#issuecomment-1821388497

This should keep code that is related together and simplify code navigation.