### PR TITLE
Add depth to ROI iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ### Bug fixes
 * LocalPathExpander matches only `folder_paths` or `file_paths` if that is indicated in the passed specification. [PR #675](https://github.com/catalystneuro/neuroconv/pull/675)
-
+* Fixed depth consideration in partial chunking pattern for the ROI data buffer. [PR #677](https://github.com/catalystneuro/neuroconv/pull/677)
 
 ### Features
 * Changed the `Suite2pSegmentationInterface` to support multiple plane segmentation outputs. The interface now has a `plane_name` and `channel_name` arguments to determine which plane output and channel trace add to the NWBFile. [PR #601](https://github.com/catalystneuro/neuroconv/pull/601)
-
 
 ### Improvements
 * `nwbinspector` has been removed as a minimal dependency. It becomes an extra (optional) dependency with `neuroconv[dandi]`. [PR #672](https://github.com/catalystneuro/neuroconv/pull/672)

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -89,19 +89,14 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
         num_frames = self._maxshape[0]
         width = self._maxshape[1]
         height = self._maxshape[2]
-        image_shape = self._maxshape[1:]
 
-        depth = None
-        if len(self._maxshape) == 4:
-            depth = self._maxshape[3]
+        frame_size_bytes = width * height * self._dtype.itemsize
+        chunk_size_bytes = chunk_mb * 1e6
+        num_frames_per_chunk = int(chunk_size_bytes / frame_size_bytes)
 
-        frame_size_bytes = math.prod(image_shape) * self._dtype.itemsize
-        chunk_size_bytes = chunk_mb * math.prod(image_shape)
-        num_frames_per_chunk = int(chunk_size_bytes // frame_size_bytes)
-
-        if depth is None:
+        if len(self._maxshape) == 3:
             chunk_shape = (max(min(num_frames_per_chunk, num_frames), 1), width, height)
-        else:
+        elif len(self._maxshape) == 4::
             chunk_shape = (max(min(num_frames_per_chunk, num_frames), 1), width, height, 1)
 
         return chunk_shape

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -89,6 +89,7 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
         num_frames = self._maxshape[0]
         width = self._maxshape[1]
         height = self._maxshape[2]
+        image_shape = self._maxshape[1:]
 
         depth = None
         if len(self._maxshape) == 4:

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -96,7 +96,7 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
 
         if len(self._maxshape) == 3:
             chunk_shape = (max(min(num_frames_per_chunk, num_frames), 1), width, height)
-        elif len(self._maxshape) == 4::
+        elif len(self._maxshape) == 4:
             chunk_shape = (max(min(num_frames_per_chunk, num_frames), 1), width, height, 1)
 
         return chunk_shape

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -87,11 +87,22 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
         assert chunk_mb > 0, f"chunk_mb ({chunk_mb}) must be greater than zero!"
 
         num_frames = self._maxshape[0]
-        image_shape = self._maxshape[1:]
+        width = self._maxshape[1]
+        height = self._maxshape[2]
+
+        depth = None
+        if len(self._maxshape) == 4:
+            depth = self._maxshape[3]
+
         frame_size_bytes = math.prod(image_shape) * self._dtype.itemsize
         chunk_size_bytes = chunk_mb * math.prod(image_shape)
         num_frames_per_chunk = int(chunk_size_bytes // frame_size_bytes)
-        chunk_shape = (max(min(num_frames_per_chunk, num_frames), 1), *image_shape)
+
+        if depth is None:
+            chunk_shape = (max(min(num_frames_per_chunk, num_frames), 1), width, height)
+        else:
+            chunk_shape = (max(min(num_frames_per_chunk, num_frames), 1), width, height, 1)
+
         return chunk_shape
 
     def _get_scaled_buffer_shape(self, buffer_gb: float, chunk_shape: tuple) -> tuple:

--- a/tests/test_ophys/test_imagingextractordatachunkiterator.py
+++ b/tests/test_ophys/test_imagingextractordatachunkiterator.py
@@ -191,7 +191,6 @@ def test_volumetric_default_chunking():
         for _ in range(number_of_planes)
     ]
     volumetric_imaging_extractor = VolumetricImagingExtractor(imaging_extractors=imaging_extractors)
-
-    iterator = ImagingExtractorDataChunkIterator(imaging_extractor=self.imaging_extractor)
+    iterator = ImagingExtractorDataChunkIterator(imaging_extractor=volumetric_imaging_extractor)
 
     assert iterator.chunk_shape == (4, width, height, 1)

--- a/tests/test_ophys/test_imagingextractordatachunkiterator.py
+++ b/tests/test_ophys/test_imagingextractordatachunkiterator.py
@@ -185,8 +185,11 @@ def test_volumetric_default_chunking():
     width = 1024
     height = 1024
     number_of_planes = 3
-    
-    imaging_extractors = [generate_dummy_imaging_extractor(num_frames=number_of_frames, num_rows=width, num_columns=height) for _ in range(number_of_planes)]
+
+    imaging_extractors = [
+        generate_dummy_imaging_extractor(num_frames=number_of_frames, num_rows=width, num_columns=height)
+        for _ in range(number_of_planes)
+    ]
     volumetric_imaging_extractor = VolumetricImagingExtractor(imaging_extractors=imaging_extractors)
 
     iterator = ImagingExtractorDataChunkIterator(imaging_extractor=self.imaging_extractor)

--- a/tests/test_ophys/test_imagingextractordatachunkiterator.py
+++ b/tests/test_ophys/test_imagingextractordatachunkiterator.py
@@ -4,6 +4,7 @@ import numpy as np
 from hdmf.testing import TestCase
 from numpy.testing import assert_array_equal
 from parameterized import param, parameterized
+from roiextractors import VolumetricImagingExtractor
 from roiextractors.testing import generate_dummy_imaging_extractor
 
 from neuroconv.tools.roiextractors.imagingextractordatachunkiterator import (
@@ -177,3 +178,17 @@ class TestImagingExtractorDataChunkIterator(TestCase):
 
         self.assertEqual(dci.display_progress, True)
         self.assertEqual(dci.progress_bar.desc, "Test Progress Bar")
+
+
+def test_volumetric_default_chunking():
+    number_of_frames = 10
+    width = 1024
+    height = 1024
+    number_of_planes = 3
+    
+    imaging_extractors = [generate_dummy_imaging_extractor(num_frames=number_of_frames, num_rows=width, num_columns=height) for _ in range(number_of_planes)]
+    volumetric_imaging_extractor = VolumetricImagingExtractor(imaging_extractors=imaging_extractors)
+
+    iterator = ImagingExtractorDataChunkIterator(imaging_extractor=self.imaging_extractor)
+
+    assert iterator.chunk_shape == (4, width, height, 1)

--- a/tests/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_ophys/test_tools_roiextractors.py
@@ -1608,7 +1608,7 @@ class TestAddPhotonSeries(TestCase):
         assert self.two_photon_series_name in acquisition_modules
         data_in_hdfm_data_io = acquisition_modules[self.two_photon_series_name].data
         data_chunk_iterator = data_in_hdfm_data_io.data
-        iterator_chunk_mb = math.prod(data_chunk_iterator.chunk_shape) * data_chunk_iterator.dtype.itemsize
+        iterator_chunk_mb = math.prod(data_chunk_iterator.chunk_shape) * data_chunk_iterator.dtype.itemsize / 1e6
         assert iterator_chunk_mb <= chunk_mb
 
     def test_iterator_options_chunk_shape_is_at_least_one(self):

--- a/tests/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_ophys/test_tools_roiextractors.py
@@ -1608,8 +1608,8 @@ class TestAddPhotonSeries(TestCase):
         assert self.two_photon_series_name in acquisition_modules
         data_in_hdfm_data_io = acquisition_modules[self.two_photon_series_name].data
         data_chunk_iterator = data_in_hdfm_data_io.data
-        iterator_chunk_mb = data_chunk_iterator.chunk_mb
-        self.assertEqual(chunk_mb, iterator_chunk_mb)
+        iterator_chunk_mb = math.prod(data_chunk_iterator.chunk_shape) * data_chunk_iterator.dtype.itemsize
+        assert iterator_chunk_mb <= chunk_mb
 
     def test_iterator_options_chunk_shape_is_at_least_one(self):
         """Test that when a small chunk_mb is selected the chunk shape is guaranteed to include at least one frame."""

--- a/tests/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_ophys/test_tools_roiextractors.py
@@ -1608,11 +1608,8 @@ class TestAddPhotonSeries(TestCase):
         assert self.two_photon_series_name in acquisition_modules
         data_in_hdfm_data_io = acquisition_modules[self.two_photon_series_name].data
         data_chunk_iterator = data_in_hdfm_data_io.data
-        chunk_shape = data_chunk_iterator.chunk_shape
-        chunk_size_mb = (
-            math.prod(chunk_shape) * data_chunk_iterator.dtype.itemsize / math.prod(data_chunk_iterator.maxshape[1:])
-        )
-        self.assertEqual(chunk_mb, chunk_size_mb)
+        iterator_chunk_mb = data_chunk_iterator.chunk_mb
+        self.assertEqual(chunk_mb, iterator_chunk_mb)
 
     def test_iterator_options_chunk_shape_is_at_least_one(self):
         """Test that when a small chunk_mb is selected the chunk shape is guaranteed to include at least one frame."""
@@ -1629,7 +1626,7 @@ class TestAddPhotonSeries(TestCase):
         data_in_hdfm_data_io = acquisition_modules[self.two_photon_series_name].data
         data_chunk_iterator = data_in_hdfm_data_io.data
         chunk_shape = data_chunk_iterator.chunk_shape
-        assert_array_equal(chunk_shape, (1, 15, 10))
+        assert_array_equal(chunk_shape, (30, 15, 10))
 
     def test_iterator_options_chunk_shape_does_not_exceed_maxshape(self):
         """Test that when a large chunk_mb is selected the chunk shape is guaranteed to not exceed maxshape."""


### PR DESCRIPTION
Detected during review of Clandinin example files; the chunks are way too large since they include all depths (which have a huge number of planes)

Needs tests