### PR TITLE
Pin runners to x64 mac

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags


### PR DESCRIPTION
Mac runners just upgraded to arm64 by default; pinning to previous runners here and in follow-up will add the new ones in addition so we can debug separately