### PR TITLE
Add packaging explicitly

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -15,3 +15,4 @@ pandas
 parse>=1.20.0
 click
 docstring-parser
+packaging  # Issue 903


### PR DESCRIPTION
No clue why no CI anywhere in our ecosystem catches this during minimal installation and imports

But adding it explicitly anyway; it is a third-party package and up to this point I figure we just assumed something upstream relied on it implicitly

cc @rly @laurelrr