### PR TITLE
Remove roundabout JSON interaction with electrode table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 * Exposed `block_index` to all OpenEphys interfaces. [PR #695](https://github.com/catalystneuro/neuroconv/pull/695)
 * Added support for `DynamicTable` columns in the `configure_backend` tool function. [PR #700](https://github.com/catalystneuro/neuroconv/pull/700)
 
+### Deprecation
+* Removed `.get_electrode_table_json()` on the `BaseRecordingExtractorInterface` in favor of GUIDE specific interactions. [PR #431](https://github.com/catalystneuro/neuroconv/pull/431)
+
 
 
 # v0.4.6 (November 30, 2023)

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -100,30 +100,6 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
 
         return metadata
 
-    def get_electrode_table_json(self) -> List[Dict[str, Any]]:
-        """
-        A convenience function for collecting and organizing the property values of the underlying recording extractor.
-
-        Uses the structure of the Handsontable (list of dict entries) component of the NWB GUIDE.
-        """
-        property_names = set(self.recording_extractor.get_property_keys()) - {
-            "contact_vector",  # TODO: add consideration for contact vector (probeinterface) info
-            "location",  # testing
-        }
-        electrode_ids = self.recording_extractor.get_channel_ids()
-
-        table = list()
-        for electrode_id in electrode_ids:
-            electrode_column = dict()
-            for property_name in property_names:
-                recording_property_value = self.recording_extractor.get_property(key=property_name, ids=[electrode_id])[
-                    0  # First axis is always electodes in SI
-                ]  # Since only fetching one electrode at a time, use trivial zero-index
-                electrode_column.update({property_name: recording_property_value})
-            table.append(electrode_column)
-        table_as_json = json.loads(json.dumps(table, cls=NWBMetaDataEncoder))
-        return table_as_json
-
     def get_original_timestamps(self) -> Union[np.ndarray, List[np.ndarray]]:
         """
         Retrieve the original unaltered timestamps for the data in this interface.

--- a/tests/test_on_data/test_recording_interfaces.py
+++ b/tests/test_on_data/test_recording_interfaces.py
@@ -490,46 +490,6 @@ class TestSpikeGLXRecordingInterface(RecordingExtractorInterfaceTestMixin, TestC
             manufacturer="Imec",
         )
 
-    def check_electrode_property_helper(self):
-        """Check that the helper function returns in the way the NWB GUIDE table component expects."""
-        electrode_table_json = self.interface.get_electrode_table_json()
-
-        spikeglx_electrode_table_schema = {
-            "type": "array",
-            "minItems": 0,
-            "items": {"$ref": "#/definitions/SpikeGLXElectrodeColumnEntry"},
-            "definitions": {
-                "SpikeGLXElectrodeColumnEntry": {
-                    "type": "object",
-                    "additionalProperties": False,
-                    "required": [
-                        "channel_name",
-                        "contact_shapes",
-                        "gain_to_uV",
-                        "offset_to_uV",
-                        "group",
-                        "group_name",
-                        "inter_sample_shift",
-                        # "location",
-                        "shank_electrode_number",
-                    ],
-                    "properties": {
-                        "channel_name": {"type": "string"},
-                        "contact_shapes": {"type": "string"},
-                        "gain_to_uV": {"type": "number"},
-                        "offset_to_uV": {"type": "number"},
-                        "group": {"type": "number"},
-                        "group_name": {"type": "string"},
-                        "inter_sample_shift": {"type": "number"},
-                        "location": {"type": "array"},
-                        "shank_electrode_number": {"type": "number"},
-                    },
-                }
-            },
-        }
-        print(f"{[electrode_table_json[0]]=}")
-        jsonschema.validate(instance=[electrode_table_json[0]], schema=spikeglx_electrode_table_schema)
-
     def run_custom_checks(self):
         self.check_electrode_property_helper()
 

--- a/tests/test_on_data/test_recording_interfaces.py
+++ b/tests/test_on_data/test_recording_interfaces.py
@@ -490,9 +490,6 @@ class TestSpikeGLXRecordingInterface(RecordingExtractorInterfaceTestMixin, TestC
             manufacturer="Imec",
         )
 
-    def run_custom_checks(self):
-        self.check_electrode_property_helper()
-
 
 class TestTdtRecordingInterface(RecordingExtractorInterfaceTestMixin, TestCase):
     data_interface_cls = TdtRecordingInterface


### PR DESCRIPTION
As per meeting; moving this from a generic interface method that has no programmatic use to GUIDE specific interactions