### PR TITLE
try new structure for conversion examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,4 +116,3 @@ extlinks = {
 html_sidebars = {
     "conversion_example_gallery": ["page-toc", "edit-this-page", "sourcelink"]
 }
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,3 +112,8 @@ extlinks = {
     "format-request-form": ("https://github.com/catalystneuro/neuroconv/issues/new?assignees=&labels=enhancement"
                             "%2Cdata+interfaces&template=format_request.yml&title=%5BNew+Format%5D%3A+", "")
 }
+
+html_sidebars = {
+    "conversion_example_gallery": ["page-toc", "edit-this-page", "sourcelink"]
+}
+

--- a/docs/conversion_example_gallery.rst
+++ b/docs/conversion_example_gallery.rst
@@ -1,5 +1,5 @@
 .. _conversion_gallery:
-
+:html_theme.sidebar_secondary.remove:
 
 Conversion Gallery
 ==================

--- a/docs/conversion_example_gallery.rst
+++ b/docs/conversion_example_gallery.rst
@@ -1,122 +1,104 @@
 .. _conversion_gallery:
 :html_theme.sidebar_secondary.remove:
 
+##################
 Conversion Gallery
-==================
+##################
 
 The examples here are guaranteed to be running correctly with our testing suite. Their aim is to be a showcase of the
 library capabilities and to get you to hit the ground running with your own conversion.
 
+*******************************
 Extracellular electrophysiology
--------------------------------
+*******************************
 
 Recording
-~~~~~~~~~
+---------
 
 .. include:: conversion_examples_gallery/recording/alphaomega.rst
 .. include:: conversion_examples_gallery/recording/axona.rst
-
-.. toctree::
-    :maxdepth: 1
-
-    Biocam <recording/biocam>
-    Blackrock <recording/blackrock>
-    European Data Format (EDF) <recording/edf>
-    Intan <recording/intan>
-    MaxOne <recording/maxone>
-    MCSRaw <recording/mcsraw>
-    MEArec <recording/mearec>
-    Neuralynx <recording/neuralynx>
-    NeuroScope <recording/neuroscope>
-    OpenEphys <recording/openephys>
-    Plexon <recording/plexon>
-    Spike2 <recording/spike2>
-    Spikegadgets <recording/spikegadgets>
-    SpikeGLX <recording/spikeglx>
-    Tucker-Davis Technologies (TDT) <recording/tdt>
+.. include:: conversion_examples_gallery/recording/biocam.rst
+.. include:: conversion_examples_gallery/recording/blackrock.rst
+.. include:: conversion_examples_gallery/recording/edf.rst
+.. include:: conversion_examples_gallery/recording/intan.rst
+.. include:: conversion_examples_gallery/recording/maxone.rst
+.. include:: conversion_examples_gallery/recording/mcsraw.rst
+.. include:: conversion_examples_gallery/recording/mearec.rst
+.. include:: conversion_examples_gallery/recording/neuralynx.rst
+.. include:: conversion_examples_gallery/recording/neuroscope.rst
+.. include:: conversion_examples_gallery/recording/openephys.rst
+.. include:: conversion_examples_gallery/recording/plexon.rst
+.. include:: conversion_examples_gallery/recording/spike2.rst
+.. include:: conversion_examples_gallery/recording/spikegadgets.rst
+.. include:: conversion_examples_gallery/recording/spikeglx.rst
+.. include:: conversion_examples_gallery/recording/tdt.rst
 
 Sorting
-~~~~~~~
+-------
 
-.. toctree::
-    :maxdepth: 1
+.. include:: conversion_examples_gallery/sorting/blackrock.rst
+.. include:: conversion_examples_gallery/sorting/cellexplorer.rst
+.. include:: conversion_examples_gallery/sorting/kilosort.rst
+.. include:: conversion_examples_gallery/sorting/neuralynx.rst
+.. include:: conversion_examples_gallery/sorting/neuroscope.rst
+.. include:: conversion_examples_gallery/sorting/phy.rst
+.. include:: conversion_examples_gallery/sorting/plexon.rst
 
-    Blackrock  <sorting/blackrock>
-    Cell Explorer <sorting/cellexplorer>
-    KiloSort <sorting/kilosort>
-    Neuralynx <sorting/neuralynx>
-    NeuroScope <sorting/neuroscope>
-    Phy <sorting/phy>
-    Plexon <sorting/plexon>
-
+*******************************
 Intracellular electrophysiology
--------------------------------
+*******************************
 
-.. toctree::
-    :maxdepth: 1
+.. include:: conversion_examples_gallery/recording/abf.rst
 
-    ABF <recording/abf>
-
+******************
 Optical physiology
-------------------
+******************
 
 Imaging
-~~~~~~~
+-------
 
-.. toctree::
-    :maxdepth: 1
+.. include:: conversion_examples_gallery/imaging/brukertiff.rst
+.. include:: conversion_examples_gallery/imaging/hdf5imaging.rst
+.. include:: conversion_examples_gallery/imaging/micromanagertiff.rst
+.. include:: conversion_examples_gallery/imaging/miniscope.rst
+.. include:: conversion_examples_gallery/imaging/scanbox.rst
+.. include:: conversion_examples_gallery/imaging/scanimage.rst
+.. include:: conversion_examples_gallery/imaging/tiff.rst
 
-    Bruker <imaging/brukertiff>
-    HDF5 <imaging/hdf5imaging>
-    Micro-Manager <imaging/micromanagertiff>
-    Miniscope <imaging/miniscope>
-    Scanbox <imaging/scanbox>
-    ScanImage <imaging/scanimage>
-    Tiff <imaging/tiff>
 
 Segmentation
-~~~~~~~~~~~~
+------------
 
-.. toctree::
-    :maxdepth: 1
+.. include:: conversion_examples_gallery/segmentation/caiman.rst
+.. include:: conversion_examples_gallery/segmentation/cnmfe.rst
+.. include:: conversion_examples_gallery/segmentation/extract.rst
+.. include:: conversion_examples_gallery/segmentation/suite2p.rst
 
-    Caiman <segmentation/caiman>
-    CNMFE <segmentation/cnmfe>
-    EXTRACT <segmentation/extract>
-    Suite2P <segmentation/suite2p>
-
+********
 Behavior
---------
+********
 
-.. toctree::
-    :maxdepth: 1
-
-    Audio <behavior/audio>
-    DeepLabCut <behavior/deeplabcut>
-    FicTrac <behavior/fictrac>
-    LightningPose <behavior/lightningpose>
-    SLEAP <behavior/sleap>
-    Videos <behavior/video>
-
+.. include:: conversion_examples_gallery/behavior/audio.rst
+.. include:: conversion_examples_gallery/behavior/deeplabcut.rst
+.. include:: conversion_examples_gallery/behavior/fictrac.rst
+.. include:: conversion_examples_gallery/behavior/lightningpose.rst
+.. include:: conversion_examples_gallery/behavior/sleap.rst
+.. include:: conversion_examples_gallery/behavior/video.rst
+.. include:: conversion_examples_gallery/behavior/neuralynx_nvt.rst
 
 Text
 ----
 
-.. toctree::
-    :maxdepth: 1
+.. include:: conversion_examples_gallery/text/csv.rst
+.. include:: conversion_examples_gallery/text/excel.rst
 
-    CSV <text/csv>
-    Excel <text/excel>
-
+*****************************
 Common interface combinations
------------------------------
+*****************************
 
-.. toctree::
-    :maxdepth: 1
-
-    combinations/spikeglx_and_phy
-    combinations/tiff_and_suite2p
-    combinations/ecephys_pose_estimation
+.. include:: conversion_examples_gallery/combinations/spikeglx_and_phy.rst
+.. include:: conversion_examples_gallery/combinations/tiff_and_suite2p.rst
+.. include:: conversion_examples_gallery/combinations/ecephys_pose_estimation.rst
 
 .. note::
   If you do not see the format you need, feel free to :format-request-form:`request it<>` or

--- a/docs/conversion_example_gallery.rst
+++ b/docs/conversion_example_gallery.rst
@@ -1,5 +1,6 @@
 .. _conversion_gallery:
 
+
 Conversion Gallery
 ==================
 
@@ -12,11 +13,12 @@ Extracellular electrophysiology
 Recording
 ~~~~~~~~~
 
+.. include:: conversion_examples_gallery/recording/alphaomega.rst
+.. include:: conversion_examples_gallery/recording/axona.rst
+
 .. toctree::
     :maxdepth: 1
 
-    AlphaOmega <recording/alphaomega>
-    Axona <recording/axona>
     Biocam <recording/biocam>
     Blackrock <recording/blackrock>
     European Data Format (EDF) <recording/edf>

--- a/docs/conversion_examples_gallery/behavior/audio.rst
+++ b/docs/conversion_examples_gallery/behavior/audio.rst
@@ -1,5 +1,5 @@
-Audio data conversion
----------------------
+Audio
+-----
 
 Install NeuroConv with the additional dependencies necessary for reading audio data.
 

--- a/docs/conversion_examples_gallery/behavior/deeplabcut.rst
+++ b/docs/conversion_examples_gallery/behavior/deeplabcut.rst
@@ -1,5 +1,5 @@
-DeepLabCut data conversion
---------------------------
+DeepLabCut
+----------
 
 Install NeuroConv with the additional dependencies necessary for reading DeepLabCut data.
 

--- a/docs/conversion_examples_gallery/behavior/fictrac.rst
+++ b/docs/conversion_examples_gallery/behavior/fictrac.rst
@@ -1,5 +1,5 @@
-FicTrac data conversion
---------------------------
+FicTrac
+-------
 
 Install NeuroConv with the additional dependencies necessary for reading `FicTrac <https://rjdmoore.net/fictrac/>`_ data.
 

--- a/docs/conversion_examples_gallery/behavior/lightningpose.rst
+++ b/docs/conversion_examples_gallery/behavior/lightningpose.rst
@@ -1,5 +1,5 @@
-LightningPose data conversion
---------------------------
+LightningPose
+-------------
 
 Install NeuroConv with the additional dependencies necessary for reading LightningPose data.
 

--- a/docs/conversion_examples_gallery/behavior/neuralynx_nvt.rst
+++ b/docs/conversion_examples_gallery/behavior/neuralynx_nvt.rst
@@ -1,5 +1,5 @@
-Neuralynx NVT data conversion
------------------------------
+Neuralynx NVT
+-------------
 
 Neuralynx NVT files contain information about position tracking. This interface requires no additional dependencies,
 so you can install NeuroConv using:

--- a/docs/conversion_examples_gallery/behavior/sleap.rst
+++ b/docs/conversion_examples_gallery/behavior/sleap.rst
@@ -1,5 +1,5 @@
-SLEAP data conversion
----------------------
+SLEAP
+-----
 
 Install NeuroConv with the additional dependencies necessary for reading SLEAP data.
 

--- a/docs/conversion_examples_gallery/behavior/video.rst
+++ b/docs/conversion_examples_gallery/behavior/video.rst
@@ -1,5 +1,5 @@
-Video data conversion (multimedia formats)
-------------------------------------------
+Video (multimedia formats)
+--------------------------
 
 Install NeuroConv with the additional dependencies necessary for reading multimedia data.
 
@@ -7,7 +7,7 @@ Install NeuroConv with the additional dependencies necessary for reading multime
 
     pip install neuroconv[video]
 
-This interface can handle conversions from avi, mov, mp4, wmv, flv and most FFmpeg_ supported formats to NWB using the
+This interface can handle conversions from .avi, .mov, .mp4, .wmv, .flv and most FFmpeg_-supported formats to NWB using the
 :py:class:`~neuroconv.datainterfaces.behavior.video.videodatainterface.VideoInterface` class.
 
 .. _FFmpeg: https://ffmpeg.org/

--- a/docs/conversion_examples_gallery/imaging/brukertiff.rst
+++ b/docs/conversion_examples_gallery/imaging/brukertiff.rst
@@ -1,5 +1,5 @@
-Bruker TIFF data conversion
----------------------------
+Bruker TIFF
+^^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading Bruker TIFF data.
 

--- a/docs/conversion_examples_gallery/imaging/hdf5imaging.rst
+++ b/docs/conversion_examples_gallery/imaging/hdf5imaging.rst
@@ -1,5 +1,5 @@
-HDF5 data conversion
---------------------
+HDF5 Imaging
+^^^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading HDF5 data.
 

--- a/docs/conversion_examples_gallery/imaging/micromanagertiff.rst
+++ b/docs/conversion_examples_gallery/imaging/micromanagertiff.rst
@@ -1,5 +1,5 @@
-Micro-Manager TIFF data conversion
-----------------------------------
+Micro-Manager TIFF
+^^^^^^^^^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading Micro-Manager TIFF data.
 

--- a/docs/conversion_examples_gallery/imaging/miniscope.rst
+++ b/docs/conversion_examples_gallery/imaging/miniscope.rst
@@ -1,5 +1,5 @@
-Miniscope data conversion
--------------------------
+Miniscope
+^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading Miniscope data.
 

--- a/docs/conversion_examples_gallery/imaging/scanbox.rst
+++ b/docs/conversion_examples_gallery/imaging/scanbox.rst
@@ -1,5 +1,5 @@
-Scanbox data conversion
------------------------
+Scanbox
+^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading Scanbox data.
 

--- a/docs/conversion_examples_gallery/imaging/scanimage.rst
+++ b/docs/conversion_examples_gallery/imaging/scanimage.rst
@@ -1,5 +1,5 @@
-ScanImage data conversion
--------------------------
+ScanImage
+^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading ScanImage data.
 

--- a/docs/conversion_examples_gallery/imaging/tiff.rst
+++ b/docs/conversion_examples_gallery/imaging/tiff.rst
@@ -1,5 +1,5 @@
-TIFF data conversion
---------------------
+TIFF
+^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading TIFF data.
 

--- a/docs/conversion_examples_gallery/recording/abf.rst
+++ b/docs/conversion_examples_gallery/recording/abf.rst
@@ -1,5 +1,5 @@
-ABF data conversion
--------------------
+ABF
+---
 
 Install NeuroConv with the additional dependencies necessary for reading ABF data.
 

--- a/docs/conversion_examples_gallery/recording/alphaomega.rst
+++ b/docs/conversion_examples_gallery/recording/alphaomega.rst
@@ -1,5 +1,5 @@
-AlphaOmega conversion
----------------------
+AlphaOmega
+^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading AlphaOmega data.
 

--- a/docs/conversion_examples_gallery/recording/axona.rst
+++ b/docs/conversion_examples_gallery/recording/axona.rst
@@ -1,5 +1,5 @@
-Axona data conversion
----------------------
+Axona
+^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading Axona data.
 

--- a/docs/conversion_examples_gallery/recording/biocam.rst
+++ b/docs/conversion_examples_gallery/recording/biocam.rst
@@ -1,5 +1,5 @@
-Biocam conversion
------------------
+Biocam
+^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading Biocam data.
 

--- a/docs/conversion_examples_gallery/recording/blackrock.rst
+++ b/docs/conversion_examples_gallery/recording/blackrock.rst
@@ -1,6 +1,5 @@
-Blackrock data conversion
--------------------------
-
+Blackrock recording
+^^^^^^^^^^^^^^^^^^^
 Install NeuroConv with the additional dependencies necessary for reading Blackrock data.
 
 .. code-block:: bash

--- a/docs/conversion_examples_gallery/recording/edf.rst
+++ b/docs/conversion_examples_gallery/recording/edf.rst
@@ -1,5 +1,5 @@
-European Data Format (EDF) conversion
--------------------------------------
+European Data Format (EDF)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading EDF data.
 

--- a/docs/conversion_examples_gallery/recording/intan.rst
+++ b/docs/conversion_examples_gallery/recording/intan.rst
@@ -1,6 +1,5 @@
-Intan data conversion
----------------------
-
+Intan
+^^^^^
 Install NeuroConv with the additional dependencies necessary for reading Intan data.
 
 .. code-block:: bash

--- a/docs/conversion_examples_gallery/recording/maxone.rst
+++ b/docs/conversion_examples_gallery/recording/maxone.rst
@@ -1,5 +1,5 @@
-MaxOne conversion
------------------
+MaxOne
+^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading MaxOne data.
 

--- a/docs/conversion_examples_gallery/recording/mcsraw.rst
+++ b/docs/conversion_examples_gallery/recording/mcsraw.rst
@@ -1,5 +1,5 @@
-MCSRaw conversion
------------------
+MCSRaw
+^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading MCSRaw data.
 

--- a/docs/conversion_examples_gallery/recording/mearec.rst
+++ b/docs/conversion_examples_gallery/recording/mearec.rst
@@ -1,5 +1,5 @@
-MEArec conversion
------------------
+MEArec
+^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading MEArec data.
 

--- a/docs/conversion_examples_gallery/recording/neuralynx.rst
+++ b/docs/conversion_examples_gallery/recording/neuralynx.rst
@@ -1,5 +1,5 @@
-Neuralynx data conversion
--------------------------
+Neuralynx
+^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading Neuralynx data.
 

--- a/docs/conversion_examples_gallery/recording/neuroscope.rst
+++ b/docs/conversion_examples_gallery/recording/neuroscope.rst
@@ -1,5 +1,5 @@
-NeuroScope data conversion
---------------------------
+NeuroScope
+^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading NeuroScope data.
 

--- a/docs/conversion_examples_gallery/recording/openephys.rst
+++ b/docs/conversion_examples_gallery/recording/openephys.rst
@@ -1,5 +1,5 @@
-OpenEphys data conversion
--------------------------
+OpenEphys
+^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading OpenEphys data.
 

--- a/docs/conversion_examples_gallery/recording/plexon.rst
+++ b/docs/conversion_examples_gallery/recording/plexon.rst
@@ -1,5 +1,5 @@
-Plexon Recording Conversion
----------------------------
+Plexon
+^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading Plexon acquisition data.
 

--- a/docs/conversion_examples_gallery/recording/spike2.rst
+++ b/docs/conversion_examples_gallery/recording/spike2.rst
@@ -1,5 +1,5 @@
-Spike2 data conversion
-----------------------
+Spike2
+^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading Spike2 data by CED.
 

--- a/docs/conversion_examples_gallery/recording/spikegadgets.rst
+++ b/docs/conversion_examples_gallery/recording/spikegadgets.rst
@@ -1,5 +1,5 @@
-Spikegadgets data conversion
-----------------------------
+Spikegadgets
+^^^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading Spikegadgets data.
 

--- a/docs/conversion_examples_gallery/recording/spikeglx.rst
+++ b/docs/conversion_examples_gallery/recording/spikeglx.rst
@@ -1,5 +1,5 @@
-SpikeGLX data conversion
-------------------------
+SpikeGLX
+^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading SpikeGLX data.
 

--- a/docs/conversion_examples_gallery/recording/tdt.rst
+++ b/docs/conversion_examples_gallery/recording/tdt.rst
@@ -1,5 +1,5 @@
-Tucker-Davis Technologies (TDT) data conversion
------------------------------------------------
+Tucker-Davis Technologies (TDT)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading TDT data.
 

--- a/docs/conversion_examples_gallery/segmentation/caiman.rst
+++ b/docs/conversion_examples_gallery/segmentation/caiman.rst
@@ -1,5 +1,5 @@
 CaImAn
-------
+^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading CaImAn data.
 

--- a/docs/conversion_examples_gallery/segmentation/cnmfe.rst
+++ b/docs/conversion_examples_gallery/segmentation/cnmfe.rst
@@ -1,5 +1,5 @@
 CNMFE
------
+^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading CNMF-E data.
 

--- a/docs/conversion_examples_gallery/segmentation/extract.rst
+++ b/docs/conversion_examples_gallery/segmentation/extract.rst
@@ -1,5 +1,5 @@
 EXTRACT
--------
+^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading EXTRACT data.
 

--- a/docs/conversion_examples_gallery/segmentation/suite2p.rst
+++ b/docs/conversion_examples_gallery/segmentation/suite2p.rst
@@ -1,5 +1,5 @@
 suite2p
--------
+^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading suite2p data.
 

--- a/docs/conversion_examples_gallery/sorting/blackrock.rst
+++ b/docs/conversion_examples_gallery/sorting/blackrock.rst
@@ -1,5 +1,5 @@
-Blackrock sorting data conversion
----------------------------------
+Blackrock sorting
+^^^^^^^^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading Blackrock sorting data.
 

--- a/docs/conversion_examples_gallery/sorting/cellexplorer.rst
+++ b/docs/conversion_examples_gallery/sorting/cellexplorer.rst
@@ -1,5 +1,5 @@
-CellExplorer data conversion
------------------------------
+CellExplorer
+^^^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading CellExplorer data.
 

--- a/docs/conversion_examples_gallery/sorting/kilosort.rst
+++ b/docs/conversion_examples_gallery/sorting/kilosort.rst
@@ -1,5 +1,5 @@
-KiloSort data conversion
-------------------------
+KiloSort
+^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading kilosort data.
 

--- a/docs/conversion_examples_gallery/sorting/neuralynx.rst
+++ b/docs/conversion_examples_gallery/sorting/neuralynx.rst
@@ -1,5 +1,5 @@
-Neuralynx data conversion
--------------------------
+Neuralynx sorting
+^^^^^^^^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading neuralynx data.
 

--- a/docs/conversion_examples_gallery/sorting/neuroscope.rst
+++ b/docs/conversion_examples_gallery/sorting/neuroscope.rst
@@ -1,5 +1,5 @@
-NeuroScope sorting data conversion
-----------------------------------
+NeuroScope sorting
+^^^^^^^^^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading neuroscope data.
 

--- a/docs/conversion_examples_gallery/sorting/phy.rst
+++ b/docs/conversion_examples_gallery/sorting/phy.rst
@@ -1,5 +1,5 @@
-Phy sorting data conversion
----------------------------
+Phy sorting
+^^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading Phy data.
 

--- a/docs/conversion_examples_gallery/sorting/plexon.rst
+++ b/docs/conversion_examples_gallery/sorting/plexon.rst
@@ -1,5 +1,5 @@
-Plexon sorting data conversion
-------------------------------
+Plexon sorting
+^^^^^^^^^^^^^^
 
 Install NeuroConv with the additional dependencies necessary for reading Plexon data.
 

--- a/docs/conversion_examples_gallery/text/csv.rst
+++ b/docs/conversion_examples_gallery/text/csv.rst
@@ -1,5 +1,5 @@
-Comma-Separated Values (CSV) files
-----------------------------------
+Comma-Separated Values (CSV)
+----------------------------
 
 Install NeuroConv. No extra dependencies are necessary for reading CSV.
 

--- a/docs/conversion_examples_gallery/text/excel.rst
+++ b/docs/conversion_examples_gallery/text/excel.rst
@@ -1,5 +1,5 @@
-Excel data conversion
----------------------
+Excel
+-----
 
 Install NeuroConv with the additional dependencies necessary for reading Excel data.
 
@@ -7,7 +7,7 @@ Install NeuroConv with the additional dependencies necessary for reading Excel d
 
     pip install neuroconv[excel]
 
-Convert Excel data to NWB using
+Convert Excel files (.xls, .xlsx) to NWB using
 :py:class:`~neuroconv.datainterfaces.text.excel.exceltimeintervalsinterface.ExcelTimeIntervalsInterface`.
 
 The Excel file must contain a header row that contains at least the column names "start_time" and "stop_time".

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Features:
   :caption: Contents
 
   user_guide/user_guide
-  conversion_examples_gallery/conversion_example_gallery
+  conversion_example_gallery
   catalogue/catalogue
   developer_guide
   api


### PR DESCRIPTION
The problem is that currently with the new pydata skin there are 3 different tables that basically do the same thing:

<img width="1383" alt="image" src="https://github.com/catalystneuro/neuroconv/assets/844306/7426148b-7d98-4e2d-86c6-e48b30981942">

With this new navigation, it may be more convenient to put all the conversion examples on a single page, making it easier to CTRL+F. You can easily navigate to the desired conversion using the sidebar.


What do you guys think of this as an alternative structure/layout?

<img width="1050" alt="image" src="https://github.com/catalystneuro/neuroconv/assets/844306/218a3065-fb11-434c-aa76-5852d55bacfe">
