### PR TITLE
Support Path objects in source_data schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Added `ScanImageMultiFileImagingInterface` for multi-file (buffered) ScanImage format and changed `ScanImageImagingInterface` to be routing classes for single and multi-plane imaging. [PR #809](https://github.com/catalystneuro/neuroconv/pull/809)
 * Improve printing of bytes [PR #831](https://github.com/catalystneuro/neuroconv/pull/831)
 * Added `configure_and_write_nwbfile` and optimized imports in `tools.nwb_helpers` module. [PR #848](https://github.com/catalystneuro/neuroconv/pull/848)
+* Support for pathlib in source data schema validation [PR #854](https://github.com/catalystneuro/neuroconv/pull/854)
 
 ### Improvements
 * Fixed docstrings related to backend configurations for various methods. [PR #822](https://github.com/catalystneuro/neuroconv/pull/822)

--- a/src/neuroconv/nwbconverter.py
+++ b/src/neuroconv/nwbconverter.py
@@ -1,6 +1,6 @@
 import json
-import warnings
 from collections import Counter
+from copy import deepcopy
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Tuple, Union
 
@@ -26,7 +26,7 @@ from .utils import (
     unroot_schema,
 )
 from .utils.dict import DeepDict
-from .utils.json_schema import NWBMetaDataEncoder
+from .utils.json_schema import NWBMetaDataEncoder, NWBSourceDataEncoder
 
 
 class NWBConverter:
@@ -119,7 +119,14 @@ class NWBConverter:
             print("conversion_options is valid!")
 
     def _validate_source_data(self, source_data: Dict[str, dict], verbose: bool = True):
-        validate(instance=source_data, schema=self.get_source_schema())
+
+        encoder = NWBSourceDataEncoder()
+        # The encoder produces a serialized object, so we deserialized it for comparison
+
+        serialized_source_data = encoder.encode(source_data)
+        decoded_source_data = json.loads(serialized_source_data)
+
+        validate(instance=decoded_source_data, schema=self.get_source_schema())
         if verbose:
             print("Source data is valid!")
 

--- a/src/neuroconv/utils/json_schema.py
+++ b/src/neuroconv/utils/json_schema.py
@@ -2,6 +2,7 @@ import collections.abc
 import inspect
 import json
 from datetime import datetime
+from pathlib import Path
 from typing import Callable, Dict, List, Literal, Optional
 
 import docstring_parser
@@ -30,6 +31,17 @@ class NWBMetaDataEncoder(json.JSONEncoder):
             return obj.tolist()
 
         # The base-class handles it
+        return super().default(obj)
+
+
+class NWBSourceDataEncoder(json.JSONEncoder):
+
+    def default(self, obj):
+
+        # Over-write behaviors for Paths
+        if isinstance(obj, Path):
+            return str(obj)
+
         return super().default(obj)
 
 

--- a/src/neuroconv/utils/json_schema.py
+++ b/src/neuroconv/utils/json_schema.py
@@ -42,6 +42,16 @@ class NWBSourceDataEncoder(json.JSONEncoder):
         if isinstance(obj, Path):
             return str(obj)
 
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+
+        # Transform numpy generic integers and floats to python ints floats
+        if isinstance(obj, np.generic):
+            return obj.item()
+
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+
         return super().default(obj)
 
 

--- a/tests/test_on_data/test_gin_ecephys/test_lfp.py
+++ b/tests/test_on_data/test_gin_ecephys/test_lfp.py
@@ -45,19 +45,19 @@ class TestEcephysLFPNwbConversions(unittest.TestCase):
     parameterized_lfp_list = [
         param(
             data_interface=AxonaLFPDataInterface,
-            interface_kwargs=dict(file_path=str(DATA_PATH / "axona" / "dataset_unit_spikes" / "20140815-180secs.eeg")),
+            interface_kwargs=dict(file_path=DATA_PATH / "axona" / "dataset_unit_spikes" / "20140815-180secs.eeg"),
         ),
         param(
             data_interface=NeuroScopeLFPInterface,
             interface_kwargs=dict(
-                file_path=str(DATA_PATH / "neuroscope" / "dataset_1" / "YutaMouse42-151117.eeg"),
-                xml_file_path=str(DATA_PATH / "neuroscope" / "dataset_1" / "YutaMouse42-151117.xml"),
+                file_path=(DATA_PATH / "neuroscope" / "dataset_1" / "YutaMouse42-151117.eeg"),
+                xml_file_path=(DATA_PATH / "neuroscope" / "dataset_1" / "YutaMouse42-151117.xml"),
             ),
         ),
         param(
             data_interface=SpikeGLXRecordingInterface,
             interface_kwargs=dict(
-                file_path=str(
+                file_path=(
                     DATA_PATH / "spikeglx" / "Noise4Sam_g0" / "Noise4Sam_g0_imec0" / "Noise4Sam_g0_t0.imec0.lf.bin"
                 )
             ),


### PR DESCRIPTION
Is that something that we would want? I always find it annoying when working on conversations that I have to stringify at the signature or before.