### PR TITLE
Fix #906

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 * Fixed bug causing overwrite of NWB GUIDE watermark. [PR #890](https://github.com/catalystneuro/neuroconv/pull/890)
+* Change error trigger with warning trigger when adding both `OnePhotonSeries` and `TwoPhotonSeries` to the same file ([Issue #906](https://github.com/catalystneuro/neuroconv/issues/906)). [PR #907](https://github.com/catalystneuro/neuroconv/pull/907)
 
 
 

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -399,10 +399,11 @@ def add_photon_series(
     metadata_copy = dict_deep_update(
         get_nwb_imaging_metadata(imaging, photon_series_type=photon_series_type), metadata_copy, append_list=False
     )
-    if photon_series_type == "TwoPhotonSeries":
-        assert (
-            "OnePhotonSeries" not in metadata_copy["Ophys"]
-        ), "Received metadata for 'OnePhotonSeries' but `photon_series_type` was not explicitly specified."
+
+    if photon_series_type == "TwoPhotonSeries" and "OnePhotonSeries" in metadata_copy["Ophys"]:
+        warn(
+            "Received metadata for both 'OnePhotonSeries' and 'TwoPhotonSeries', make sure photon_series_type is specified correctly."
+        )
 
     assert parent_container in [
         "acquisition",

--- a/tests/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_ophys/test_tools_roiextractors.py
@@ -1715,11 +1715,17 @@ class TestAddPhotonSeries(TestCase):
         """Test warning is raised when `photon_series_type` specifies 'TwoPhotonSeries' but metadata contains also 'OnePhotonSeries'."""
 
         exc_msg = "Received metadata for both 'OnePhotonSeries' and 'TwoPhotonSeries', make sure photon_series_type is specified correctly."
+        photon_series_metadata = deepcopy(self.one_photon_series_metadata)
+        photon_series_metadata["Ophys"].update(
+            TwoPhotonSeries=self.two_photon_series_metadata["Ophys"]["TwoPhotonSeries"]
+        )
+
         with self.assertWarnsWith(warn_type=UserWarning, exc_msg=exc_msg):
             add_photon_series(
                 imaging=self.imaging_extractor,
                 nwbfile=self.nwbfile,
-                metadata=self.one_photon_series_metadata,
+                metadata=photon_series_metadata,
+                photon_series_type="TwoPhotonSeries",
             )
 
     def test_add_one_photon_series(self):

--- a/tests/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_ophys/test_tools_roiextractors.py
@@ -1712,11 +1712,10 @@ class TestAddPhotonSeries(TestCase):
             )
 
     def test_add_photon_series_inconclusive_metadata(self):
-        """Test error is raised when `photon_series_type` specifies 'TwoPhotonSeries' but metadata contains 'OnePhotonSeries'."""
-        with self.assertRaisesWith(
-            AssertionError,
-            "Received metadata for 'OnePhotonSeries' but `photon_series_type` was not explicitly specified.",
-        ):
+        """Test warning is raised when `photon_series_type` specifies 'TwoPhotonSeries' but metadata contains also 'OnePhotonSeries'."""
+
+        exc_msg = "Received metadata for both 'OnePhotonSeries' and 'TwoPhotonSeries', make sure photon_series_type is specified correctly."
+        with self.assertWarnsWith(warn_type=UserWarning, exc_msg=exc_msg):
             add_photon_series(
                 imaging=self.imaging_extractor,
                 nwbfile=self.nwbfile,


### PR DESCRIPTION
Here it is assumed that either OnePhotonSeries or TwoPhotonSeries can co-exist in the same nwbfile. That I not necessarily true, e.g. dual acquisition of both two-photon and one-photon imaging ([paper](https://www.nature.com/articles/s41593-023-01498-y))
https://github.com/catalystneuro/neuroconv/blob/5a65e7417d90411bca3dce8312f8d6d483d30b05/src/neuroconv/tools/roiextractors/roiextractors.py#L402-L405

Changed this to trigger a simple warning