### PR TITLE
Downpin spikeinterface to fix tests on main

### DIFF
--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -30,7 +30,7 @@ jobs:
   run-tests:
     needs: assess-file-changes
     if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' }}
-    uses: catalystneuro/neuroconv/.github/workflows/testing.yml@downpin_spike_interface
+    uses: catalystneuro/neuroconv/.github/workflows/testing.yml@main
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -30,7 +30,7 @@ jobs:
   run-tests:
     needs: assess-file-changes
     if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' }}
-    uses: catalystneuro/neuroconv/.github/workflows/testing.yml@main
+    uses: catalystneuro/neuroconv/.github/workflows/testing.yml@downpin_spike_interface
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/src/neuroconv/datainterfaces/ecephys/requirements.txt
+++ b/src/neuroconv/datainterfaces/ecephys/requirements.txt
@@ -1,2 +1,2 @@
-spikeinterface>=0.99.1
+spikeinterface>=0.99.1,<0.100.0
 packaging<22.0


### PR DESCRIPTION
Daily tests on `main` started failing as of SI release `0.100.0`: several hours ago, https://github.com/catalystneuro/neuroconv/actions/runs/7802776510/job/21281012657

Downpinning until fix is pushed separately