### PR TITLE
Avoid double computation for backend check

### DIFF
--- a/src/neuroconv/tools/nwb_helpers/_configure_backend.py
+++ b/src/neuroconv/tools/nwb_helpers/_configure_backend.py
@@ -28,10 +28,10 @@ def configure_backend(
     ndx_events = importlib.import_module("ndx_events") if is_ndx_events_installed else None
 
     # A remapping of the object IDs in the backend configuration might necessary
-    objects_requiring_remapping = backend_configuration.find_locations_requiring_remapping(nwbfile=nwbfile)
-    if objects_requiring_remapping:
+    locations_to_remap = backend_configuration.find_locations_requiring_remapping(nwbfile=nwbfile)
+    if locations_to_remap:
         backend_configuration = backend_configuration.build_remapped_backend(
-            location_to_new_configurations=objects_requiring_remapping,
+            locations_to_remap=locations_to_remap,
         )
 
     # Set all DataIO based on the configuration

--- a/src/neuroconv/tools/nwb_helpers/_configure_backend.py
+++ b/src/neuroconv/tools/nwb_helpers/_configure_backend.py
@@ -28,9 +28,11 @@ def configure_backend(
     ndx_events = importlib.import_module("ndx_events") if is_ndx_events_installed else None
 
     # A remapping of the object IDs in the backend configuration might necessary
-    backend_is_incompatible_with_nwbfile = not backend_configuration.is_compatible_with_nwbfile(nwbfile=nwbfile)
-    if backend_is_incompatible_with_nwbfile:
-        backend_configuration = backend_configuration.build_remapped_backend_to_nwbfile(nwbfile=nwbfile)
+    objects_requiring_remapping = backend_configuration.find_locations_requiring_remapping(nwbfile=nwbfile)
+    if objects_requiring_remapping:
+        backend_configuration = backend_configuration.build_remapped_backend(
+            location_to_new_configurations=objects_requiring_remapping,
+        )
 
     # Set all DataIO based on the configuration
     data_io_class = backend_configuration.data_io_class

--- a/src/neuroconv/tools/nwb_helpers/_configure_backend.py
+++ b/src/neuroconv/tools/nwb_helpers/_configure_backend.py
@@ -30,9 +30,7 @@ def configure_backend(
     # A remapping of the object IDs in the backend configuration might necessary
     locations_to_remap = backend_configuration.find_locations_requiring_remapping(nwbfile=nwbfile)
     if locations_to_remap:
-        backend_configuration = backend_configuration.build_remapped_backend(
-            locations_to_remap=locations_to_remap,
-        )
+        backend_configuration = backend_configuration.build_remapped_backend(locations_to_remap=locations_to_remap)
 
     # Set all DataIO based on the configuration
     data_io_class = backend_configuration.data_io_class

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -1463,6 +1463,7 @@ def get_electrode_group_indices(recording, nwbfile):
         group_names = list(np.unique(recording.get_property("group").astype(str)))
     else:
         group_names = None
+
     if group_names is None:
         electrode_group_indices = None
     else:


### PR DESCRIPTION
From the discussion in https://github.com/catalystneuro/neuroconv/pull/816/files#r1607028944 from #816

OK, this is I think a simpler approach. breaks the previous construction into two functions. The first part finds all the locations that require-remapping and the second part uses pydantic machinery to create a copy of the model and modify only what requires modification.

I think this should be faster and is more flexible. What would be missing is some testing. Let me know what you think.