### PR TITLE
add `AlphaOmega` recording to docs API

### DIFF
--- a/docs/api/interfaces.ecephys.rst
+++ b/docs/api/interfaces.ecephys.rst
@@ -9,6 +9,10 @@ Base Sorting
 ------------
 .. automodule:: neuroconv.datainterfaces.ecephys.basesortingextractorinterface
 
+AlphaOmega
+----------
+.. automodule:: neuroconv.datainterfaces.ecephys.alphaomega.alphaomegadatainterface
+
 Axona Recording
 ---------------
 .. automodule:: neuroconv.datainterfaces.ecephys.axona.axonadatainterface


### PR DESCRIPTION
It seems this was missing.