### PR TITLE
Add plexon 2 support

### DIFF
--- a/src/neuroconv/datainterfaces/__init__.py
+++ b/src/neuroconv/datainterfaces/__init__.py
@@ -53,6 +53,7 @@ from .ecephys.openephys.openephyslegacydatainterface import (
 from .ecephys.openephys.openephyssortingdatainterface import OpenEphysSortingInterface
 from .ecephys.phy.phydatainterface import PhySortingInterface
 from .ecephys.plexon.plexondatainterface import (
+    Plexon2RecordingInterface,
     PlexonRecordingInterface,
     PlexonSortingInterface,
 )

--- a/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
@@ -48,6 +48,49 @@ class PlexonRecordingInterface(BaseRecordingExtractorInterface):
         return metadata
 
 
+class Plexon2RecordingInterface(BaseRecordingExtractorInterface):
+    """
+    Primary data interface class for converting Plexon2 data.
+
+    Uses the :py:class:`~spikeinterface.extractors.Plexon2RecordingExtractor`.
+    """
+
+    display_name = "Plexon2 Recording"
+    associated_suffixes = (".pl2",)
+    info = "Interface for Plexon2 recording data."
+
+    @classmethod
+    def get_source_schema(cls) -> dict:
+        source_schema = super().get_source_schema()
+        source_schema["properties"]["file_path"]["description"] = "Path to the .pl2 file."
+        return source_schema
+
+    def __init__(self, file_path: FilePathType, verbose: bool = True, es_key: str = "ElectricalSeries"):
+        """
+        Load and prepare data for Plexon.
+
+        Parameters
+        ----------
+        file_path : str or Path
+            Path to the .plx file.
+        verbose : bool, default: True
+            Allows verbosity.
+        es_key : str, default: "ElectricalSeries"
+        """
+        stream_id = "3"  # TODO figure out if "4" is not raw signal as well
+        super().__init__(
+            file_path=file_path,
+            verbose=verbose,
+            es_key=es_key,
+            stream_id=stream_id,
+        )
+
+    def get_metadata(self) -> DeepDict:
+        metadata = super().get_metadata()
+
+        return metadata
+
+
 class PlexonSortingInterface(BaseSortingExtractorInterface):
     """
     Primary data interface class for converting Plexon spiking data.

--- a/tests/test_on_data/test_gin_ecephys/test_raw_recordings.py
+++ b/tests/test_on_data/test_gin_ecephys/test_raw_recordings.py
@@ -26,6 +26,7 @@ from neuroconv.datainterfaces import (
     NeuroScopeRecordingInterface,
     OpenEphysBinaryRecordingInterface,
     OpenEphysLegacyRecordingInterface,
+    Plexon2RecordingInterface,
     PlexonRecordingInterface,
     SpikeGadgetsRecordingInterface,
     SpikeGLXRecordingInterface,


### PR DESCRIPTION
I am able to run local conversions, I need to add tests to the ci.

Should fix https://github.com/catalystneuro/neuroconv/issues/204

To-do:

- [ ] Set up CI tests that take into account wine in ubuntu
- [ ] See if I get windows error on the CI, fix it.
- [ ] Set up metadata from the annotations. See below.
- [ ] Add example to conversion gallery.
- [ ] Figure out if stream should be blocked or accessible. Making it accessible but setting default as spikeinterface now. See header for signals below.

Metadata available:

```
'name': 'Block containing PL2 data#0',
 'm_CreatorComment': b'4ch sorted spikes, continuous wideband, and LFP. Events on event channels 1-16, strobe values 32513-32767. One aux input.',
 'm_CreatorSoftwareName': b'OmniPlex',
 'm_CreatorSoftwareVersion': b'1.10.29',
 'm_CreatorDateTime': datetime.datetime(113, 11, 20, 15, 59, 39),
 'm_CreatorDateTimeMilliseconds': 0,
 'm_TimestampFrequency': 40000.0,
 'm_NumberOfChannelHeaders': 334,
 'm_TotalNumberOfSpikeChannels': 64,
 'm_NumberOfRecordedSpikeChannels': 64,
 'm_TotalNumberOfAnalogChannels': 224,
 'm_NumberOFRecordedAnalogChannels': 69,
 'm_NumberOfDigitalChannels': 46,
 'm_MinimumTrodality': 1,
 'm_MaximumTrodality': 1,
 'm_NumberOfNonOmniPlexSources': 0,
 'm_Unused': 0,
 'm_ReprocessorComment': b'',
 'm_ReprocessorSoftwareName': b'',
 'm_ReprocessorSoftwareVersion': b'',
 'm_ReprocessorDateTime': None,
 'm_ReprocessorDateTimeMilliseconds': 0,
 'm_StartRecordingTime': 4470476,
 'm_DurationOfRecording': 1179268}
```

The header for the signals:

```python
{'nb_block': 1,
 'nb_segment': [1],
 'signal_streams': array([('stream@40000.0Hz', '3'), ('stream@40000.0Hz', '4'),
        ('stream@1000.0Hz', '7'), ('stream@1000.0Hz', '12')],
       dtype=[('name', '<U64'), ('id', '<U64')]),
 'signal_channels': array([('WB01', 'source3.1', 40000., 'int16', 'Volts', 6.10351563e-07, 0., '3'),
        ('WB02', 'source3.2', 40000., 'int16', 'Volts', 6.10351563e-07, 0., '3'),
        ('WB03', 'source3.3', 40000., 'int16', 'Volts', 6.10351563e-07, 0., '3'),
        ('WB04', 'source3.4', 40000., 'int16', 'Volts', 6.10351563e-07, 0., '3'),
        ('SPKC01', 'source4.1', 40000., 'int16', 'Volts', 6.10351563e-07, 0., '4'),
        ('SPKC02', 'source4.2', 40000., 'int16', 'Volts', 6.10351563e-07, 0., '4'),
        ('SPKC03', 'source4.3', 40000., 'int16', 'Volts', 6.10351563e-07, 0., '4'),
        ('SPKC04', 'source4.4', 40000., 'int16', 'Volts', 6.10351563e-07, 0., '4'),
        ('FP01', 'source7.1',  1000., 'int16', 'Volts', 6.10351563e-07, 0., '7'),
        ('FP02', 'source7.2',  1000., 'int16', 'Volts', 6.10351563e-07, 0., '7'),
        ('FP03', 'source7.3',  1000., 'int16', 'Volts', 6.10351563e-07, 0., '7'),
        ('FP04', 'source7.4',  1000., 'int16', 'Volts', 6.10351563e-07, 0., '7'),
        ('AI01', 'source12.1',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12')],
       dtype=[('name', '<U64'), ('id', '<U64'), ('sampling_rate', '<f8'), ('dtype', '<U16'), ('units', '<U64'), ('gain', '<f8'), ('offset', '<f8'), ('stream_id', '<U64')]),
 'spike_channels': array([('SPK01.0', 'unit1.0', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK01.1', 'unit1.1', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK01.2', 'unit1.2', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK01.3', 'unit1.3', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK01.4', 'unit1.4', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK02.0', 'unit2.0', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK02.1', 'unit2.1', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK02.2', 'unit2.2', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK02.3', 'unit2.3', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK02.4', 'unit2.4', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK03.0', 'unit3.0', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK03.1', 'unit3.1', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK03.2', 'unit3.2', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK03.3', 'unit3.3', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK03.4', 'unit3.4', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK04.0', 'unit4.0', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK04.1', 'unit4.1', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK04.2', 'unit4.2', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK04.3', 'unit4.3', 'Volts', 6.10351563e-07, 0., 8, 40000.),
        ('SPK04.4', 'unit4.4', 'Volts', 6.10351563e-07, 0., 8, 40000.)],
       dtype=[('name', '<U64'), ('id', '<U64'), ('wf_units', '<U64'), ('wf_gain', '<f8'), ('wf_offset', '<f8'), ('wf_left_sweep', '<i8'), ('wf_sampling_rate', '<f8')]),
 'event_channels': array([('KBD1', '1', b'event'), ('KBD2', '2', b'event'),
        ('KBD3', '3', b'event'), ('KBD4', '4', b'event'),
        ('KBD5', '5', b'event'), ('KBD6', '6', b'event'),
        ('KBD7', '7', b'event'), ('KBD8', '8', b'event'),
        ('EVT01', '1', b'event'), ('EVT02', '2', b'event'),
        ('EVT03', '3', b'event'), ('EVT04', '4', b'event'),
        ('EVT05', '5', b'event'), ('EVT06', '6', b'event'),
        ('EVT07', '7', b'event'), ('EVT08', '8', b'event'),
        ('EVT09', '9', b'event'), ('EVT10', '10', b'event'),
        ('EVT11', '11', b'event'), ('EVT12', '12', b'event'),
        ('EVT13', '13', b'event'), ('EVT14', '14', b'event'),
        ('EVT15', '15', b'event'), ('EVT16', '16', b'event'),
        ('EVT17', '17', b'event'), ('EVT18', '18', b'event'),
        ('EVT19', '19', b'event'), ('EVT20', '20', b'event'),
        ('EVT21', '21', b'event'), ('EVT22', '22', b'event'),
        ('EVT23', '23', b'event'), ('EVT24', '24', b'event'),
        ('EVT25', '25', b'event'), ('EVT26', '26', b'event'),
        ('EVT27', '27', b'event'), ('EVT28', '28', b'event'),
        ('EVT29', '29', b'event'), ('EVT30', '30', b'event'),
        ('EVT31', '31', b'event'), ('EVT32', '32', b'event'),
        ('Strobed', '1', b'event'), ('RSTART', '2', b'event'),
        ('RSTOP', '3', b'event'), ('CPX1', '1', b'event'),
        ('CPX2', '2', b'event'), ('CPX3', '3', b'event')],
       dtype=[('name', '<U64'), ('id', '<U64'), ('type', 'S5')])}
```