### PR TITLE
Fix path expander II

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Upcoming
 
 ### Bug fixes
-* LocalPathExpander matches only `folder_paths` or `file_paths` if that is indicated in the passed specification. [PR #675](https://github.com/catalystneuro/neuroconv/pull/675)
+* LocalPathExpander matches only `folder_paths` or `file_paths` if that is indicated in the passed specification. [PR #679](https://github.com/catalystneuro/neuroconv/pull/675) and [PR #675](https://github.com/catalystneuro/neuroconv/pull/679
 
 
 ### Features

--- a/src/neuroconv/tools/path_expansion.py
+++ b/src/neuroconv/tools/path_expansion.py
@@ -13,6 +13,31 @@ from ..utils import DeepDict
 
 class AbstractPathExpander(abc.ABC):
     def extract_metadata(self, base_directory: DirectoryPath, format_: str):
+        """
+        Uses the parse library to extract metadata from file paths in the base_directory.
+
+        This method iterates over files in `base_directory`, parsing each file path according to `format_`.
+        The format string is adjusted to the current operating system's path separator. The method yields
+        each file path and its corresponding parsed metadata. To constrain metadata matches to only the
+        name of the file or folder/directory, the method checks that the metadata does not contain the
+        OS path separator (e.g., '/' or '\\').
+
+        Parameters
+        ----------
+        base_directory : DirectoryPath
+            The base directory from which to list files for metadata extraction. It should be a path-like
+            object that is convertible to a `pathlib.Path`.
+        format_ : str
+            The format string used for parsing the file paths. This string can represent a path in any
+            OS format, and is adjusted internally to match the current OS's path separator.
+
+        Yields
+        ------
+        Tuple[Path, Dict[str, Any]]
+            A tuple containing the file path as a `Path` object and a dictionary of the named metadata
+            extracted from the file path.
+        """
+
         format_ = format_.replace("\\", os.sep)  # Actual character is a single back-slash; first is an escape for that
         format_ = format_.replace("/", os.sep)  # our f-string uses '/' to communicate os-independent separators
 

--- a/src/neuroconv/tools/path_expansion.py
+++ b/src/neuroconv/tools/path_expansion.py
@@ -19,7 +19,10 @@ class AbstractPathExpander(abc.ABC):
         for filepath in self.list_directory(base_directory=Path(base_directory)):
             result = parse(format_, filepath)
             if result:
-                yield filepath, result.named
+                named_result = result.named
+                no_field_in_metadata_contains_os_sep = all(os.sep not in str(val) for val in named_result.values())
+                if no_field_in_metadata_contains_os_sep:
+                    yield filepath, named_result
 
     @abc.abstractmethod
     def list_directory(self, base_directory: DirectoryPath) -> Iterable[FilePath]:

--- a/tests/test_minimal/test_tools/test_expand_paths.py
+++ b/tests/test_minimal/test_tools/test_expand_paths.py
@@ -13,7 +13,7 @@ from neuroconv.utils import NWBMetaDataEncoder
 def test_only_folder_match(tmpdir):
     base_directory = Path(tmpdir)
 
-    sub_directory1 = base_directory /  "subject1" / "a_simple_pattern_1"
+    sub_directory1 = base_directory / "subject1" / "a_simple_pattern_1"
     sub_directory2 = base_directory / "subject2" / "a_simple_pattern_2"
 
     sub_directory1.mkdir(exist_ok=True, parents=True)
@@ -41,13 +41,12 @@ def test_only_folder_match(tmpdir):
         }
     }
 
-    # Instantiate LocalPathExpander
-
     path_expander = LocalPathExpander()
     metadata_list = path_expander.expand_paths(source_data_spec)
     folder_paths = [metadata_match["source_data"]["a_source"]["folder_path"] for metadata_match in metadata_list]
 
-    expected = {str(sub_directory1), str(sub_directory2), str(sub_directory3)}
+    # Note that sub_directory3 is not included because it does not conform to the pattern
+    expected = {str(sub_directory1), str(sub_directory2)}
 
     assert set(folder_paths) == expected
 
