### PR TITLE
use abstract class DatasetIOConfiguration for typing

### DIFF
--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_common_dataset_io_configuration_model.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_common_dataset_io_configuration_model.py
@@ -1,13 +1,8 @@
 """Unit tests for the all common Pydantic validations shared across DatasetConfigurations children."""
 
-from typing import Union
-
 import pytest
 
-from neuroconv.tools.nwb_helpers import (
-    HDF5DatasetIOConfiguration,
-    ZarrDatasetIOConfiguration,
-)
+from neuroconv.tools.nwb_helpers import DatasetIOConfiguration
 from neuroconv.tools.testing import (
     mock_HDF5DatasetIOConfiguration,
     mock_ZarrDatasetIOConfiguration,
@@ -17,9 +12,7 @@ from neuroconv.tools.testing import (
 @pytest.mark.parametrize(
     argnames="dataset_configuration_class", argvalues=[mock_HDF5DatasetIOConfiguration, mock_ZarrDatasetIOConfiguration]
 )
-def test_validator_chunk_length_consistency(
-    dataset_configuration_class: Union[HDF5DatasetIOConfiguration, ZarrDatasetIOConfiguration]
-):
+def test_validator_chunk_length_consistency(dataset_configuration_class: DatasetIOConfiguration):
     with pytest.raises(ValueError) as error_info:
         dataset_configuration_class(chunk_shape=(78_125, 64, 1), buffer_shape=(1_250_000, 384))
 
@@ -34,7 +27,7 @@ def test_validator_chunk_length_consistency(
     argnames="dataset_configuration_class", argvalues=[mock_HDF5DatasetIOConfiguration, mock_ZarrDatasetIOConfiguration]
 )
 def test_validator_chunk_and_buffer_length_consistency(
-    dataset_configuration_class: Union[HDF5DatasetIOConfiguration, ZarrDatasetIOConfiguration]
+    dataset_configuration_class: DatasetIOConfiguration
 ):
     with pytest.raises(ValueError) as error_info:
         dataset_configuration_class(chunk_shape=(78_125, 64, 1), buffer_shape=(1_250_000, 384, 1))
@@ -50,7 +43,7 @@ def test_validator_chunk_and_buffer_length_consistency(
     argnames="dataset_configuration_class", argvalues=[mock_HDF5DatasetIOConfiguration, mock_ZarrDatasetIOConfiguration]
 )
 def test_validator_chunk_shape_nonpositive_elements(
-    dataset_configuration_class: Union[HDF5DatasetIOConfiguration, ZarrDatasetIOConfiguration]
+    dataset_configuration_class: DatasetIOConfiguration
 ):
     with pytest.raises(ValueError) as error_info:
         dataset_configuration_class(chunk_shape=(1, -2), buffer_shape=(1_250_000, 384))
@@ -66,7 +59,7 @@ def test_validator_chunk_shape_nonpositive_elements(
     argnames="dataset_configuration_class", argvalues=[mock_HDF5DatasetIOConfiguration, mock_ZarrDatasetIOConfiguration]
 )
 def test_validator_buffer_shape_nonpositive_elements(
-    dataset_configuration_class: Union[HDF5DatasetIOConfiguration, ZarrDatasetIOConfiguration]
+    dataset_configuration_class: DatasetIOConfiguration
 ):
     with pytest.raises(ValueError) as error_info:
         dataset_configuration_class(chunk_shape=(78_125, 64), buffer_shape=(78_125, -2))
@@ -81,9 +74,7 @@ def test_validator_buffer_shape_nonpositive_elements(
 @pytest.mark.parametrize(
     argnames="dataset_configuration_class", argvalues=[mock_HDF5DatasetIOConfiguration, mock_ZarrDatasetIOConfiguration]
 )
-def test_validator_chunk_shape_exceeds_buffer_shape(
-    dataset_configuration_class: Union[HDF5DatasetIOConfiguration, ZarrDatasetIOConfiguration]
-):
+def test_validator_chunk_shape_exceeds_buffer_shape(dataset_configuration_class: DatasetIOConfiguration):
     with pytest.raises(ValueError) as error_info:
         dataset_configuration_class(chunk_shape=(78_126, 64), buffer_shape=(78_125, 384))
 
@@ -97,9 +88,7 @@ def test_validator_chunk_shape_exceeds_buffer_shape(
 @pytest.mark.parametrize(
     argnames="dataset_configuration_class", argvalues=[mock_HDF5DatasetIOConfiguration, mock_ZarrDatasetIOConfiguration]
 )
-def test_validator_buffer_shape_exceeds_full_shape(
-    dataset_configuration_class: Union[HDF5DatasetIOConfiguration, ZarrDatasetIOConfiguration]
-):
+def test_validator_buffer_shape_exceeds_full_shape(dataset_configuration_class: DatasetIOConfiguration):
     with pytest.raises(ValueError) as error_info:
         dataset_configuration_class(chunk_shape=(78_125, 64), buffer_shape=(1_250_000, 385))
 
@@ -113,9 +102,7 @@ def test_validator_buffer_shape_exceeds_full_shape(
 @pytest.mark.parametrize(
     argnames="dataset_configuration_class", argvalues=[mock_HDF5DatasetIOConfiguration, mock_ZarrDatasetIOConfiguration]
 )
-def test_validator_chunk_dimensions_do_not_evenly_divide_buffer(
-    dataset_configuration_class: Union[HDF5DatasetIOConfiguration, ZarrDatasetIOConfiguration]
-):
+def test_validator_chunk_dimensions_do_not_evenly_divide_buffer(dataset_configuration_class: DatasetIOConfiguration):
     with pytest.raises(ValueError) as error_info:
         dataset_configuration_class(
             chunk_shape=(78_125, 7),
@@ -132,8 +119,6 @@ def test_validator_chunk_dimensions_do_not_evenly_divide_buffer(
 @pytest.mark.parametrize(
     argnames="dataset_configuration_class", argvalues=[mock_HDF5DatasetIOConfiguration, mock_ZarrDatasetIOConfiguration]
 )
-def test_validator_chunk_dimensions_do_not_evenly_divide_buffer_skip_full_shape(
-    dataset_configuration_class: Union[HDF5DatasetIOConfiguration, ZarrDatasetIOConfiguration]
-):
+def test_validator_chunk_dimensions_do_not_evenly_divide_buffer_skip_full_shape(dataset_configuration_class: DatasetIOConfiguration):
     """Any divisibility is allowed when the buffer shape is capped at the full length of an axis."""
     dataset_configuration_class(chunk_shape=(78_125, 7), buffer_shape=(1_250_000, 384))

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_common_dataset_io_configuration_model.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_common_dataset_io_configuration_model.py
@@ -26,9 +26,7 @@ def test_validator_chunk_length_consistency(dataset_configuration_class: Dataset
 @pytest.mark.parametrize(
     argnames="dataset_configuration_class", argvalues=[mock_HDF5DatasetIOConfiguration, mock_ZarrDatasetIOConfiguration]
 )
-def test_validator_chunk_and_buffer_length_consistency(
-    dataset_configuration_class: DatasetIOConfiguration
-):
+def test_validator_chunk_and_buffer_length_consistency(dataset_configuration_class: DatasetIOConfiguration):
     with pytest.raises(ValueError) as error_info:
         dataset_configuration_class(chunk_shape=(78_125, 64, 1), buffer_shape=(1_250_000, 384, 1))
 
@@ -42,9 +40,7 @@ def test_validator_chunk_and_buffer_length_consistency(
 @pytest.mark.parametrize(
     argnames="dataset_configuration_class", argvalues=[mock_HDF5DatasetIOConfiguration, mock_ZarrDatasetIOConfiguration]
 )
-def test_validator_chunk_shape_nonpositive_elements(
-    dataset_configuration_class: DatasetIOConfiguration
-):
+def test_validator_chunk_shape_nonpositive_elements(dataset_configuration_class: DatasetIOConfiguration):
     with pytest.raises(ValueError) as error_info:
         dataset_configuration_class(chunk_shape=(1, -2), buffer_shape=(1_250_000, 384))
 
@@ -58,9 +54,7 @@ def test_validator_chunk_shape_nonpositive_elements(
 @pytest.mark.parametrize(
     argnames="dataset_configuration_class", argvalues=[mock_HDF5DatasetIOConfiguration, mock_ZarrDatasetIOConfiguration]
 )
-def test_validator_buffer_shape_nonpositive_elements(
-    dataset_configuration_class: DatasetIOConfiguration
-):
+def test_validator_buffer_shape_nonpositive_elements(dataset_configuration_class: DatasetIOConfiguration):
     with pytest.raises(ValueError) as error_info:
         dataset_configuration_class(chunk_shape=(78_125, 64), buffer_shape=(78_125, -2))
 
@@ -119,6 +113,8 @@ def test_validator_chunk_dimensions_do_not_evenly_divide_buffer(dataset_configur
 @pytest.mark.parametrize(
     argnames="dataset_configuration_class", argvalues=[mock_HDF5DatasetIOConfiguration, mock_ZarrDatasetIOConfiguration]
 )
-def test_validator_chunk_dimensions_do_not_evenly_divide_buffer_skip_full_shape(dataset_configuration_class: DatasetIOConfiguration):
+def test_validator_chunk_dimensions_do_not_evenly_divide_buffer_skip_full_shape(
+    dataset_configuration_class: DatasetIOConfiguration,
+):
     """Any divisibility is allowed when the buffer shape is capped at the full length of an axis."""
     dataset_configuration_class(chunk_shape=(78_125, 7), buffer_shape=(1_250_000, 384))


### PR DESCRIPTION
Replaces `Union[HDF5DatasetIOConfiguration, ZarrDatasetIOConfiguration]` with `DatasetIOConfiguration`. This doesn't change much, but this is the standard way of specifying multiple subclasses that share a base class, and it readies the repo for additional backends if they should ever come