### PR TITLE
[Backend Configuration VIIId] Purge H5DataIO references - LightningPose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 ### Improvements
 * Make annotations from the raw format available on `IntanRecordingInterface`. [PR #934](https://github.com/catalystneuro/neuroconv/pull/943)
 * Add an option to suppress display the progress bar (tqdm) in `VideoContext`  [PR #937](https://github.com/catalystneuro/neuroconv/pull/937)
+* Automatic compression of data in the `LightnignPoseDataInterface` has been disabled - users should refer to the new `configure_backend` method for a general approach for setting compression. [PR #942](https://github.com/catalystneuro/neuroconv/pull/942)
+
+
 
 ## v0.4.11 (June 14, 2024)
 

--- a/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposedatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposedatainterface.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Optional, Tuple
 
 import numpy as np
-from hdmf.backends.hdf5 import H5DataIO
 from pynwb import NWBFile
 
 from ....basetemporalalignmentinterface import BaseTemporalAlignmentInterface
@@ -230,7 +229,7 @@ class LightningPoseDataInterface(BaseTemporalAlignmentInterface):
             assert len(timestamps) == len(
                 pose_estimation_data
             ), f"The length of timestamps ({len(timestamps)}) and pose estimation data ({len(pose_estimation_data)}) must be equal."
-            pose_estimation_series_kwargs = dict(timestamps=H5DataIO(data=timestamps, compression="gzip"))
+            pose_estimation_series_kwargs = dict(timestamps=timestamps)
 
         pose_estimation_series = []
         for keypoint_name in self.keypoint_names:


### PR DESCRIPTION
Finishing the final purge of H5DataIO references

This PR is for the LightningPose interface

This PR is independent of the others (not forming a chain until it's necessary to do so) so can be merged whenever ready