@@ -55,11 +54,11 @@ def test_only_folder_match(tmpdir):
 def test_only_file_match(tmpdir):
     base_directory = Path(tmpdir)
 
-    sub_directory1 = base_directory / "a_simple_pattern_1"
-    sub_directory2 = base_directory / "a_simple_pattern_2"
+    sub_directory1 = base_directory / "subject1" / "a_simple_pattern_1"
+    sub_directory2 = base_directory / "subject2" / "a_simple_pattern_2"
 
-    sub_directory1.mkdir(exist_ok=True)
-    sub_directory2.mkdir(exist_ok=True)
+    sub_directory1.mkdir(exist_ok=True, parents=True)
+    sub_directory2.mkdir(exist_ok=True, parents=True)
 
     # Add files with the same name to both folders
     file1 = sub_directory1 / "a_simple_pattern_1.bin"
@@ -70,8 +69,8 @@ def test_only_file_match(tmpdir):
     file2.touch()
 
     # Add another sub-nested folder with a folder
-    sub_directory3 = sub_directory1 / "a_simple_pattern_3"
-    sub_directory3.mkdir(exist_ok=True)
+    sub_directory3 = sub_directory1 / "intermediate_nested" / "a_simple_pattern_3"
+    sub_directory3.mkdir(exist_ok=True, parents=True)
     file3 = sub_directory3 / "a_simple_pattern_3.bin"
     file3.touch()
 
@@ -79,17 +78,16 @@ def test_only_file_match(tmpdir):
     source_data_spec = {
         "a_source": {
             "base_directory": base_directory,
-            "file_path": "a_simple_pattern_{session_id}.bin",
+            "file_path": "{subject_id}/{a_parent_folder}/a_simple_pattern_{session_id}.bin",
         }
     }
-
-    # Instantiate LocalPathExpander
 
     path_expander = LocalPathExpander()
     metadata_list = path_expander.expand_paths(source_data_spec)
     file_paths = [metadata_match["source_data"]["a_source"]["file_path"] for metadata_match in metadata_list]
 
-    expected = {str(file1), str(file2), str(file3)}
+    # Note that file3 is not included because it does not conform to the pattern
+    expected = {str(file1), str(file2)}
     assert set(file_paths) == expected
 
 

--- a/tests/test_minimal/test_tools/test_expand_paths.py
+++ b/tests/test_minimal/test_tools/test_expand_paths.py
@@ -13,11 +13,11 @@ from neuroconv.utils import NWBMetaDataEncoder
 def test_only_folder_match(tmpdir):
     base_directory = Path(tmpdir)
 
-    sub_directory1 = base_directory / "a_simple_pattern_1"
-    sub_directory2 = base_directory / "a_simple_pattern_2"
+    sub_directory1 = base_directory /  "subject1" / "a_simple_pattern_1"
+    sub_directory2 = base_directory / "subject2" / "a_simple_pattern_2"
 
-    sub_directory1.mkdir(exist_ok=True)
-    sub_directory2.mkdir(exist_ok=True)
+    sub_directory1.mkdir(exist_ok=True, parents=True)
+    sub_directory2.mkdir(exist_ok=True, parents=True)
 
     # Add files with the same name to both folders
     file1 = sub_directory1 / "a_simple_pattern_1.bin"
@@ -28,8 +28,8 @@ def test_only_folder_match(tmpdir):
     file2.touch()
 
     # Add another sub-nested folder with a folder
-    sub_directory3 = sub_directory1 / "a_simple_pattern_3"
-    sub_directory3.mkdir(exist_ok=True)
+    sub_directory3 = sub_directory1 / "intermediate_nested" / "a_simple_pattern_3"
+    sub_directory3.mkdir(exist_ok=True, parents=True)
     file3 = sub_directory3 / "a_simple_pattern_3.bin"
     file3.touch()
 
@@ -37,7 +37,7 @@ def test_only_folder_match(tmpdir):
     source_data_spec = {
         "a_source": {
             "base_directory": base_directory,
-            "folder_path": "a_simple_pattern_{session_id}",
+            "folder_path": "{subject_id}/a_simple_pattern_{session_id}",
         }
     }
 

