### PR TITLE
Try to remove packaging bound

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/requirements.txt
+++ b/src/neuroconv/datainterfaces/ecephys/requirements.txt
@@ -1,2 +1,1 @@
 spikeinterface>=0.100.0
-packaging<22.0


### PR DESCRIPTION
From comment https://github.com/catalystneuro/neuroconv/pull/195#issuecomment-1342900752

Trying to loosen this bound as a part of a potential fix to the GUIDE for supporting a PyInstaller hook for Pydantic v2

Testing here to see if the previous issue with the packaging lower bound has been resolved by now