### PR TITLE
Fix check in intan datainterface for spikeinterface version

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -37,7 +37,7 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
         super().__init__(**source_data)
         self.recording_extractor = self.get_extractor()(**source_data)
         property_names = self.recording_extractor.get_property_keys()
-        # TODO remove this and go and change all the uses of channel_name once spikeinterface > 0.100.7 is released
+        # TODO remove this and go and change all the uses of channel_name once spikeinterface > 0.101.0 is released
         if "channel_name" not in property_names and "channel_names" in property_names:
             channel_names = self.recording_extractor.get_property("channel_names")
             self.recording_extractor.set_property("channel_name", channel_names)

--- a/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
@@ -82,13 +82,13 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
         spikeinterface_version = get_package_version(name="spikeinterface")
 
         init_kwargs = dict(file_path=file_path, stream_id=self.stream_id, verbose=verbose, es_key=es_key)
-        if neo_version >= Version("0.13.1") and spikeinterface_version >= Version("0.100.6"):
+        if neo_version >= Version("0.13.1") and spikeinterface_version >= Version("0.101.0"):
             init_kwargs["ignore_integrity_checks"] = ignore_integrity_checks
         else:
             if ignore_integrity_checks:
                 warnings.warn(
                     "The 'ignore_integrity_checks' parameter is not supported for neo versions < 0.13.1. "
-                    "or spikeinterface versions < 0.100.6.",
+                    "or spikeinterface versions < 0.101.0.",
                     UserWarning,
                 )
 


### PR DESCRIPTION
I used the wrong semantic version because I did not expect another mini release of spikeinterface before the new one.

This is causing some problems to @luiztauffer. 