### PR TITLE
Path as string in FicTrac test

### DIFF
--- a/tests/test_on_data/test_behavior_interfaces.py
+++ b/tests/test_on_data/test_behavior_interfaces.py
@@ -161,7 +161,7 @@ class TestFicTracDataInterface(DataInterfaceTestMixin, unittest.TestCase):
     interface_kwargs = [
         dict(
             file_path=str(BEHAVIOR_DATA_PATH / "FicTrac" / "sample" / "sample-20230724_113055.dat"),
-            configuration_file_path=BEHAVIOR_DATA_PATH / "FicTrac" / "sample" / "config.txt",
+            configuration_file_path=str(BEHAVIOR_DATA_PATH / "FicTrac" / "sample" / "config.txt"),
         ),
     ]
 
@@ -225,12 +225,6 @@ class TestFicTracDataInterface(DataInterfaceTestMixin, unittest.TestCase):
                 assert spatial_series.comments == expected_metadata
 
                 assert spatial_series.timestamps[0] == 0.0
-
-    # TODO: undo this skip in future PR
-    def check_run_conversion_default_backend_in_nwbconverter(
-        self, nwbfile_path: str, backend: Literal["hdf5", "zarr"] = "hdf5"
-    ):
-        pass
 
 
 class TestFicTracDataInterfaceWithRadius(DataInterfaceTestMixin, unittest.TestCase):


### PR DESCRIPTION
Replaces #825 because of dodgy commit history issue.