### PR TITLE
Pin Zarr for tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,7 +40,7 @@ jobs:
 
 
       - name: Install neuroconv with minimal requirements
-        run: pip install .
+        run: pip install .[test]
       - name: Run import tests
         run: |
           pytest tests/imports.py::TestImportStructure::test_top_level

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -6,7 +6,6 @@ scipy>=1.4.1
 h5py>=3.9.0
 hdmf>=3.13.0
 hdmf_zarr>=0.7.0
-zarr<2.18.0  # Error with Blosc (read-only during decode) in numcodecs on May 7; check later if resolved
 pynwb>=2.7.0
 pydantic>=2.0.0
 typing_extensions>=4.1.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -6,6 +6,7 @@ scipy>=1.4.1
 h5py>=3.9.0
 hdmf>=3.13.0
 hdmf_zarr>=0.7.0
+zarr<2.18.0  # Error with Blosc (read-only during decode) in numcodecs on May 7; check later if resolved
 pynwb>=2.7.0
 pydantic>=2.0.0
 typing_extensions>=4.1.0

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -4,3 +4,4 @@ ndx-events>=0.2.0  # for special tests to ensure load_namespaces is set to allow
 parameterized>=0.8.1
 ndx-miniscope
 spikeinterface[qualitymetrics]>=0.100.0
+zarr<2.18.0  # Error with Blosc (read-only during decode) in numcodecs on May 7; check later if resolved


### PR DESCRIPTION
Tests just failed today due to a surprise break from Zarr release yesterday - some issue with decoding Blosc for our custom backend configuration stuff

Shouldn't effect actual typical usage of the backend feature aside from Blosc I assume, since none of the other compressor tests complain

[Filed issue with hdmf-zarr](https://github.com/hdmf-dev/hdmf-zarr/issues/192) so team knows about it, and if it's an issue with the way they specify the read from the IO level (I doubt it, but never know)

Downpinning in tests temporarily to fix the CI, will check over time if resolved automagically