### PR TITLE
[Bug] Fix non-lazy ROIExtractors import

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,7 +41,7 @@ jobs:
 
 
       - name: Install neuroconv with minimal requirements
-        run: pip install .[test]
+        run: pip install .
       - name: Run import tests
         run: |
           pytest tests/imports.py::TestImportStructure::test_top_level
@@ -50,7 +50,8 @@ jobs:
       - name: Run minimal tests
         run: pytest tests/test_minimal -vv -rsx -n auto --dist loadscope
 
-
+      - name: Install additional specific testing-only requirements
+        run: pip install .[test]
 
       - name: Install with ecephys requirements
         run: pip install .[ecephys]
@@ -75,8 +76,8 @@ jobs:
 
 
 
-      - name: Install full requirements (-e needed for codecov report)
-        run: pip install -e .[full]
+      - name: Install full requirements
+        run: pip install -e .[full]  # -e needed for codecov report
 
 
 

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -4,4 +4,3 @@ ndx-events>=0.2.0  # for special tests to ensure load_namespaces is set to allow
 parameterized>=0.8.1
 ndx-miniscope
 spikeinterface[qualitymetrics]>=0.99.1
-roiextractors

--- a/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterface.py
+++ b/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterface.py
@@ -3,9 +3,6 @@ import json
 from typing import Optional
 
 from dateutil.parser import parse as dateparse
-from roiextractors.extractors.tiffimagingextractors.scanimagetiff_utils import (
-    extract_extra_metadata,
-)
 
 from ..baseimagingextractorinterface import BaseImagingExtractorInterface
 from ....utils import FilePathType
@@ -42,6 +39,10 @@ class ScanImageImagingInterface(BaseImagingExtractorInterface):
             The sampling frequency can usually be extracted from the scanimage metadata in
             exif:ImageDescription:state.acq.frameRate. If not, use this.
         """
+        from roiextractors.extractors.tiffimagingextractors.scanimagetiff_utils import (
+            extract_extra_metadata,
+        )
+
         self.image_metadata = extract_extra_metadata(file_path=file_path)
 
         if "state.acq.frameRate" in self.image_metadata:

--- a/tests/imports.py
+++ b/tests/imports.py
@@ -7,6 +7,8 @@ pytest tests/import_structure.py::TestImportStructure::test_name
 
 from unittest import TestCase
 
+from neuroconv import BaseDataInterface
+
 
 def _strip_magic_module_attributes(ls: list) -> list:
     exclude_keys = [
@@ -89,3 +91,11 @@ class TestImportStructure(TestCase):
         ] + interface_name_list
 
         assert sorted(current_structure) == sorted(expected_structure)
+
+
+def test_datainterfaces_import():
+    """Minimal installation should be able to import interfaces from the .datainterfaces submodule."""
+    # Nothing special about SpikeGLX; just need to pick something to import to ensure a minimal install doesn't fail
+    from neuroconv.datainterfaces import SpikeGLXRecodingInterface
+
+    assert isinstance(SpikeGLXRecodingInterface, BaseDataInterface)


### PR DESCRIPTION
Failed to notice this with PR #731, my bad. Imports like this should be lazy and done within the `__init__` of the class so the outer imports don't fail under a minimal installation