--- a/tests/test_minimal/test_tools/test_expand_paths.py
+++ b/tests/test_minimal/test_tools/test_expand_paths.py
@@ -112,7 +112,7 @@ def test_only_file_match(tmpdir):
         str(base_directory / "subject1" / "a_simple_pattern_1" / "a_simple_pattern_1.bin"),
         str(base_directory / "subject2" / "a_simple_pattern_2" / "a_simple_pattern_2.bin"),
     }
-    assert set(file_paths) == expected
+    assert file_paths == expected
 
     metadata_list = [match["metadata"].to_dict() for match in matches_list]
     expected_metadata = [

--- a/tests/test_minimal/test_tools/test_expand_paths.py
+++ b/tests/test_minimal/test_tools/test_expand_paths.py
@@ -42,13 +42,23 @@ def test_only_folder_match(tmpdir):
     }
 
     path_expander = LocalPathExpander()
-    metadata_list = path_expander.expand_paths(source_data_spec)
-    folder_paths = [metadata_match["source_data"]["a_source"]["folder_path"] for metadata_match in metadata_list]
+    matches_list = path_expander.expand_paths(source_data_spec)
 
+    folder_paths = [match["source_data"]["a_source"]["folder_path"] for match in matches_list]
     # Note that sub_directory3 is not included because it does not conform to the pattern
     expected = {str(sub_directory1), str(sub_directory2)}
-
     assert set(folder_paths) == expected
+
+    metadata_list = [match["metadata"].to_dict() for match in matches_list]
+    expected_metadata = [
+        {"Subject": {"subject_id": "subject1"}, "NWBFile": {"session_id": "1"}},
+        {"Subject": {"subject_id": "subject2"}, "NWBFile": {"session_id": "2"}},
+    ]
+
+    # Sort both lists by subject id to ensure order is the same
+    metadata_list = sorted(metadata_list, key=lambda x: x["Subject"]["subject_id"])
+    expected_metadata = sorted(expected_metadata, key=lambda x: x["Subject"]["subject_id"])
+    assert metadata_list == expected_metadata
 
 
 def test_only_file_match(tmpdir):
@@ -83,12 +93,31 @@ def test_only_file_match(tmpdir):
     }
 
     path_expander = LocalPathExpander()
-    metadata_list = path_expander.expand_paths(source_data_spec)
-    file_paths = [metadata_match["source_data"]["a_source"]["file_path"] for metadata_match in metadata_list]
+    matches_list = path_expander.expand_paths(source_data_spec)
+    file_paths = [match["source_data"]["a_source"]["file_path"] for match in matches_list]
 
     # Note that file3 is not included because it does not conform to the pattern
     expected = {str(file1), str(file2)}
     assert set(file_paths) == expected
+
+    metadata_list = [match["metadata"].to_dict() for match in matches_list]
+    expected_metadata = [
+        {
+            "Subject": {"subject_id": "subject1"},
+            "NWBFile": {"session_id": "1"},
+            "extras": {"a_parent_folder": "a_simple_pattern_1"},
+        },
+        {
+            "Subject": {"subject_id": "subject2"},
+            "NWBFile": {"session_id": "2"},
+            "extras": {"a_parent_folder": "a_simple_pattern_2"},
+        },
+    ]
+
+    # Sort both lists by subject id to ensure order is the same
+    metadata_list = sorted(metadata_list, key=lambda x: x["Subject"]["subject_id"])
+    expected_metadata = sorted(expected_metadata, key=lambda x: x["Subject"]["subject_id"])
+    assert metadata_list == expected_metadata
 
 
 def test_expand_paths(tmpdir):


### PR DESCRIPTION
After #675 @bendichter [mentioned ](https://github.com/catalystneuro/neuroconv/pull/675#issuecomment-1840847452) that we are still missing the case of nested over matching:

> "a_simple_pattern_{session_id}" applied to "tmp/base_directory/a_simple_pattern_2/nested/" will still return session_id="2/nested/" when it should not match

and proposed a solution of excluding metadata entries that have file separators (slashes in posix or double front slashes on windows) from the matches. This PR implements this solution and amends the tests to reflect that.

This should fix #674