### PR TITLE
Do not write `offset_to_uV` and `gain_to_uV` in `Electrodes`

### DIFF
--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -175,7 +175,12 @@ def add_electrode_groups(recording: BaseRecording, nwbfile: pynwb.NWBFile, metad
             nwbfile.create_electrode_group(**electrode_group_kwargs)
 
 
-def add_electrodes(recording: BaseRecording, nwbfile: pynwb.NWBFile, metadata: dict = None, exclude: tuple = ()):
+def add_electrodes(
+    recording: BaseRecording,
+    nwbfile: pynwb.NWBFile,
+    metadata: dict = None,
+    exclude: Optional[tuple] = None,
+):
     """
     Add channels from recording object as electrodes to nwbfile object.
 
@@ -236,8 +241,13 @@ def add_electrodes(recording: BaseRecording, nwbfile: pynwb.NWBFile, metadata: d
     # 1. Build columns details from extractor properties: dict(name: dict(description='',data=data, index=False))
     data_to_add = defaultdict(dict)
 
+    if exclude is None:
+        exclude = tuple()
+
+    exclude = list(exclude)
+
     recorder_properties = recording.get_property_keys()
-    excluded_properties = list(exclude) + ["contact_vector"]
+    excluded_properties = exclude + ["offset_to_uV", "gain_to_uV", "contact_vector"]
     properties_to_extract = [property for property in recorder_properties if property not in excluded_properties]
 
     for property in properties_to_extract:

--- a/tests/test_on_data/test_gin_ecephys/test_raw_recordings.py
+++ b/tests/test_on_data/test_gin_ecephys/test_raw_recordings.py
@@ -236,6 +236,17 @@ class TestEcephysRawRecordingsNwbConversions(unittest.TestCase):
         converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True, metadata=metadata)
         recording = converter.data_interface_objects["TestRecording"].recording_extractor
 
+        # Read NWB file
+        from pynwb import NWBHDF5IO
+
+        with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
+            nwbfile = io.read()
+            electrodes = nwbfile.electrodes
+            electrodes_columns = electrodes.colnames
+
+            assert "offset_to_uV" not in electrodes_columns
+            assert "grain_to_uV" not in electrodes_columns
+
         es_key = converter.data_interface_objects["TestRecording"].es_key
         electrical_series_name = metadata["Ecephys"][es_key]["name"] if es_key else None
         if not isinstance(recording, BaseRecording):


### PR DESCRIPTION
As in the title. This includes a test and now I modified the code to pass most of the cases. However, there is something on the scaled tests for BlackRock and other formats which indicates that they were relying on those columns for correct gain. This is probably wrong and I will investigate further on the following days. 

Plus, I eliminate a keyword that was set to a mutable value, a well know footgun in python