### PR TITLE
Fix writing electrodes field in add_electrical_series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Improvements
 
+* Fixed writing the `electrodes` field in `add_electrical_series` when multiple groups are present. [PR #784](https://github.com/catalystneuro/neuroconv/pull/784)
 * Upgraded Pydantic support to `>v2.0.0`. [PR #767](https://github.com/catalystneuro/neuroconv/pull/767)
 * Absorbed the `DatasetInfo` model into the `DatasetIOConfiguration` model. [PR #767](https://github.com/catalystneuro/neuroconv/pull/767)
 * Keyword argument `field_name` of the `DatasetIOConfiguration.from_neurodata_object` method has been renamed to `dataset_name` to be more consistent with its usage. This only affects direct initialization of the model; usage via the `BackendConfiguration` constructor and its associated helper functions in `neuroconv.tools.nwb_helpers` is unaffected. [PR #767](https://github.com/catalystneuro/neuroconv/pull/767)

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -605,12 +605,17 @@ def add_electrical_series(
     channel_names = recording.get_property("channel_name")
     if channel_names is None:
         channel_names = recording.get_channel_ids().astype("str")
+    if "group_name" in recording.get_property_keys():
+        group_names = recording.get_property("group_name")
+    else:
+        group_names = recording.get_channel_groups()
 
     # We use those channels to select the electrodes to be added to the ElectricalSeries
     channel_name_column = nwbfile.electrodes["channel_name"][:]
-    mask = np.isin(channel_name_column, channel_names)
-    table_ids = np.nonzero(mask)[0]
-
+    channel_mask = np.isin(channel_name_column, channel_names)
+    group_name_column = nwbfile.electrodes["group_name"][:]
+    group_mask = np.isin(group_name_column, group_names)
+    (table_ids,) = np.nonzero(np.logical_and(channel_mask, group_mask))
     electrode_table_region = nwbfile.create_electrode_table_region(
         region=table_ids.tolist(), description="electrode_table_region"
     )

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -152,6 +152,12 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         )
         self.assertEqual(len(self.nwbfile.electrodes), len(self.test_recording_extractor.channel_ids))
         self.assertIn("ElectricalSeriesRaw1", self.nwbfile.acquisition)
+        # check channel names and group names
+        electrodes = self.nwbfile.acquisition["ElectricalSeriesRaw1"].electrodes[:]
+        np.testing.assert_equal(electrodes["channel_name"], self.test_recording_extractor.channel_ids.astype("str"))
+        np.testing.assert_equal(
+            electrodes["group_name"], self.test_recording_extractor.get_channel_groups().astype("str")
+        )
         # set new channel groups to create a new  electrode_group
         self.test_recording_extractor.set_channel_groups(["group1"] * len(self.test_recording_extractor.channel_ids))
         add_electrical_series(
@@ -164,6 +170,12 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         self.assertIn("ElectricalSeriesRaw1", self.nwbfile.acquisition)
         self.assertIn("ElectricalSeriesRaw2", self.nwbfile.acquisition)
         self.assertEqual(len(self.nwbfile.electrodes), 2 * len(self.test_recording_extractor.channel_ids))
+        # check channel names and group names
+        electrodes = self.nwbfile.acquisition["ElectricalSeriesRaw2"].electrodes[:]
+        np.testing.assert_equal(electrodes["channel_name"], self.test_recording_extractor.channel_ids.astype("str"))
+        np.testing.assert_equal(
+            electrodes["group_name"], self.test_recording_extractor.get_channel_groups().astype("str")
+        )
 
         self.test_recording_extractor.set_channel_groups(original_groups)
 
@@ -1131,7 +1143,9 @@ from neuroconv.tools import get_package_version
 spike_interface_version = get_package_version("spikeinterface")
 
 
-@unittest.skipIf(spike_interface_version > Version("0.100"), reason="WaeformExtractor not available in spikeinterface")
+@unittest.skipIf(
+    spike_interface_version >= Version("0.101"), reason="WaveformExtractor not available in spikeinterface"
+)
 class TestWriteWaveforms(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -106,7 +106,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         expected_data = self.test_recording_extractor.get_traces(segment_index=0)
         np.testing.assert_array_almost_equal(expected_data, extracted_data)
 
-    def test_write_multiple_electrical_series_from_same_group(self):
+    def test_write_multiple_electrical_series_from_same_electrode_group(self):
         metadata = dict(
             Ecephys=dict(
                 ElectricalSeriesRaw=dict(name="ElectricalSeriesRaw", description="raw series"),
@@ -134,7 +134,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         self.assertIn("ElectricalSeriesLFP", self.nwbfile.acquisition)
         self.assertEqual(len(self.nwbfile.electrodes), len(self.test_recording_extractor.channel_ids))
 
-    def test_write_multiple_electrical_series_from_different_groups(self):
+    def test_write_multiple_electrical_series_with_different_electrode_groups(self):
         metadata = dict(
             Ecephys=dict(
                 ElectricalSeriesRaw1=dict(name="ElectricalSeriesRaw1", description="raw series"),


### PR DESCRIPTION
Related to https://github.com/SpikeInterface/spikeinterface/issues/2588

The mask to find the electrodes corresponding to the electrical series should use both channel names and channel groups, while the current implementation only uses channel names.

Extended the test too, because we were only checking the `nwbfile.electrodes`, not the `es.electrodes`