### PR TITLE
Propagate annotations to `IntanRecordingInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * Fixed a case of the `NeuroScopeSortingExtractor` when the optional `xml_file_path` is not specified. [PR #926](https://github.com/catalystneuro/neuroconv/pull/926)
 * Fixed `Can't specify experiment type when converting .abf to .nwb with Neuroconv`. [PR #609](https://github.com/catalystneuro/neuroconv/pull/609)
 
-
+### Improvements
+* Make annotations from the raw format available on `IntanRecordingInterface`. [PR #934](https://github.com/catalystneuro/neuroconv/pull/943)
 
 ## v0.4.11 (June 14, 2024)
 

--- a/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
@@ -81,7 +81,14 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
         neo_version = get_package_version(name="neo")
         spikeinterface_version = get_package_version(name="spikeinterface")
 
-        init_kwargs = dict(file_path=file_path, stream_id=self.stream_id, verbose=verbose, es_key=es_key)
+        init_kwargs = dict(
+            file_path=file_path,
+            stream_id=self.stream_id,
+            verbose=verbose,
+            es_key=es_key,
+            all_annotations=True,
+        )
+
         if neo_version >= Version("0.13.1") and spikeinterface_version >= Version("0.101.0"):
             init_kwargs["ignore_integrity_checks"] = ignore_integrity_checks
         else:


### PR DESCRIPTION
Also included in #933 but probably easier to make this quick improvement here.

This  propagates the annotations of intan that were made available on https://github.com/NeuralEnsemble/python-neo/pull/1477