### PR TITLE
Remove conda for most of the ci

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,6 +63,9 @@ body:
         - 3.7
         - 3.8
         - 3.9
+        - 3.10
+        - 3.11
+        - 3.12
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/dev-testing.yml
+++ b/.github/workflows/dev-testing.yml
@@ -25,7 +25,6 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-      - uses: s-weigand/setup-conda@v1
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
       - name: Setup Python
@@ -63,7 +62,6 @@ jobs:
 
       - name: Display installed packages and their sources
         run: |
-          conda list
           pip list
 
       - name: Get ephy_testing_data current head hash

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -12,7 +12,6 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: s-weigand/setup-conda@v1
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/live-service-testing.yml
+++ b/.github/workflows/live-service-testing.yml
@@ -20,7 +20,6 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: s-weigand/setup-conda@v1
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,7 +22,6 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: s-weigand/setup-conda@v1
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/update-s3-testing-data.yml
+++ b/.github/workflows/update-s3-testing-data.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: s-weigand/setup-conda@v1
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
       - name: Setup Python


### PR DESCRIPTION
The only place were we required it now is to upload the data to S3 when that fails. I am confining the use of the action there as the CI is giving deprecations warnings for this actions already.

Let's see if my assumption of this not being used is correct.