### PR TITLE
Pass progress_bar_class to HDMF

### DIFF
--- a/src/neuroconv/tools/spikeinterface/spikeinterfacerecordingdatachunkiterator.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterfacerecordingdatachunkiterator.py
@@ -3,6 +3,7 @@ from typing import Iterable, Optional, Tuple
 from hdmf.data_utils import GenericDataChunkIterator
 from spikeinterface import BaseRecording
 
+from tqdm import tqdm
 
 class SpikeInterfaceRecordingDataChunkIterator(GenericDataChunkIterator):
     """DataChunkIterator specifically for use on RecordingExtractor objects."""
@@ -17,6 +18,7 @@ class SpikeInterfaceRecordingDataChunkIterator(GenericDataChunkIterator):
         chunk_mb: Optional[float] = None,
         chunk_shape: Optional[tuple] = None,
         display_progress: bool = False,
+        progress_bar_class: Optional[tqdm] = None,
         progress_bar_options: Optional[dict] = None,
     ):
         """
@@ -68,6 +70,7 @@ class SpikeInterfaceRecordingDataChunkIterator(GenericDataChunkIterator):
             chunk_mb=chunk_mb,
             chunk_shape=chunk_shape,
             display_progress=display_progress,
+            progress_bar_class=progress_bar_class,
             progress_bar_options=progress_bar_options,
         )
 


### PR DESCRIPTION
To properly pass `progress_Bar_class` to HDMF (https://github.com/hdmf-dev/hdmf/pull/1110) through the GUIDE in https://github.com/NeurodataWithoutBorders/nwb-guide/pull/778, the `SpikeInterfaceRecordingDataChunkIterator` needs to pass another argument to the parent class.