### PR TITLE
Change `ImagingExtractorDataChunkIterator` `chunk_shape` to be a multiple of the image size and default `chunk_mb` to 10.0

### DIFF
--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -62,12 +62,12 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
             assert chunk_mb * 1e6 <= buffer_gb * 1e9, "chunk_mb must be less than or equal to buffer_gb!"
 
         if chunk_mb is None and chunk_shape is None:
-            chunk_mb = 1.0
+            chunk_mb = 10.0
 
         self._maxshape = self._get_maxshape()
         self._dtype = self._get_dtype()
         if chunk_shape is None:
-            chunk_shape = super()._get_default_chunk_shape(chunk_mb=chunk_mb)
+            chunk_shape = self._get_scaled_chunk_shape(chunk_mb=chunk_mb)
 
         if buffer_gb is None and buffer_shape is None:
             buffer_gb = 1.0
@@ -81,6 +81,17 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
             display_progress=display_progress,
             progress_bar_options=progress_bar_options,
         )
+
+    def _get_scaled_chunk_shape(self, chunk_mb: float) -> tuple:
+        """Select the chunk_shape less than the threshold of chunk_mb that is also a multiple of the image size."""
+        assert chunk_mb > 0, f"chunk_mb ({chunk_mb}) must be greater than zero!"
+
+        image_shape = self._maxshape[1:]
+        frame_size_bytes = np.prod(image_shape) * self._dtype.itemsize
+        chunk_size_bytes = chunk_mb * np.prod(image_shape)
+        num_frames_per_chunk = int(chunk_size_bytes // frame_size_bytes)
+        chunk_shape = (max(num_frames_per_chunk, 1), *image_shape)
+        return chunk_shape
 
     def _get_scaled_buffer_shape(self, buffer_gb: float, chunk_shape: tuple) -> tuple:
         """Select the buffer_shape less than the threshold of buffer_gb that is also a multiple of the chunk_shape."""

--- a/tests/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_ophys/test_tools_roiextractors.py
@@ -1593,6 +1593,44 @@ class TestAddPhotonSeries(TestCase):
         self.assertEqual(data_chunk_iterator.buffer_shape, buffer_shape)
         self.assertEqual(data_chunk_iterator.chunk_shape, chunk_shape)
 
+    def test_iterator_options_chunk_mb_propagation(self):
+        """Test that chunk_mb is propagated to the data chunk iterator and the chunk shape is correctly set to fit."""
+        chunk_mb = 10.0
+        add_photon_series(
+            imaging=self.imaging_extractor,
+            nwbfile=self.nwbfile,
+            metadata=self.two_photon_series_metadata,
+            iterator_type="v2",
+            iterator_options=dict(chunk_mb=chunk_mb),
+        )
+
+        acquisition_modules = self.nwbfile.acquisition
+        assert self.two_photon_series_name in acquisition_modules
+        data_in_hdfm_data_io = acquisition_modules[self.two_photon_series_name].data
+        data_chunk_iterator = data_in_hdfm_data_io.data
+        chunk_shape = data_chunk_iterator.chunk_shape
+        chunk_size_mb = (
+            np.prod(chunk_shape) * data_chunk_iterator.dtype.itemsize / np.prod(data_chunk_iterator.maxshape[1:])
+        )
+        self.assertEqual(chunk_mb, chunk_size_mb)
+
+    def test_iterator_options_chunk_shape_is_at_least_one(self):
+        """Test that when a small chunk_mb is selected the chunk shape is guaranteed to include at least one frame."""
+        chunk_mb = 1.0
+        add_photon_series(
+            imaging=self.imaging_extractor,
+            nwbfile=self.nwbfile,
+            metadata=self.two_photon_series_metadata,
+            iterator_type="v2",
+            iterator_options=dict(chunk_mb=chunk_mb),
+        )
+        acquisition_modules = self.nwbfile.acquisition
+        assert self.two_photon_series_name in acquisition_modules
+        data_in_hdfm_data_io = acquisition_modules[self.two_photon_series_name].data
+        data_chunk_iterator = data_in_hdfm_data_io.data
+        chunk_shape = data_chunk_iterator.chunk_shape
+        assert_array_equal(chunk_shape, (1, 15, 10))
+
     def test_add_two_photon_series_roundtrip(self):
         add_photon_series(
             imaging=self.imaging_extractor, nwbfile=self.nwbfile, metadata=self.two_photon_series_metadata


### PR DESCRIPTION
Proposing to add a private method `_get_scaled_chunk_shape` to select `chunk_shape` less than the chunk_mb threshold while also making sure it is a multiple of the image size. Also changing default `chunk_mb` to 10.0.
@CodyCBakerPhD Let me know if these changes make sense to include here, or updating `chunk_shape` should be done separately for each conversion.