### PR TITLE
Remove date tags & debug release trigger for docker images

### DIFF
--- a/.github/workflows/build_and_upload_docker_image_dev.yml
+++ b/.github/workflows/build_and_upload_docker_image_dev.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true  # Push is a shorthand for --output=type=registry
-          tags: ghcr.io/catalystneuro/neuroconv:dev,ghcr.io/catalystneuro/neuroconv:${{ steps.date.outputs.date_tag }}
+          tags: ghcr.io/catalystneuro/neuroconv:dev
           context: .
           file: dockerfiles/neuroconv_dev_dockerfile
           provenance: false

--- a/.github/workflows/build_and_upload_docker_image_dev.yml
+++ b/.github/workflows/build_and_upload_docker_image_dev.yml
@@ -2,7 +2,7 @@ name: Build and Upload Docker Image of Current Dev Branch to GHCR
 
 on:
   schedule:
-    - cron: "0 16 * * 1"  # Weekly at noon EST on Monday
+    - cron: "0 13 * * *" # Daily at 9 EST
   workflow_dispatch:
 
 concurrency:  # Cancel previous workflows on the same pull request
@@ -26,11 +26,6 @@ jobs:
           registry: ghcr.io
           username: ${{ secrets.DOCKER_UPLOADER_USERNAME }}
           password: ${{ secrets.DOCKER_UPLOADER_PASSWORD }}
-      - name: Get current date
-        id: date
-        run: |
-          date_tag="$(date +'%Y-%m-%d')"
-          echo "date_tag=$date_tag" >> $GITHUB_OUTPUT
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/build_and_upload_docker_image_latest_release.yml
+++ b/.github/workflows/build_and_upload_docker_image_latest_release.yml
@@ -2,7 +2,7 @@ name: Build and Upload Docker Image of Latest Release to GHCR
 
 on:
   workflow_run:
-    workflows: [auto-publish]
+    workflows: [Upload Package to PyPI]
     types: [completed]
   workflow_dispatch:
 

--- a/.github/workflows/build_and_upload_docker_image_yaml_variable.yml
+++ b/.github/workflows/build_and_upload_docker_image_yaml_variable.yml
@@ -2,7 +2,7 @@ name: Build and Upload Docker Image of latest with YAML variable to GHCR
 
 on:
   workflow_run:
-    workflows: [build_and_upload_docker_image_latest_release]
+    workflows: [Build and Upload Docker Image of Latest Release to GHCR]
     types: [completed]
   workflow_dispatch:
 


### PR DESCRIPTION
The dev date tags are needlessly flooding the GHCR; apparently it keeps around any images that have a unique tag (which would apply to all date tags) and only overrides based on that (such as static `dev` tag)

Also wondered why the builds weren't triggering for latest release, realized it was a naming issue in the GitHub Action