### PR TITLE
general cleanup

### DIFF
--- a/src/neuroconv/basedatainterface.py
+++ b/src/neuroconv/basedatainterface.py
@@ -8,7 +8,6 @@ from pynwb import NWBFile
 
 from .tools.nwb_helpers import make_nwbfile_from_metadata, make_or_load_nwbfile
 from .utils import (
-    dict_deep_update,
     get_schema_from_method_signature,
     load_dict_from_file,
 )

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -353,7 +353,7 @@ def extract_session_start_time(
     If neither of these methods works, the function returns None.
 
     The session start time, has two different meanings depending on the source of the FicTrac data:
-    - For video file sources (.avi, .mp4, etc), the session start time corresponds to the time when the
+    - For video file sources (.avi, .mp4, etc.), the session start time corresponds to the time when the
     FicTrac analysis commenced. That is, the session start time reflects the analysis time rather than
     the actual start of the experiment.
     - For camera sources (such as PGR or Basler), the session start time is either the time reported by the camera

--- a/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
@@ -194,7 +194,7 @@ class VideoInterface(BaseDataInterface):
 
         Parameters
         ----------
-        starting_times : list of floats
+        aligned_segment_starting_times : list of floats
             The relative starting times of each video.
         stub_test : bool, default: False
             If timestamps have not been set to this interface, it will attempt to retrieve them

--- a/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
@@ -143,7 +143,7 @@ class AxonaPositionDataInterface(BaseDataInterface):
 
     def __init__(self, file_path: str):
         super().__init__(filename=file_path)
-        self.source_data(file_path=file_path)
+        self.source_data = dict(file_path=file_path)
 
     def add_to_nwbfile(self, nwbfile: NWBFile, metadata: dict):
         """

--- a/src/neuroconv/datainterfaces/ecephys/blackrock/header_tools.py
+++ b/src/neuroconv/datainterfaces/ecephys/blackrock/header_tools.py
@@ -27,10 +27,10 @@ def processheaders(curr_file, packet_fields):
 
     # unpack the binary data from the header based on the format strings of each field.
     # This returns a list of data, but it's not always correctly formatted (eg, FileSpec
-    # is read as ints 2 and 3 but I want it as '2.3'
+    # is read as ints 2 and 3, but I want it as '2.3'
     packet_unpacked = unpack(packet_format_str, packet_binary)
 
-    # Create a iterator from the data list.  This allows a formatting function
+    # Create an iterator from the data list.  This allows a formatting function
     # to use more than one item from the list if needed, and the next formatting
     # function can pick up on the correct item in the list
     data_iter = iter(packet_unpacked)

--- a/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -118,7 +118,7 @@ def extract_neo_header_metadata(neo_reader) -> dict:
     # check if neuralynx file header objects are present and use these metadata extraction
     if hasattr(neo_reader, "file_headers"):
         # use only ncs files as only continuous signals are extracted
-        # note that in the neo io the order of file headers is be the same as for channels
+        # note that in the neo io the order of file headers is the same as for channels
         headers = [header for filename, header in neo_reader.file_headers.items() if filename.lower().endswith(".ncs")]
 
     # use metadata provided as array_annotations for each channel (neo version <=0.11.0)

--- a/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscope_utils.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscope_utils.py
@@ -71,7 +71,7 @@ def get_neural_channels(xml_file_path: str) -> list:
     Warning:
     This function assumes that all the channels that correspond to neural data are involved in spike detection.
     More concretely, it assumes that the channels appear on the `spikeDetection` field of the XML file.
-    If this is not the case, the function will return an incorrect list of neural channels channels.
+    If this is not the case, the function will return an incorrect list of neural channels.
     Please report this as an issue if this is the case.
     """
     root = get_xml(xml_file_path)
@@ -85,7 +85,7 @@ def get_channel_groups(xml_file_path: str) -> list:
     """
     Auxiliary function for retrieving a list of groups, each containing a list of channels.
 
-    These are all of the channels that are connected to the probe.
+    These are all the channels that are connected to the probe.
 
     Returns
     -------

--- a/src/neuroconv/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
@@ -31,7 +31,7 @@ class SpikeGadgetsRecordingInterface(BaseRecordingExtractorInterface):
             Path to the .rec file.
         gains : array_like, optional
             The early versions of SpikeGadgets do not automatically record the conversion factor ('gain') of the
-            acquisition system. Thus it must be specified either as a single value (if all channels have the same gain)
+            acquisition system. Thus, it must be specified either as a single value (if all channels have the same gain)
             or an array of values for each channel.
         es_key : str, default: "ElectricalSeries"
         """

--- a/src/neuroconv/datainterfaces/text/timeintervalsinterface.py
+++ b/src/neuroconv/datainterfaces/text/timeintervalsinterface.py
@@ -1,4 +1,3 @@
-import os
 from abc import abstractmethod
 from pathlib import Path
 from typing import Dict, Optional

--- a/src/neuroconv/nwbconverter.py
+++ b/src/neuroconv/nwbconverter.py
@@ -90,7 +90,7 @@ class NWBConverter:
     def validate_metadata(self, metadata: Dict[str, dict]):
         """Validate metadata against Converter metadata_schema."""
         encoder = NWBMetaDataEncoder()
-        # The encoder produces a serialized object so we deserialized it for comparison
+        # The encoder produces a serialized object, so we deserialized it for comparison
         serialized_metadata = encoder.encode(metadata)
         decoded_metadata = json.loads(serialized_metadata)
         validate(instance=decoded_metadata, schema=self.get_metadata_schema())

--- a/src/neuroconv/tools/data_transfers/_dandi.py
+++ b/src/neuroconv/tools/data_transfers/_dandi.py
@@ -26,7 +26,7 @@ def automatic_dandi_upload(
 
     Requires an API token set as an envrinment variable named DANDI_API_KEY.
 
-    To set this in your bash terminal in Linux or MacOS, run
+    To set this in your bash terminal in Linux or macOS, run
         export DANDI_API_KEY=...
     or in Windows
         set DANDI_API_KEY=...

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -94,7 +94,7 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):
 
         unpadded_buffer_bytes = math.prod(unpadded_buffer_shape) * dtype.itemsize
 
-        # Method that starts by filling the smallest axis completely or calculates best partial fill
+        # Method that starts by filling the smallest axis completely or calculates the best partial fill
         padded_buffer_shape = np.array(chunk_shape)
         chunks_per_axis = np.ceil(maxshape / chunk_shape)
         small_axis_fill_size = chunk_bytes * min(chunks_per_axis)

--- a/src/neuroconv/tools/importing.py
+++ b/src/neuroconv/tools/importing.py
@@ -71,7 +71,7 @@ def get_package(
         specify this dictionary to raise a more specific error to that issue.
 
         For example, `excluded_platforms_and_python_versions = dict(darwin=["3.7"])` will raise an
-        informative error when running on MacOS with Python version 3.7.
+        informative error when running on macOS with Python version 3.7.
 
         This also applies to specific architectures of platforms, such as
         `excluded_platforms_and_python_versions = dict(darwin=dict(arm=["3.7"]))` to exclude a specific Python

--- a/src/neuroconv/tools/neo/neo.py
+++ b/src/neuroconv/tools/neo/neo.py
@@ -33,11 +33,11 @@ def get_electrodes_metadata(neo_reader, electrodes_ids: list, block: int = 0) ->
     The typical information we look for is the information accepted by pynwb.icephys.IntracellularElectrode:
       - name – the name of this electrode
       - device – the device that was used to record from this electrode
-      - description – Recording description, description of electrode (e.g., whole-cell, sharp, etc)
+      - description – Recording description, description of electrode (e.g., whole-cell, sharp, etc.)
       - comment: Free-form text (can be from Methods)
       - slice – Information about slice used for recording.
       - seal – Information about seal used for recording.
-      - location – Area, layer, comments on estimation, stereotaxis coordinates (if in vivo, etc).
+      - location – Area, layer, comments on estimation, stereotaxis coordinates (if in vivo, etc.).
       - resistance – Electrode resistance COMMENT: unit: Ohm.
       - filtering – Electrode specific filtering.
       - initial_access_resistance – Initial access resistance.

--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
@@ -78,7 +78,7 @@ class DatasetInfo(BaseModel):
         """
         Not overriding __repr__ as this is intended to render only when wrapped in print().
 
-        Reason being two-fold; a standard `repr` is intended to be slightly more machine readable / a more basic
+        Reason being two-fold; a standard `repr` is intended to be slightly more machine-readable / a more basic
         representation of the true object state. But then also because an iterable of these objects, such as a
         `List[DataSetInfo]`, would print out the nested representations, which only look good when using the basic
         `repr` (that is, this fancy string print-out does not look good when nested in another container).
@@ -152,7 +152,7 @@ class DatasetIOConfiguration(BaseModel, ABC):
         """
         Not overriding __repr__ as this is intended to render only when wrapped in print().
 
-        Reason being two-fold; a standard `repr` is intended to be slightly more machine readable / a more basic
+        Reason being two-fold; a standard `repr` is intended to be slightly more machine-readable / a more basic
         representation of the true object state. But then also because an iterable of these objects, such as a
         `List[DatasetConfiguration]`, would print out the nested representations, which only look good when using the
         basic `repr` (that is, this fancy string print-out does not look good when nested in another container).

--- a/src/neuroconv/tools/nwb_helpers/_dataset_configuration.py
+++ b/src/neuroconv/tools/nwb_helpers/_dataset_configuration.py
@@ -35,7 +35,7 @@ def _is_dataset_written_to_file(
         and backend == "hdf5"
         and candidate_dataset.file == existing_file  # If the source HDF5 Dataset is the appending NWBFile
     ) or (
-        isinstance(candidate_dataset, zarr.Array)  # If the source data is an Zarr Array
+        isinstance(candidate_dataset, zarr.Array)  # If the source data is a Zarr Array
         and backend == "zarr"
         and candidate_dataset.store == existing_file  # If the source Zarr 'file' is the appending NWBFile
     )
@@ -57,7 +57,7 @@ def get_default_dataset_io_configurations(
     nwbfile : pynwb.NWBFile
         An in-memory NWBFile object, either generated from the base class or read from an existing file of any backend.
     backend : "hdf5" or "zarr"
-        Which backend format type you would like to use in configuring each datasets compression methods and options.
+        Which backend format type you would like to use in configuring each dataset's compression methods and options.
 
     Yields
     ------

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -358,7 +358,7 @@ def add_photon_series(
         Specify which element of the list with this parameter.
     parent_container: {'acquisition', 'processing/ophys'}, optional
         The container where the photon series is added, default is nwbfile.acquisition.
-        When 'processing/ophys' is chosen, the photon series is added to nwbfile.processing['ophys'].
+        When 'processing/ophys' is chosen, the photon series is added to ``nwbfile.processing['ophys']``.
 
     Returns
     -------

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -276,7 +276,7 @@ def add_electrodes(recording: BaseRecording, nwbfile: pynwb.NWBFile, metadata: d
         data_to_add["location"].update(description="location")
         data_to_add.pop("brain_area")
 
-    # If no group_names are provide use information from groups or default values
+    # If no group_names are provided, use information from groups or default values
     if "group_name" in data_to_add:
         group_name_array = data_to_add["group_name"]["data"].astype("str", copy=False)
     else:
@@ -300,7 +300,7 @@ def add_electrodes(recording: BaseRecording, nwbfile: pynwb.NWBFile, metadata: d
     data_to_add["group"].update(description="the ElectrodeGroup object", data=group_list, index=False)
 
     # 2 Divide properties to those that will be added as rows (default plus previous) and columns (new properties)
-    # This mapping contains all the defaults that might be required by by pre-defined columns on the NWB schema
+    # This mapping contains all the defaults that might be required by pre-defined columns on the NWB schema
     # https://nwb-schema.readthedocs.io/en/latest/format.html#groups-general-extracellular-ephys-electrodes
     required_schema_property_to_default_value = dict(
         id=None,
@@ -653,7 +653,7 @@ def add_electrical_series(
 
     # Now we decide whether to store the timestamps as a regular series or as an irregular series.
     if recording.has_time_vector(segment_index=segment_index):
-        # First we check if the recording has a a time vector to avoid creating artificial timestamps
+        # First we check if the recording has a time vector to avoid creating artificial timestamps
         timestamps = recording.get_times(segment_index=segment_index)
         rate = calculate_regular_series_rate(series=timestamps)  # Returns None if it is not regular
         recording_t_start = timestamps[0]

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -516,7 +516,7 @@ def add_electrical_series(
     write_scaled: bool = False,
     compression: Optional[str] = "gzip",
     compression_opts: Optional[int] = None,
-    iterator_type: str = "v2",
+    iterator_type: Optional[str] = "v2",
     iterator_opts: Optional[dict] = None,
 ):
     """
@@ -779,7 +779,7 @@ def write_recording(
     write_scaled: bool = False,
     compression: Optional[str] = "gzip",
     compression_opts: Optional[int] = None,
-    iterator_type: str = "v2",
+    iterator_type: Optional[str] = "v2",
     iterator_opts: Optional[dict] = None,
 ) -> pynwb.NWBFile:
     """

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -277,7 +277,6 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
 
     data_interface_cls: Type[BaseRecordingExtractorInterface]
 
-
     def check_read_nwb(self, nwbfile_path: str):
         from spikeinterface.extractors import NwbRecordingExtractor
 

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -277,9 +277,6 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
 
     data_interface_cls: Type[BaseRecordingExtractorInterface]
 
-    def __init__(self):
-        super().__init__()
-        self.nwb_recording = None
 
     def check_read_nwb(self, nwbfile_path: str):
         from spikeinterface.extractors import NwbRecordingExtractor

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -60,6 +60,13 @@ class DataInterfaceTestMixin:
     conversion_options: dict = dict()
     maxDiff = None
 
+    def __init__(self):
+        self.nwbfile_path = None
+        self.test_kwargs = None
+        self.case = None
+        self.nwbfile_path = None
+        self.interface = None
+
     def test_source_schema_valid(self):
         schema = self.data_interface_cls.get_source_schema()
         Draft7Validator.check_schema(schema=schema)
@@ -132,6 +139,11 @@ class TemporalAlignmentMixin:
     data_interface_cls: Type[BaseDataInterface]
     interface_kwargs: Union[dict, List[dict]]
     maxDiff = None
+
+    def __init__(self):
+        self.test_kwargs = None
+        self.case = None
+        self.interface = None
 
     def setUpFreshInterface(self):
         """Protocol for creating a fresh instance of the interface."""
@@ -219,7 +231,7 @@ class TemporalAlignmentMixin:
 
 
 class ImagingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
-    data_interface_cls: BaseImagingExtractorInterface
+    data_interface_cls: Type[BaseImagingExtractorInterface]
 
     def check_read_nwb(self, nwbfile_path: str):
         from roiextractors import NwbImagingExtractor
@@ -276,6 +288,10 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
     """
 
     data_interface_cls: Type[BaseRecordingExtractorInterface]
+
+    def __init__(self):
+        super().__init__()
+        self.nwb_recording = None
 
     def check_read_nwb(self, nwbfile_path: str):
         from spikeinterface.extractors import NwbRecordingExtractor
@@ -496,8 +512,8 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
 
 
 class SortingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
-    data_interface_cls: BaseSortingExtractorInterface
-    associated_recording_cls: Optional[BaseRecordingExtractorInterface] = None
+    data_interface_cls: Type[BaseSortingExtractorInterface]
+    associated_recording_cls: Optional[Type[BaseRecordingExtractorInterface]] = None
     associated_recording_kwargs: Optional[dict] = None
 
     def setUpFreshInterface(self):

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -60,12 +60,6 @@ class DataInterfaceTestMixin:
     conversion_options: dict = dict()
     maxDiff = None
 
-    def __init__(self):
-        self.nwbfile_path = None
-        self.test_kwargs = None
-        self.case = None
-        self.interface = None
-
     def test_source_schema_valid(self):
         schema = self.data_interface_cls.get_source_schema()
         Draft7Validator.check_schema(schema=schema)
@@ -138,11 +132,6 @@ class TemporalAlignmentMixin:
     data_interface_cls: Type[BaseDataInterface]
     interface_kwargs: Union[dict, List[dict]]
     maxDiff = None
-
-    def __init__(self):
-        self.test_kwargs = None
-        self.case = None
-        self.interface = None
 
     def setUpFreshInterface(self):
         """Protocol for creating a fresh instance of the interface."""

--- a/src/neuroconv/utils/dict.py
+++ b/src/neuroconv/utils/dict.py
@@ -66,9 +66,9 @@ def append_replace_dict_in_list(ls, d, compare_key, list_dict_deep_update: bool 
         (which is a dict) say: ls[3][compare_key] == d[compare_key], then it will dict_deep_update these instead of
         appending d to list ls. Only if compare_key is not present in any of dicts in the list ls, then d is simply
         appended to ls.
-    2.  If d is of immutable types like str, int etc, the ls is either appended with d or not.
+    2.  If d is of immutable types like str, int etc., the ls is either appended with d or not.
         This depends on the value of remove_repeats. If remove_repeats is False, then ls is always appended with d.
-        If remove_repeats is True, then if value d is present then its not appended else it is.
+        If remove_repeats is True, then if value d is present then it is not appended else it is.
 
     Parameters
     ----------
@@ -126,7 +126,7 @@ def dict_deep_update(
         dictionary to update from
     append_list: bool
         if the item to update is a list, whether to append the lists or replace the list in d
-        eg. d = dict(key1=[1,2,3]), u = dict(key1=[3,4,5]).
+        e.g. d = dict(key1=[1,2,3]), u = dict(key1=[3,4,5]).
         If True then updated dictionary d=dict(key1=[1,2,3,4,5]) else d=dict(key1=[3,4,5])
     remove_repeats: bool
         for updating list in d[key] with list in u[key]: if true then remove repeats: list(set(ls))
@@ -166,7 +166,7 @@ def dict_deep_update(
             >>> output = [
                 {"name": "timeseries1", "desc": "desc2 of u", "starting_time": 0.0},
                 {"name": "timeseries2", "desc": "desc2"},
-            ]  # unit key is absent since its a replacement
+            ]  # unit key is absent since it is a replacement
     Returns
     -------
     d: dict

--- a/src/neuroconv/utils/json_schema.py
+++ b/src/neuroconv/utils/json_schema.py
@@ -254,7 +254,7 @@ def get_schema_from_hdmf_class(hdmf_class):
                 if docval_arg["name"] in pynwb_children_fields:
                     items = get_schema_from_hdmf_class(item)
                     schema_arg[docval_arg["name"]].update(type="array", items=items, minItems=1, maxItems=1)
-                # if it is link
+                # if it is a link
                 else:
                     target = item.__module__ + "." + item.__name__
                     schema_arg[docval_arg["name"]].update(type="string", target=target)
@@ -325,7 +325,7 @@ def get_metadata_schema_for_icephys():
 def validate_metadata(metadata: Dict[str, dict], schema: Dict[str, dict], verbose: bool = False):
     """Validate metadata against a schema."""
     encoder = NWBMetaDataEncoder()
-    # The encoder produces a serialized object so we deserialized it for comparison
+    # The encoder produces a serialized object, so we deserialized it for comparison
 
     serialized_metadata = encoder.encode(metadata)
     decoded_metadata = json.loads(serialized_metadata)

--- a/tests/imports.py
+++ b/tests/imports.py
@@ -1,5 +1,5 @@
 """
-This module is meant for the tests to be run as stand-alone so as to emulate a fresh import.
+This module is meant for the tests to be run as stand-alone to emulate a fresh import.
 
 Run them by using:
 pytest tests/import_structure.py::TestImportStructure::test_name

--- a/tests/test_behavior/test_audio_interface.py
+++ b/tests/test_behavior/test_audio_interface.py
@@ -208,7 +208,7 @@ On instance['Audio']['write_as']:
                         buffer_gb=1e7 / 1e9,
                     )
                 )
-            ),  # use a low buffer_gb so we can test the full GenericDataChunkIterator
+            ),  # use a low buffer_gb, so we can test the full GenericDataChunkIterator
         )
 
         with NWBHDF5IO(path=nwbfile_path, mode="r") as io:

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -233,23 +233,24 @@ class TestAddElectricalSeriesSavingTimestampsVsRates(unittest.TestCase):
 
 
 class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
-    def setUp(self):
-
+    @classmethod
+    def setUpClass(cls):
         """Use common recording objects and values."""
-        self.sampling_frequency = 1.0
-        self.num_channels = 3
-        self.num_frames = 5
-        self.channel_ids = ["a", "b", "c"]
-        self.traces_list = [np.ones(shape=(self.num_frames, self.num_channels))]
+        cls.sampling_frequency = 1.0
+        cls.num_channels = 3
+        cls.num_frames = 5
+        cls.channel_ids = ["a", "b", "c"]
+        cls.traces_list = [np.ones(shape=(cls.num_frames, cls.num_channels))]
 
         # Combinations of gains and default
-        self.gains_default = [1, 1, 1]
-        self.offset_defaults = [0, 0, 0]
-        self.gains_uniform = [2, 2, 2]
-        self.offsets_uniform = [3, 3, 3]
-        self.gains_variable = [1, 2, 3]
-        self.offsets_variable = [1, 2, 3]
+        cls.gains_default = [1, 1, 1]
+        cls.offset_defaults = [0, 0, 0]
+        cls.gains_uniform = [2, 2, 2]
+        cls.offsets_uniform = [3, 3, 3]
+        cls.gains_variable = [1, 2, 3]
+        cls.offsets_variable = [1, 2, 3]
 
+    def setUp(self):
         """Start with a fresh NWBFile, ElectrodeTable, and remapped BaseRecordings each time."""
         self.nwbfile = NWBFile(
             session_description="session_description1", identifier="file_id1", session_start_time=testing_session_time
@@ -378,24 +379,29 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
 
 
 class TestAddElectricalSeriesChunking(unittest.TestCase):
-    def setUp(self):
-        """Start with a fresh NWBFile, ElectrodeTable, and remapped BaseRecordings each time."""
-        self.sampling_frequency = 1.0
-        self.num_channels = 3
-        self.num_frames = 20
-        self.channel_ids = ["a", "b", "c"]
-        self.traces_list = [np.ones(shape=(self.num_frames, self.num_channels))]
+    @classmethod
+    def setUpClass(cls):
+        """Use common recording objects and values."""
+        cls.sampling_frequency = 1.0
+        cls.num_channels = 3
+        cls.num_frames = 20
+        cls.channel_ids = ["a", "b", "c"]
+        cls.traces_list = [np.ones(shape=(cls.num_frames, cls.num_channels))]
         # Flat traces [1, 1, 1] per channel
-        self.test_recording_extractor = NumpyRecording(
-            self.traces_list, self.sampling_frequency, channel_ids=self.channel_ids
+        cls.test_recording_extractor = NumpyRecording(
+            cls.traces_list, cls.sampling_frequency, channel_ids=cls.channel_ids
         )
 
         # Combinations of gains and default
-        self.gains_default = [2, 2, 2]
-        self.offset_default = [1, 1, 1]
+        cls.gains_default = [2, 2, 2]
+        cls.offset_default = [1, 1, 1]
 
-        self.test_recording_extractor.set_channel_gains(gains=self.gains_default)
-        self.test_recording_extractor.set_channel_offsets(offsets=self.offset_default)
+        cls.test_recording_extractor.set_channel_gains(gains=cls.gains_default)
+        cls.test_recording_extractor.set_channel_offsets(offsets=cls.offset_default)
+
+    def setUp(self):
+        """Start with a fresh NWBFile, ElectrodeTable, and remapped BaseRecordings each time."""
+
         self.nwbfile = NWBFile(
             session_description="session_description1", identifier="file_id1", session_start_time=testing_session_time
         )
@@ -481,29 +487,30 @@ class TestAddElectricalSeriesChunking(unittest.TestCase):
 
 
 class TestWriteRecording(unittest.TestCase):
-
-    def setUp(self):
-        """Start with a fresh NWBFile, ElectrodeTable, and remapped BaseRecordings each time."""
-
+    @classmethod
+    def setUpClass(cls):
         # 3 samples in each segment
-        self.num_channels = 3
-        self.sampling_frequency = 1.0
-        self.single_segment_recording_extractor = generate_recording(
-            sampling_frequency=self.sampling_frequency, num_channels=self.num_channels, durations=[3.0]
+        cls.num_channels = 3
+        cls.sampling_frequency = 1.0
+        cls.single_segment_recording_extractor = generate_recording(
+            sampling_frequency=cls.sampling_frequency, num_channels=cls.num_channels, durations=[3.0]
         )
-        self.multiple_segment_recording_extractor = generate_recording(
-            sampling_frequency=self.sampling_frequency, num_channels=self.num_channels, durations=[3.0, 3.0]
+        cls.multiple_segment_recording_extractor = generate_recording(
+            sampling_frequency=cls.sampling_frequency, num_channels=cls.num_channels, durations=[3.0, 3.0]
         )
 
         # Add gains and offsets
-        self.gains_default = [1, 1, 1]
-        self.offset_default = [0, 0, 0]
+        cls.gains_default = [1, 1, 1]
+        cls.offset_default = [0, 0, 0]
 
-        self.single_segment_recording_extractor.set_channel_gains(self.gains_default)
-        self.single_segment_recording_extractor.set_channel_offsets(self.offset_default)
+        cls.single_segment_recording_extractor.set_channel_gains(cls.gains_default)
+        cls.single_segment_recording_extractor.set_channel_offsets(cls.offset_default)
 
-        self.multiple_segment_recording_extractor.set_channel_gains(self.gains_default)
-        self.multiple_segment_recording_extractor.set_channel_offsets(self.offset_default)
+        cls.multiple_segment_recording_extractor.set_channel_gains(cls.gains_default)
+        cls.multiple_segment_recording_extractor.set_channel_offsets(cls.offset_default)
+
+    def setUp(self):
+        """Start with a fresh NWBFile, ElectrodeTable, and remapped BaseRecordings each time."""
 
         self.nwbfile = NWBFile(
             session_description="session_description1", identifier="file_id1", session_start_time=testing_session_time
@@ -559,13 +566,14 @@ class TestWriteRecording(unittest.TestCase):
 
 
 class TestAddElectrodes(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Use common recording objects and values."""
+        cls.num_channels = 4
+        cls.base_recording = generate_recording(num_channels=cls.num_channels, durations=[3])
+
     def setUp(self):
         """Start with a fresh NWBFile, ElectrodeTable, and remapped BaseRecordings each time."""
-
-        # Use common recording objects and values.
-        self.num_channels = 4
-        self.base_recording = generate_recording(num_channels=self.num_channels, durations=[3])
-
         self.nwbfile = NWBFile(
             session_description="session_description1", identifier="file_id1", session_start_time=testing_session_time
         )
@@ -846,16 +854,17 @@ class TestAddElectrodes(TestCase):
 
 
 class TestAddUnitsTable(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Use common recording objects and values."""
+        cls.num_units = 4
+        cls.single_segment_sorting = generate_sorting(num_units=cls.num_units, durations=[3])
+        cls.multiple_segment_sorting = generate_sorting(num_units=cls.num_units, durations=[3, 4])
+        cls.base_sorting = cls.single_segment_sorting
+        # Base sorting unit ids are [0, 1, 2, 3]
 
     def setUp(self):
         """Start with a fresh NWBFile, and remapped sorters each time."""
-
-        self.num_units = 4
-        self.single_segment_sorting = generate_sorting(num_units=self.num_units, durations=[3])
-        self.multiple_segment_sorting = generate_sorting(num_units=self.num_units, durations=[3, 4])
-        self.base_sorting = self.single_segment_sorting
-        # Base sorting unit ids are [0, 1, 2, 3]
-
         self.nwbfile = NWBFile(
             session_description="session_description1", identifier="file_id1", session_start_time=testing_session_time
         )
@@ -1109,19 +1118,20 @@ class TestAddUnitsTable(TestCase):
 
 
 class TestWriteWaveforms(TestCase):
-
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        """Use common recording objects and values."""
         from spikeinterface.postprocessing import compute_template_metrics
         from spikeinterface.qualitymetrics import compute_quality_metrics
 
-        self.num_units = 4
-        self.num_channels = 4
+        cls.num_units = 4
+        cls.num_channels = 4
         duration_1 = 6
         duration_2 = 7
-        single_segment_rec = generate_recording(num_channels=self.num_channels, durations=[duration_1])
-        single_segment_sort = generate_sorting(num_units=self.num_units, durations=[duration_1])
-        multi_segment_rec = generate_recording(num_channels=self.num_channels, durations=[duration_1, duration_2])
-        multi_segment_sort = generate_sorting(num_units=self.num_units, durations=[duration_1, duration_2])
+        single_segment_rec = generate_recording(num_channels=cls.num_channels, durations=[duration_1])
+        single_segment_sort = generate_sorting(num_units=cls.num_units, durations=[duration_1])
+        multi_segment_rec = generate_recording(num_channels=cls.num_channels, durations=[duration_1, duration_2])
+        multi_segment_sort = generate_sorting(num_units=cls.num_units, durations=[duration_1, duration_2])
         single_segment_rec.annotate(is_filtered=True)
         multi_segment_rec.annotate(is_filtered=True)
         single_segment_rec = single_segment_rec.save()
@@ -1129,35 +1139,36 @@ class TestWriteWaveforms(TestCase):
         single_segment_sort = single_segment_sort.save()
         multi_segment_sort = multi_segment_sort.save()
 
-        self.single_segment_we = extract_waveforms(single_segment_rec, single_segment_sort, folder=None, mode="memory")
-        self.multi_segment_we = extract_waveforms(multi_segment_rec, multi_segment_sort, folder=None, mode="memory")
+        cls.single_segment_we = extract_waveforms(single_segment_rec, single_segment_sort, folder=None, mode="memory")
+        cls.multi_segment_we = extract_waveforms(multi_segment_rec, multi_segment_sort, folder=None, mode="memory")
 
         # add quality/template metrics to test property propagation
-        compute_template_metrics(self.single_segment_we)
-        compute_template_metrics(self.multi_segment_we)
-        compute_quality_metrics(self.single_segment_we)
-        compute_quality_metrics(self.multi_segment_we)
+        compute_template_metrics(cls.single_segment_we)
+        compute_template_metrics(cls.multi_segment_we)
+        compute_quality_metrics(cls.single_segment_we)
+        compute_quality_metrics(cls.multi_segment_we)
 
         # slice sorting
         slice_sorting = single_segment_sort.select_units(single_segment_sort.unit_ids[::2])
-        self.we_slice = extract_waveforms(single_segment_rec, slice_sorting, folder=None, mode="memory")
+        cls.we_slice = extract_waveforms(single_segment_rec, slice_sorting, folder=None, mode="memory")
 
         # recordingless
-        self.tmpdir = Path(mkdtemp())
-        self.waveform_recordingless_path = self.tmpdir / "waveforms_recordingless"
-        we = extract_waveforms(single_segment_rec, single_segment_sort, folder=self.waveform_recordingless_path)
+        cls.tmpdir = Path(mkdtemp())
+        cls.waveform_recordingless_path = cls.tmpdir / "waveforms_recordingless"
+        we = extract_waveforms(single_segment_rec, single_segment_sort, folder=cls.waveform_recordingless_path)
         # reload without recording
-        self.we_recless = WaveformExtractor.load_from_folder(self.waveform_recordingless_path, with_recording=False)
-        self.we_recless_recording = single_segment_rec
+        cls.we_recless = WaveformExtractor.load_from_folder(cls.waveform_recordingless_path, with_recording=False)
+        cls.we_recless_recording = single_segment_rec
 
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmpdir)
 
-        # Start with a fresh NWBFile, and remapped sorters each time.
+    def setUp(self):
+        """Start with a fresh NWBFile, and remapped sorters each time."""
         self.nwbfile = NWBFile(
             session_description="session_description1", identifier="file_id1", session_start_time=testing_session_time
         )
-
-    def tearDown(self):
-        rmtree(self.tmpdir)
 
     def _test_waveform_write(self, we, nwbfile, test_properties=True):
         # test unit columns

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -33,14 +33,18 @@ testing_session_time = datetime.now().astimezone()
 
 
 class TestAddElectricalSeriesWriting(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Use common recording objects and values."""
+        cls.num_channels = 3
+        cls.sampling_frequency = 1.0
+        cls.durations = [3.0]  # 3 samples in the recorder
+        cls.test_recording_extractor = generate_recording(
+            sampling_frequency=cls.sampling_frequency, num_channels=cls.num_channels, durations=cls.durations
+        )
+
     def setUp(self):
         """Start with a fresh NWBFile, ElectrodeTable, and remapped BaseRecordings each time."""
-        self.num_channels = 3
-        self.sampling_frequency = 1.0
-        self.durations = [3.0]  # 3 samples in the recorder
-        self.test_recording_extractor = generate_recording(
-            sampling_frequency=self.sampling_frequency, num_channels=self.num_channels, durations=self.durations
-        )
         self.nwbfile = NWBFile(
             session_description="session_description1", identifier="file_id1", session_start_time=testing_session_time
         )

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -50,7 +50,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         )
 
     def test_default_values(self):
-        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile)
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         assert "ElectricalSeriesRaw" in acquisition_module
@@ -66,7 +66,10 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         np.testing.assert_array_almost_equal(expected_data, extracted_data)
 
     def test_write_as_lfp(self):
-        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, write_as="lfp")
+        write_as = "lfp"
+        add_electrical_series(
+            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None, write_as=write_as
+        )
 
         processing_module = self.nwbfile.processing
         assert "ecephys" in processing_module
@@ -84,7 +87,10 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         np.testing.assert_array_almost_equal(expected_data, extracted_data)
 
     def test_write_as_processing(self):
-        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, write_as="processed")
+        write_as = "processed"
+        add_electrical_series(
+            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None, write_as=write_as
+        )
 
         processing_module = self.nwbfile.processing
         assert "ecephys" in processing_module
@@ -113,6 +119,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
             nwbfile=self.nwbfile,
             metadata=metadata,
             es_key="ElectricalSeriesRaw",
+            iterator_type=None,
         )
         self.assertEqual(len(self.nwbfile.electrodes), len(self.test_recording_extractor.channel_ids))
         self.assertIn("ElectricalSeriesRaw", self.nwbfile.acquisition)
@@ -122,6 +129,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
             nwbfile=self.nwbfile,
             metadata=metadata,
             es_key="ElectricalSeriesLFP",
+            iterator_type=None,
         )
         self.assertIn("ElectricalSeriesRaw", self.nwbfile.acquisition)
         self.assertIn("ElectricalSeriesLFP", self.nwbfile.acquisition)
@@ -141,6 +149,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
             nwbfile=self.nwbfile,
             metadata=metadata,
             es_key="ElectricalSeriesRaw1",
+            iterator_type=None,
         )
         self.assertEqual(len(self.nwbfile.electrodes), len(self.test_recording_extractor.channel_ids))
         self.assertIn("ElectricalSeriesRaw1", self.nwbfile.acquisition)
@@ -151,6 +160,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
             nwbfile=self.nwbfile,
             metadata=metadata,
             es_key="ElectricalSeriesRaw2",
+            iterator_type=None,
         )
         self.assertIn("ElectricalSeriesRaw1", self.nwbfile.acquisition)
         self.assertIn("ElectricalSeriesRaw2", self.nwbfile.acquisition)
@@ -164,7 +174,9 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         reg_expression = f"'write_as' should be 'raw', 'processed' or 'lfp', but instead received value {write_as}"
 
         with self.assertRaisesRegex(AssertionError, reg_expression):
-            add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, write_as=write_as)
+            add_electrical_series(
+                recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None, write_as=write_as
+            )
 
     def test_write_with_higher_gzip_level(self):
         compression = "gzip"
@@ -172,6 +184,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         add_electrical_series(
             recording=self.test_recording_extractor,
             nwbfile=self.nwbfile,
+            iterator_type=None,
             compression=compression,
             compression_opts=compression_opts,
         )
@@ -184,7 +197,9 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
 
     def test_write_with_lzf_compression(self):
         compression = "lzf"
-        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, compression=compression)
+        add_electrical_series(
+            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None, compression=compression
+        )
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -211,7 +226,7 @@ class TestAddElectricalSeriesSavingTimestampsVsRates(unittest.TestCase):
         )
 
     def test_uniform_timestamps(self):
-        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile)
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -224,7 +239,7 @@ class TestAddElectricalSeriesSavingTimestampsVsRates(unittest.TestCase):
     def test_non_uniform_timestamps(self):
         expected_timestamps = np.array([0.0, 2.0, 10.0])
         self.test_recording_extractor.set_times(times=expected_timestamps, with_warning=False)
-        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile)
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -270,7 +285,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         self.test_recording_extractor.set_channel_gains(gains=gains)
         self.test_recording_extractor.set_channel_offsets(offsets=offsets)
 
-        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile)
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -295,7 +310,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         self.test_recording_extractor.set_channel_gains(gains=gains)
         self.test_recording_extractor.set_channel_offsets(offsets=offsets)
 
-        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile)
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -320,7 +335,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         self.test_recording_extractor.set_channel_gains(gains=gains)
         self.test_recording_extractor.set_channel_offsets(offsets=offsets)
 
-        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile)
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -347,7 +362,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         gains = self.gains_default
         self.test_recording_extractor.set_channel_gains(gains=gains)
 
-        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile)
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -378,7 +393,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         reg_expression = f"Recording extractors with heterogeneous offsets are not supported"
 
         with self.assertRaisesRegex(ValueError, reg_expression):
-            add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile)
+            add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
 
 class TestAddElectricalSeriesChunking(unittest.TestCase):
@@ -451,7 +466,7 @@ class TestAddElectricalSeriesChunking(unittest.TestCase):
         np.testing.assert_array_almost_equal(expected_data, extracted_data)
 
     def test_non_iterative_write(self):
-        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile)
+        add_electrical_series(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -521,7 +536,7 @@ class TestWriteRecording(unittest.TestCase):
 
     def test_default_values_single_segment(self):
         """This test that the names are written appropriately for the single segment case (numbers not added)"""
-        write_recording(recording=self.single_segment_recording_extractor, nwbfile=self.nwbfile)
+        write_recording(recording=self.single_segment_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         assert "ElectricalSeriesRaw" in acquisition_module
@@ -537,7 +552,7 @@ class TestWriteRecording(unittest.TestCase):
         np.testing.assert_array_almost_equal(expected_data, extracted_data)
 
     def test_write_multiple_segments(self):
-        write_recording(recording=self.multiple_segment_recording_extractor, nwbfile=self.nwbfile)
+        write_recording(recording=self.multiple_segment_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         assert len(acquisition_module) == 2

--- a/tests/test_on_data/test_yaml_conversion_specification.py
+++ b/tests/test_on_data/test_yaml_conversion_specification.py
@@ -2,7 +2,6 @@ import sys
 import unittest
 from datetime import datetime
 from pathlib import Path
-from typing import Union
 
 import pytest
 from hdmf.testing import TestCase

--- a/tests/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_ophys/test_tools_roiextractors.py
@@ -1517,7 +1517,7 @@ class TestAddPhotonSeries(TestCase):
         excess = 1.5  # Of what is available in memory
         num_frames_to_overflow = (available_memory_in_bytes * excess) / (element_size_in_bytes * math.prod(image_size))
 
-        # Mock recording extractor with as much frames as necessary to overflow memory
+        # Mock recording extractor with as many frames as necessary to overflow memory
         mock_imaging = Mock()
         mock_imaging.get_dtype.return_value = dtype
         mock_imaging.get_image_size.return_value = image_size


### PR DESCRIPTION
None of these changes change the functionality of the code. They are all just tidying up a bit.

* remove unused imports
* fix typos
* attributes like `data_interface_cls: BaseSortingExtractorInterface` should be `Type[BaseSortingExtractorInterface]`, indicating that it takes a class, not an object
* fix some typehint annotations
