### PR TITLE
Fix sleap python range

### DIFF
--- a/src/neuroconv/datainterfaces/behavior/sleap/requirements.txt
+++ b/src/neuroconv/datainterfaces/behavior/sleap/requirements.txt
@@ -1,3 +1,3 @@
-sleap-io>=0.0.2; python_version>='3.10'
-sleap-io>=0.0.2,<=0.0.12; python_version<'3.10'
+sleap-io>=0.0.2; python_version>='3.9'
+sleap-io>=0.0.2,<=0.0.12; python_version<'3.9'
 av>=10.0.0

--- a/src/neuroconv/datainterfaces/behavior/sleap/requirements.txt
+++ b/src/neuroconv/datainterfaces/behavior/sleap/requirements.txt
@@ -1,3 +1,3 @@
 sleap-io>=0.0.2; python_version>='3.9'
-sleap-io>=0.0.2,<=0.0.12; python_version<'3.9'
+sleap-io>=0.0.2,<0.0.12; python_version<'3.9'
 av>=10.0.0

--- a/src/neuroconv/datainterfaces/behavior/sleap/requirements.txt
+++ b/src/neuroconv/datainterfaces/behavior/sleap/requirements.txt
@@ -1,2 +1,3 @@
-sleap-io>=0.0.2
+sleap-io>=0.0.2; python>=3.10
+sleap-io>=0.0.2,<=0.0.12; python<3.10
 av>=10.0.0

--- a/src/neuroconv/datainterfaces/behavior/sleap/requirements.txt
+++ b/src/neuroconv/datainterfaces/behavior/sleap/requirements.txt
@@ -1,3 +1,3 @@
-sleap-io>=0.0.2; python>=3.10
-sleap-io>=0.0.2,<=0.0.12; python<3.10
+sleap-io>=0.0.2; python_version>='3.10'
+sleap-io>=0.0.2,<=0.0.12; python_version<'3.10'
 av>=10.0.0


### PR DESCRIPTION
Recent release of sleap doesn't support Python 3.9 and causes error in CI; not one of our dev test suite packages so didn't catch it until today