### PR TITLE
Add router to alternate SI class for pl2

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
@@ -22,6 +22,8 @@ class PlexonRecordingInterface(BaseRecordingExtractorInterface):
             Allows verbosity.
         es_key : str, default: "ElectricalSeries"
         """
+        if Path(file_path).suffix == ".pl2":
+            self.ExtractorName = "Plexon2RecordingExtractor"
         super().__init__(file_path=file_path, verbose=verbose, es_key=es_key)
 
 

--- a/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
 from ....utils.types import FilePathType


### PR DESCRIPTION
I missed this when I heard `pl2` support had been finalized in SI; I figured they added the proper routing to the main Plexon recording extractor, but apparently it was added as a different class

