### PR TITLE
Fix intan version for extra attributes

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
@@ -82,7 +82,7 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
         spikeinterface_version = get_package_version(name="spikeinterface")
 
         init_kwargs = dict(file_path=file_path, stream_id=self.stream_id, verbose=verbose, es_key=es_key)
-        if neo_version < Version("0.13.0") and spikeinterface_version < Version("0.100"):
+        if neo_version < Version("0.13.0") and spikeinterface_version < Version("0.100.10"):
             if ignore_integrity_checks:
                 warnings.warn(
                     "The 'ignore_integrity_checks' parameter is not supported for neo versions < 0.13.1. "

--- a/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
@@ -82,7 +82,7 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
         spikeinterface_version = get_package_version(name="spikeinterface")
 
         init_kwargs = dict(file_path=file_path, stream_id=self.stream_id, verbose=verbose, es_key=es_key)
-        if neo_version <= Version("0.13.0") and spikeinterface_version <= Version("0.100"):
+        if neo_version < Version("0.13.0") and spikeinterface_version < Version("0.100"):
             if ignore_integrity_checks:
                 warnings.warn(
                     "The 'ignore_integrity_checks' parameter is not supported for neo versions < 0.13.1. "

--- a/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
@@ -82,7 +82,7 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
         spikeinterface_version = get_package_version(name="spikeinterface")
 
         init_kwargs = dict(file_path=file_path, stream_id=self.stream_id, verbose=verbose, es_key=es_key)
-        if neo_version < Version("0.13.0") and spikeinterface_version < Version("0.100.10"):
+        if neo_version < Version("0.13.1") or spikeinterface_version < Version("0.100.10"):
             if ignore_integrity_checks:
                 warnings.warn(
                     "The 'ignore_integrity_checks' parameter is not supported for neo versions < 0.13.1. "

--- a/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
@@ -82,15 +82,15 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
         spikeinterface_version = get_package_version(name="spikeinterface")
 
         init_kwargs = dict(file_path=file_path, stream_id=self.stream_id, verbose=verbose, es_key=es_key)
-        if neo_version >= Version("0.13.1") and spikeinterface_version >= Version("0.101.0"):
-            init_kwargs["ignore_integrity_checks"] = ignore_integrity_checks
-        else:
+        if neo_version <= Version("0.13.0") and spikeinterface_version <= Version("0.100"):
             if ignore_integrity_checks:
                 warnings.warn(
                     "The 'ignore_integrity_checks' parameter is not supported for neo versions < 0.13.1. "
                     "or spikeinterface versions < 0.101.0.",
                     UserWarning,
                 )
+        else:
+            init_kwargs["ignore_integrity_checks"] = ignore_integrity_checks
 
         if stream_id is not None:
             warnings.warn(


### PR DESCRIPTION
Spikeinterface has started using a pre-release system which broke some of the logic here. In short:

```python
spikeinterface_version
<Version('0.101.0rc0')>
spikeinterface_version <= Version("0.100")
False
Version("0.100") <= Version("0.100.6")
True
spikeinterface_version >= Version("0.101.0")
False
```

So I had to switch the comparisons here to the negative and don't use the patch part of the semantic versioning to codify intent.
