### PR TITLE
Move testing dependencies on the CI to testing requirements.

### DIFF
--- a/.github/workflows/dev-testing.yml
+++ b/.github/workflows/dev-testing.yml
@@ -37,9 +37,6 @@ jobs:
           python -m pip install -U pip  # Official recommended way
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"
-          pip install wheel # Needed for scan image
-
-
 
       - name: Install full requirements
         run: pip install --no-cache-dir .[full,test]

--- a/.github/workflows/dev-testing.yml
+++ b/.github/workflows/dev-testing.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Global Setup
         run: |
           python -m pip install -U pip  # Official recommended way
-          pip install pytest-xdist
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"
           pip install wheel # Needed for scan image

--- a/.github/workflows/formatwise-installation-testing.yml
+++ b/.github/workflows/formatwise-installation-testing.yml
@@ -27,10 +27,8 @@ jobs:
       - name: Global Setup
         run: |
           python -m pip install -U pip  # Official recommended way
-          pip install pytest-xdist
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"
-          pip install wheel # Needed for scan image
       - name: Install neuroconv with minimal requirements
         run: pip install .[test]
 

--- a/.github/workflows/live-service-testing.yml
+++ b/.github/workflows/live-service-testing.yml
@@ -34,7 +34,7 @@ jobs:
           git config --global user.name "CI Almighty"
 
       - name: Install full requirements
-        run: pip install .[full]
+        run: pip install .[test,full]
 
       - name: Run subset of tests that use S3 live services
         run: pytest -rsx -n auto tests/test_minimal/test_tools/s3_tools.py

--- a/.github/workflows/live-service-testing.yml
+++ b/.github/workflows/live-service-testing.yml
@@ -30,10 +30,8 @@ jobs:
       - name: Global Setup
         run: |
           python -m pip install -U pip  # Official recommended way
-          pip install pytest-xdist
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"
-          pip install wheel # Needed for scan image
 
       - name: Install full requirements
         run: pip install .[full]

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,11 +32,8 @@ jobs:
       - name: Global Setup
         run: |
           python -m pip install -U pip  # Official recommended way
-          pip install pytest-xdist
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"
-          pip install wheel # Needed for scan image
-
       - name: Install NeuroConv with minimal requirements
         run: pip install .
       - name: Test initial import of all non-lazy dependencies

--- a/.github/workflows/update-s3-testing-data.yml
+++ b/.github/workflows/update-s3-testing-data.yml
@@ -24,8 +24,6 @@ jobs:
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"
 
-
-
       - name: Get ephys_testing_data current head hash
         id: ephys
         run: echo "::set-output name=HASH_EPHY_DATASET::$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -5,3 +5,4 @@ parameterized>=0.8.1
 ndx-miniscope
 spikeinterface[qualitymetrics]>=0.100.0
 zarr<2.18.0  # Error with Blosc (read-only during decode) in numcodecs on May 7; check later if resolved
+pytest-xdist


### PR DESCRIPTION
From the discussion on https://github.com/catalystneuro/neuroconv/pull/904 were some dependencies were installed implictly on the CI through testing libraries:

pytest-xdist and wheel.

I am moving the first to the testing-requirements file and leaving wheel out to see exactly where we neeed it. Either at the level of scanimage requirements or as a general testing dependency.