### PR TITLE
get json schema descriptions from docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Absorbed the `DatasetInfo` model into the `DatasetIOConfiguration` model. [PR #767](https://github.com/catalystneuro/neuroconv/pull/767)
 * Keyword argument `field_name` of the `DatasetIOConfiguration.from_neurodata_object` method has been renamed to `dataset_name` to be more consistent with its usage. This only affects direct initialization of the model; usage via the `BackendConfiguration` constructor and its associated helper functions in `neuroconv.tools.nwb_helpers` is unaffected. [PR #767](https://github.com/catalystneuro/neuroconv/pull/767)
 * Manual construction of a `DatasetIOConfiguration` now requires the field `dataset_name`, and will be validated to match the final path of `location_in_file`. Usage via the automated constructors is unchanged. [PR #767](https://github.com/catalystneuro/neuroconv/pull/767)
-
+* Enhance `get_schema_from_method_signature` to extract description from the method docval. [PR #771](https://github.com/catalystneuro/neuroconv/pull/771)
 
 
 # v0.4.7 (February 21, 2024)

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -14,3 +14,4 @@ tqdm>=4.60.0
 pandas
 parse>=1.20.0
 click
+docstring-parser

--- a/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
@@ -162,12 +162,20 @@ class AxonaPositionDataInterface(BaseDataInterface):
         return get_schema_from_method_signature(cls.__init__)
 
     def __init__(self, file_path: str):
+        """
+
+        Parameters
+        ----------
+        file_path: str
+            Path to .bin or .set file.
+        """
         super().__init__(filename=file_path)
         self.source_data = dict(file_path=file_path)
 
     def add_to_nwbfile(self, nwbfile: NWBFile, metadata: dict):
         """
         Run conversion for this data interface.
+
         Parameters
         ----------
         nwbfile : NWBFile

--- a/src/neuroconv/utils/json_schema.py
+++ b/src/neuroconv/utils/json_schema.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime
 from typing import Callable, Dict, List, Literal, Optional
 
+import docstring_parser
 import hdmf.data_utils
 import numpy as np
 import pynwb
@@ -88,10 +89,14 @@ def get_schema_from_method_signature(method: Callable, exclude: list = None) -> 
         FolderPathType="string",
     )
     args_spec = dict()
+    parsed_docstring = docstring_parser.parse(method.__doc__)
     for param_name, param in inspect.signature(method).parameters.items():
         if param_name in exclude:
             continue
         args_spec[param_name] = dict()
+        for doc_param in parsed_docstring.params:
+            if doc_param.arg_name == param_name and doc_param.description:
+                args_spec[param_name].update(description=doc_param.description)
         if param.annotation:
             if getattr(param.annotation, "__origin__", None) == Literal:
                 args_spec[param_name]["enum"] = list(param.annotation.__args__)

--- a/tests/test_behavior/test_audio_interface.py
+++ b/tests/test_behavior/test_audio_interface.py
@@ -94,14 +94,7 @@ class TestAudioInterface(AudioInterfaceTestMixin, TestCase):
         self.assertEqual(len(audio_metadata), self.num_audio_files)
 
     def test_incorrect_write_as(self):
-        expected_error_message = """'bad_option' is not one of ['stimulus', 'acquisition']
-
-Failed validating 'enum' in schema['properties']['Audio']['properties']['write_as']:
-    {'default': 'stimulus', 'enum': ['stimulus', 'acquisition']}
-
-On instance['Audio']['write_as']:
-    'bad_option'"""
-        with self.assertRaisesWith(exc_type=jsonschema.exceptions.ValidationError, exc_msg=expected_error_message):
+        with self.assertRaises(jsonschema.exceptions.ValidationError):
             self.nwb_converter.run_conversion(
                 nwbfile_path=self.nwbfile_path,
                 metadata=self.metadata,

--- a/tests/test_minimal/test_utils/test_json_schema_utils.py
+++ b/tests/test_minimal/test_utils/test_json_schema_utils.py
@@ -7,6 +7,7 @@ from typing import Dict, Union
 import numpy as np
 from pynwb.ophys import ImagingPlane, TwoPhotonSeries
 
+from neuroconv.datainterfaces import AlphaOmegaRecordingInterface
 from neuroconv.utils import (
     NWBMetaDataEncoder,
     dict_deep_update,
@@ -15,8 +16,6 @@ from neuroconv.utils import (
     get_schema_from_method_signature,
     load_dict_from_file,
 )
-
-from neuroconv.datainterfaces import AlphaOmegaRecordingInterface
 
 
 def compare_dicts(a: dict, b: dict):
@@ -245,26 +244,16 @@ def test_np_array_encoding():
 def test_get_schema_from_NWBDataInterface():
     schema = get_schema_from_method_signature(AlphaOmegaRecordingInterface.__init__)
     assert schema == {
-        "required": [
-            "folder_path"
-        ],
+        "required": ["folder_path"],
         "properties": {
             "folder_path": {
                 "format": "directory",
                 "description": "Path to the folder of .mpx files.",
-                "type": "string"
-            },
-            "verbose": {
-                "description": "Allows verbose.\nDefault is True.",
-                "type": "boolean",
-                "default": True
-            },
-            "es_key": {
                 "type": "string",
-                "default": "ElectricalSeries"
-            }
+            },
+            "verbose": {"description": "Allows verbose.\nDefault is True.", "type": "boolean", "default": True},
+            "es_key": {"type": "string", "default": "ElectricalSeries"},
         },
         "type": "object",
-        "additionalProperties": False
+        "additionalProperties": False,
     }
-

--- a/tests/test_minimal/test_utils/test_json_schema_utils.py
+++ b/tests/test_minimal/test_utils/test_json_schema_utils.py
@@ -16,6 +16,8 @@ from neuroconv.utils import (
     load_dict_from_file,
 )
 
+from neuroconv.datainterfaces import AlphaOmegaRecordingInterface
+
 
 def compare_dicts(a: dict, b: dict):
     a = sort_item(a)
@@ -238,3 +240,31 @@ def test_np_array_encoding():
     np_array = np.array([1, 2, 3])
     encoded = json.dumps(np_array, cls=NWBMetaDataEncoder)
     assert encoded == "[1, 2, 3]"
+
+
+def test_get_schema_from_NWBDataInterface():
+    schema = get_schema_from_method_signature(AlphaOmegaRecordingInterface.__init__)
+    assert schema == {
+        "required": [
+            "folder_path"
+        ],
+        "properties": {
+            "folder_path": {
+                "format": "directory",
+                "description": "Path to the folder of .mpx files.",
+                "type": "string"
+            },
+            "verbose": {
+                "description": "Allows verbose.\nDefault is True.",
+                "type": "boolean",
+                "default": True
+            },
+            "es_key": {
+                "type": "string",
+                "default": "ElectricalSeries"
+            }
+        },
+        "type": "object",
+        "additionalProperties": False
+    }
+


### PR DESCRIPTION
In GUIDE, the we need data entry help text for fields of the interface constructors. See for example:

<img width="742" alt="image" src="https://github.com/catalystneuro/neuroconv/assets/844306/92907ddc-40a9-4f9c-ade3-6e1831457a9e">

Without this help field, it is sometimes quite unclear which specific file or folder the user is meant to select. This help text is taken from the "description" field in the source json schema. This particular field for the `SpikeGLXRecordingInterface` was added manually to the source schema:

https://github.com/catalystneuro/neuroconv/blob/f80899b00a3749e5c8c9adf812ca0b69b45e7dd3/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py#L27-L31

While it is possible to do this with every DataInterface, that would be redundant with the docstring of the init and would add a lot of lines of code.

This PR solves this problem in general by instead taking this description directly from the docstring of the `__init__`. It adds a new dependency, docstring-parser, to the minimal installation, which is a downside. docstring-parser Is not a very well-established package and may break in the future.

Note that with this PR, all source schemas are already being generated and validated against json schema with these lines:

https://github.com/catalystneuro/neuroconv/blob/f80899b00a3749e5c8c9adf812ca0b69b45e7dd3/src/neuroconv/tools/testing/data_interface_mixins.py#L64-L66

One additional test simply uses an arbitrary DataInterface to confirm that the descriptions are indeed being added to the schema.

I can see two alternative solutions.

1. manually add these descriptions to the json schema as it is currently done with the `SpikeGLXRecordingInterface`. This is explicit, but also a bit redundant.
2. Change all DataInterfaces to extend from pydantic BaseModels, and replace our custom json schema generation with the corresponding functionality within pydantic.

The current solution achieves the same goal with minimal changes to the existing codebase.