### PR TITLE
Parse param.annotation as type in case of `__future__.annotations`

### DIFF
--- a/src/neuroconv/utils/json_schema.py
+++ b/src/neuroconv/utils/json_schema.py
@@ -128,6 +128,9 @@ def get_schema_from_method_signature(method: Callable, exclude: list = None) -> 
                     input_schema["properties"].update({param_name: dict(format="directory")})
             else:
                 arg = param.annotation
+                # in case __future__.annotations is imported, the annotation is a string
+                if isinstance(arg, str):
+                    arg = type(arg)
                 if arg.__name__ in annotation_json_type_map:
                     args_spec[param_name]["type"] = annotation_json_type_map[arg.__name__]
                 else:

--- a/tests/test_minimal/test_utils/test_json_schema_utils.py
+++ b/tests/test_minimal/test_utils/test_json_schema_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 from copy import deepcopy
@@ -65,6 +67,31 @@ def test_get_schema_from_method_signature():
     )
 
     assert schema == correct_schema
+
+
+def test_get_schema_from_method_signature_future_annotations():
+    """
+    Intended to trigger the behavior where the type of the annotation found is a string, not the class type.
+
+    I.e., `"str"` is found instead of `str`.
+    """
+    class A:
+        def __init__(self, a: str):
+            pass
+
+    schema = get_schema_from_method_signature(A.__init__)
+
+    expected_schema = dict(
+        additionalProperties=False,
+        properties=dict(
+            a=dict(type="string"),
+        ),
+        required=[
+            "a",
+        ],
+        type="object",
+    )
+    assert schema == expected_schema
 
 
 def test_dict_deep_update_1():

--- a/tests/test_minimal/test_utils/test_json_schema_utils.py
+++ b/tests/test_minimal/test_utils/test_json_schema_utils.py
@@ -75,6 +75,7 @@ def test_get_schema_from_method_signature_future_annotations():
 
     I.e., `"str"` is found instead of `str`.
     """
+
     class A:
         def __init__(self, a: str):
             pass


### PR DESCRIPTION
Small fix for a very hard-to-debug problem.

If someone has a `from __future__ import annotations` in a package and implements a `DataInterface` in it, the `inspect.signature(...).parameters` return annotations as `str` instead of actual `type`.

## To reproduce

Instantiate a simple interface that does nothing in an `interface.py`:

```
from neuroconv import BaseDataInterface
from neuroconv.utils import FolderPathType

class MockInterface(BaseDataInterface):
    def __init__(self, folder_path: FolderPathType):
        self.folder_path = folder_path

    def add_to_nwbfile(
        self,
        nwbfile,
        metadata,
    ):
        pass
```

Then run:
```
from interface import MockInterface

MockInterface.get_source_schema() 
# works fine
```

Now add `from __future__ import annotations` at the top of the `interface.py` and run in a new session:
```
from interface import MockInterface

MockInterface.get_source_schema() 
# fails
```
The latter fails with this error without this PR:
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[3], line 1
----> 1 MockInterface.get_source_schema()

File ~/Documents/codes/catalystneuro/neuroconv/src/neuroconv/basedatainterface.py:26, in BaseDataInterface.get_source_schema(cls)
     23 @classmethod
     24 def get_source_schema(cls):
     25     """Infer the JSON schema for the source_data from the method signature (annotation typing)."""
---> 26     return get_schema_from_method_signature(cls, exclude=["source_data"])

File ~/Documents/codes/catalystneuro/neuroconv/src/neuroconv/utils/json_schema.py:134, in get_schema_from_method_signature(method, exclude)
    130 arg = param.annotation
    131 # in case __future__.annotations is imported, the annotation is a string
    132 # if isinstance(arg, str):
    133 #     arg = type(arg)
--> 134 if arg.__name__ in annotation_json_type_map:
    135     args_spec[param_name]["type"] = annotation_json_type_map[arg.__name__]
    136 else:

AttributeError: 'str' object has no attribute '__name__'
```