### PR TITLE
Remove wrong assumptions about electrode metadata in Intan

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
@@ -9,32 +9,6 @@ from ....tools import get_package, get_package_version
 from ....utils import FilePathType, get_schema_from_hdmf_class
 
 
-def extract_electrode_metadata(recording_extractor) -> dict:
-
-    neo_version = get_package_version(name="neo")
-
-    # The native native_channel_name in Intan have the following form: A-000, A-001, A-002, B-000, B-001, B-002, etc.
-    if neo_version > Version("0.13.0"):  # TODO: Remove after the release of neo 0.14.0
-        native_channel_names = recording_extractor.get_channel_ids()
-    else:
-        # Previous to version 0.13.1 the native_channel_name was stored as channel_name
-        native_channel_names = recording_extractor.get_property("channel_name")
-
-    group_names = [channel.split("-")[0] for channel in native_channel_names]
-    unique_group_names = set(group_names)
-    group_electrode_numbers = [int(channel.split("-")[1]) for channel in native_channel_names]
-    custom_names = list()
-
-    electrodes_metadata = dict(
-        group_names=group_names,
-        unique_group_names=unique_group_names,
-        group_electrode_numbers=group_electrode_numbers,
-        custom_names=custom_names,
-    )
-
-    return electrodes_metadata
-
-
 class IntanRecordingInterface(BaseRecordingExtractorInterface):
     """
     Primary data interface class for converting Intan data using the
@@ -81,7 +55,9 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
         neo_version = get_package_version(name="neo")
         spikeinterface_version = get_package_version(name="spikeinterface")
 
-        init_kwargs = dict(file_path=file_path, stream_id=self.stream_id, verbose=verbose, es_key=es_key)
+        init_kwargs = dict(
+            file_path=file_path, stream_id=self.stream_id, verbose=verbose, es_key=es_key, all_annotations=True
+        )
         if neo_version >= Version("0.13.1") and spikeinterface_version >= Version("0.101.0"):
             init_kwargs["ignore_integrity_checks"] = ignore_integrity_checks
         else:
@@ -100,22 +76,6 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
             self.stream_id = stream_id
 
         super().__init__(**init_kwargs)
-        electrodes_metadata = extract_electrode_metadata(recording_extractor=self.recording_extractor)
-
-        group_names = electrodes_metadata["group_names"]
-        group_electrode_numbers = electrodes_metadata["group_electrode_numbers"]
-        unique_group_names = electrodes_metadata["unique_group_names"]
-        custom_names = electrodes_metadata["custom_names"]
-
-        channel_ids = self.recording_extractor.get_channel_ids()
-        self.recording_extractor.set_property(key="group_name", ids=channel_ids, values=group_names)
-        if len(unique_group_names) > 1:
-            self.recording_extractor.set_property(
-                key="group_electrode_number", ids=channel_ids, values=group_electrode_numbers
-            )
-
-        if any(custom_names):
-            self.recording_extractor.set_property(key="custom_channel_name", ids=channel_ids, values=custom_names)
 
     def get_metadata_schema(self) -> dict:
         metadata_schema = super().get_metadata_schema()
@@ -137,36 +97,9 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
         device_list = [device]
         ecephys_metadata.update(Device=device_list)
 
-        # Add electrode group
-        unique_group_name = set(self.recording_extractor.get_property("group_name"))
-        electrode_group_list = [
-            dict(
-                name=group_name,
-                description=f"Group {group_name} electrodes.",
-                device="Intan",
-                location="",
-            )
-            for group_name in unique_group_name
-        ]
-        ecephys_metadata.update(ElectrodeGroup=electrode_group_list)
-
         # Add electrodes and electrode groups
         ecephys_metadata.update(
-            Electrodes=[
-                dict(name="group_name", description="The name of the ElectrodeGroup this electrode is a part of.")
-            ],
             ElectricalSeriesRaw=dict(name="ElectricalSeriesRaw", description="Raw acquisition traces."),
         )
-
-        # Add group electrode number if available
-        recording_extractor_properties = self.recording_extractor.get_property_keys()
-        if "group_electrode_number" in recording_extractor_properties:
-            ecephys_metadata["Electrodes"].append(
-                dict(name="group_electrode_number", description="0-indexed channel within a group.")
-            )
-        if "custom_channel_name" in recording_extractor_properties:
-            ecephys_metadata["Electrodes"].append(
-                dict(name="custom_channel_name", description="Custom channel name assigned in Intan.")
-            )
 
         return metadata

--- a/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
@@ -59,7 +59,7 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
             )
             self.stream_id = stream_id
         else:
-            self.stream_id = "0"
+            self.stream_id = "0"  # These are the amplifier channels or to the stream_name 'RHD2000 amplifier channel'
 
         init_kwargs = dict(
             file_path=file_path,


### PR DESCRIPTION
I have been working on Intan recently.

Currently, the `IntanRecordingInterface` is making the assumption that the ports of the controller are electrode groups but this is not the case. There are cases where those digital channels are divided into smaller groups and there are cases where a single probe is connected to two ports.

I am removing all of those assumptions in this PR.

Other properties like native_channel_order are actually in the recording annotations which I am propagating here.