### PR TITLE
Improve spikeglx metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * The `OpenEphysBinaryRecordingInterface` now uses `lxml` for extracting the session start time from the settings.xml file and does not depend on `pyopenephys` anymore. [PR #971](https://github.com/catalystneuro/neuroconv/pull/971)
 * Swap the majority of package setup and build steps to `pyproject.toml` instead of `setup.py`. [PR #955](https://github.com/catalystneuro/neuroconv/pull/955)
 * The `DeeplabcutInterface` now skips inferring timestamps from movie when timestamps are specified, running faster. [PR #967](https://github.com/catalystneuro/neuroconv/pull/967)
+* Improve metadata wirintg to SpikeGLX data interface. Added contact ids, shank ids and remove references to shanks for neuropixels 1.0. Also deprecated the previous neuroconv exclusive property "electrode_shank_number` [PR #986](https://github.com/catalystneuro/neuroconv/pull/986)
+
 
 ### Dependencies
 * Updated `spikeinterface` to `v0.101.0` to use `SortingAnalyzer` instead of `WaveformExtractor` (discontinued) in the `spikeinterface` tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * The `OpenEphysBinaryRecordingInterface` now uses `lxml` for extracting the session start time from the settings.xml file and does not depend on `pyopenephys` anymore. [PR #971](https://github.com/catalystneuro/neuroconv/pull/971)
 * Swap the majority of package setup and build steps to `pyproject.toml` instead of `setup.py`. [PR #955](https://github.com/catalystneuro/neuroconv/pull/955)
 * The `DeeplabcutInterface` now skips inferring timestamps from movie when timestamps are specified, running faster. [PR #967](https://github.com/catalystneuro/neuroconv/pull/967)
-* Improve metadata wirintg to SpikeGLX data interface. Added contact ids, shank ids and remove references to shanks for neuropixels 1.0. Also deprecated the previous neuroconv exclusive property "electrode_shank_number` [PR #986](https://github.com/catalystneuro/neuroconv/pull/986)
+* Improve metadata writing for SpikeGLX data interface. Added contact ids, shank ids and, remove references to shanks for neuropixels 1.0. Also deprecated the previous neuroconv exclusive property "electrode_shank_number` [PR #986](https://github.com/catalystneuro/neuroconv/pull/986)
 
 
 ### Dependencies

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglx_utils.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglx_utils.py
@@ -8,7 +8,7 @@ from ....utils import FilePathType
 
 
 def add_recording_extractor_properties(recording_extractor) -> None:
-    """Automatically add shank group_name and shank_electrode_number for spikeglx."""
+    """Utility functions for setting some properties on the recording extractor"""
     probe = recording_extractor.get_probe()
     channel_ids = recording_extractor.get_channel_ids()
 
@@ -20,16 +20,14 @@ def add_recording_extractor_properties(recording_extractor) -> None:
         recording_extractor.set_property(key="shank_ids", values=shank_ids)
         group_name = [f"{probe_name}{shank_id}" for shank_id in shank_ids]
     else:
-        shank_electrode_number = recording_extractor.ids_to_indices(channel_ids)
         group_name = [f"{probe_name}"] * len(channel_ids)
 
-    recording_extractor.set_property(key="shank_electrode_number", ids=channel_ids, values=shank_electrode_number)
     recording_extractor.set_property(key="group_name", ids=channel_ids, values=group_name)
 
     contact_shapes = probe.contact_shapes  # The geometry of the contact shapes
     recording_extractor.set_property(key="contact_shapes", ids=channel_ids, values=contact_shapes)
 
-    contact_ids = probe.contact_ids
+    contact_ids = probe.contact_ids  # s{shank_number}e{electrode_number} or e{electrode_number}
     recording_extractor.set_property(key="contact_ids", ids=channel_ids, values=contact_ids)
 
 

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglx_utils.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglx_utils.py
@@ -107,7 +107,6 @@ def get_device_metadata(meta) -> dict:
             "21": "NP2.0(1-shank)",
             "24": "NP2.0(4-shank)",
             "1030": "NP1.0 NHP",
-            "2013": "NP2.0(4-shank)",
         }
         probe_type = str(meta["imDatPrb_type"])
         probe_type_description = probe_type_to_probe_description[probe_type]

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglx_utils.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglx_utils.py
@@ -16,17 +16,21 @@ def add_recording_extractor_properties(recording_extractor) -> None:
     probe_name = recording_extractor.stream_id[:5].capitalize()
 
     if probe.get_shank_count() > 1:
-        shank_electrode_number = [int(contact_id.split("e")[1]) for contact_id in probe.contact_ids]
-        group_name = [f"{probe_name}{contact_id.split('e')[0]}" for contact_id in probe.contact_ids]
+        shank_ids = probe.get_shank_ids()
+        recording_extractor.set_property(key="shank_ids", values=shank_ids)
+        group_name = [f"{probe_name}{shank_id}" for shank_id in shank_ids]
     else:
         shank_electrode_number = recording_extractor.ids_to_indices(channel_ids)
-        group_name = [f"{probe_name}Shank0"] * len(channel_ids)
+        group_name = [f"{probe_name}"] * len(channel_ids)
 
     recording_extractor.set_property(key="shank_electrode_number", ids=channel_ids, values=shank_electrode_number)
     recording_extractor.set_property(key="group_name", ids=channel_ids, values=group_name)
 
     contact_shapes = probe.contact_shapes  # The geometry of the contact shapes
     recording_extractor.set_property(key="contact_shapes", ids=channel_ids, values=contact_shapes)
+
+    contact_ids = probe.contact_ids
+    recording_extractor.set_property(key="contact_ids", ids=channel_ids, values=contact_ids)
 
 
 def get_session_start_time(recording_metadata: dict) -> datetime:
@@ -105,6 +109,7 @@ def get_device_metadata(meta) -> dict:
             "21": "NP2.0(1-shank)",
             "24": "NP2.0(4-shank)",
             "1030": "NP1.0 NHP",
+            "2013": "NP2.0(4-shank)",
         }
         probe_type = str(meta["imDatPrb_type"])
         probe_type_description = probe_type_to_probe_description[probe_type]

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglx_utils.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglx_utils.py
@@ -16,7 +16,7 @@ def add_recording_extractor_properties(recording_extractor) -> None:
     probe_name = recording_extractor.stream_id[:5].capitalize()
 
     if probe.get_shank_count() > 1:
-        shank_ids = probe.get_shank_ids()
+        shank_ids = probe.shank_ids
         recording_extractor.set_property(key="shank_ids", values=shank_ids)
         group_name = [f"{probe_name}{shank_id}" for shank_id in shank_ids]
     else:

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
@@ -18,8 +18,16 @@ from ....utils import FilePathType, get_schema_from_method_signature
 class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
     display_name = "SpikeGLX Recording"
     keywords = BaseRecordingExtractorInterface.keywords + ("Neuropixels",)
-    associated_suffixes = (".imec{probe_number}", ".ap", ".lf", ".meta", ".bin")
+    associated_suffixes = (".imec{probe_index}", ".ap", ".lf", ".meta", ".bin")
     info = "Interface for SpikeGLX recording data."
+
+    # TODO: Add probe_index to probeinterface and propagate it from there
+    # Note to developer.
+    # In a conversion with Jennifer Colonell she refers to the number after imec as the probe index
+    # Quoting here:
+    # imec0 is the probe in the lowest slot and port number, imec1 in the next highest, and so on.
+    # If you have probes in {slot 2, port 3}, {slot 3, port1} and {slot3, port2},
+    # the probe indices in the SGLX output will be 0, 1, and 2, respectively.
 
     ExtractorName = "SpikeGLXRecordingExtractor"
 
@@ -60,6 +68,7 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
             stream_id=self.stream_id,
             verbose=verbose,
             es_key=es_key,
+            all_annotations=True,
         )
         self.source_data["file_path"] = str(file_path)
         self.meta = self.recording_extractor.neo_reader.signals_info_dict[(0, self.stream_id)]["meta"]
@@ -95,10 +104,15 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
 
         # Electrodes columns descriptions
         metadata["Ecephys"]["Electrodes"] = [
-            dict(name="shank_electrode_number", description="0-indexed channel within a shank."),
             dict(name="group_name", description="Name of the ElectrodeGroup this electrode is a part of."),
             dict(name="contact_shapes", description="The shape of the electrode"),
+            dict(name="contact_ids", description="The id of the contact on the electrode"),
         ]
+
+        if self.recording_extractor.get_probe().get_shank_count() > 1:
+            metadata["Ecephys"]["Electrodes"].append(
+                dict(name="shank_ids", description="The shank id of the electrode")
+            )
 
         return metadata
 

--- a/tests/test_on_data/test_format_converters/spikeglx_multi_probe_metadata.json
+++ b/tests/test_on_data/test_format_converters/spikeglx_multi_probe_metadata.json
@@ -17,14 +17,14 @@
     ],
     "ElectrodeGroup": [
       {
-        "name": "Imec0Shank0",
-        "description": "A group representing probe/shank 'Imec0Shank0'.",
+        "name": "Imec0",
+        "description": "A group representing probe/shank 'Imec0'.",
         "location": "unknown",
         "device": "NeuropixelImec0"
       },
       {
-        "name": "Imec1Shank0",
-        "description": "A group representing probe/shank 'Imec1Shank0'.",
+        "name": "Imec1",
+        "description": "A group representing probe/shank 'Imec1'.",
         "location": "unknown",
         "device": "NeuropixelImec1"
       }
@@ -35,16 +35,16 @@
     },
     "Electrodes": [
       {
-        "name": "shank_electrode_number",
-        "description": "0-indexed channel within a shank."
-      },
-      {
         "name": "group_name",
         "description": "Name of the ElectrodeGroup this electrode is a part of."
       },
       {
         "name": "contact_shapes",
         "description": "The shape of the electrode"
+      },
+      {
+        "name": "contact_ids",
+        "description": "The id of the contact on the electrode"
       }
     ],
     "ElectricalSeriesAPImec1": {

--- a/tests/test_on_data/test_format_converters/spikeglx_single_probe_metadata.json
+++ b/tests/test_on_data/test_format_converters/spikeglx_single_probe_metadata.json
@@ -17,8 +17,8 @@
     ],
     "ElectrodeGroup": [
       {
-        "name": "Imec0Shank0",
-        "description": "A group representing probe/shank 'Imec0Shank0'.",
+        "name": "Imec0",
+        "description": "A group representing probe/shank 'Imec0'.",
         "location": "unknown",
         "device": "NeuropixelImec0"
       },
@@ -35,16 +35,16 @@
     },
     "Electrodes": [
       {
-        "name": "shank_electrode_number",
-        "description": "0-indexed channel within a shank."
-      },
-      {
         "name": "group_name",
         "description": "Name of the ElectrodeGroup this electrode is a part of."
       },
       {
         "name": "contact_shapes",
         "description": "The shape of the electrode"
+      },
+      {
+        "name": "contact_ids",
+        "description": "The id of the contact on the electrode"
       }
     ],
     "ElectricalSeriesNIDQ": {

--- a/tests/test_on_data/test_format_converters/test_spikeglx_converter.py
+++ b/tests/test_on_data/test_format_converters/test_spikeglx_converter.py
@@ -45,7 +45,7 @@ class TestSingleProbeSpikeGLXConverter(TestCase):
             assert len(nwbfile.devices) == 2
 
             assert "NIDQChannelGroup" in nwbfile.electrode_groups
-            assert "Imec0Shank0" in nwbfile.electrode_groups
+            assert "Imec0" in nwbfile.electrode_groups
             assert len(nwbfile.electrode_groups) == 2
 
     def test_single_probe_spikeglx_converter(self):
@@ -61,7 +61,15 @@ class TestSingleProbeSpikeGLXConverter(TestCase):
         del test_metadata["NWBFile"]["source_script"]
         del test_metadata["NWBFile"]["source_script_file_name"]
 
-        assert test_metadata == expected_metadata
+        expected_ecephys_metadata = expected_metadata["Ecephys"]
+        test_ecephys_metadata = test_metadata["Ecephys"]
+
+        device_metadata = test_ecephys_metadata.pop("Device")
+        expected_device_metadata = expected_ecephys_metadata.pop("Device")
+
+        assert device_metadata == expected_device_metadata
+
+        assert test_ecephys_metadata == expected_ecephys_metadata
 
         nwbfile_path = self.tmpdir / "test_single_probe_spikeglx_converter.nwb"
         converter.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)
@@ -127,8 +135,8 @@ class TestMultiProbeSpikeGLXConverter(TestCase):
         assert "NeuropixelImec1" in nwbfile.devices
         assert len(nwbfile.devices) == 2
 
-        assert "Imec0Shank0" in nwbfile.electrode_groups
-        assert "Imec1Shank0" in nwbfile.electrode_groups
+        assert "Imec0" in nwbfile.electrode_groups
+        assert "Imec1" in nwbfile.electrode_groups
         assert len(nwbfile.electrode_groups) == 2
 
     def test_multi_probe_spikeglx_converter(self):
@@ -146,7 +154,15 @@ class TestMultiProbeSpikeGLXConverter(TestCase):
         del test_metadata["NWBFile"]["source_script"]
         del test_metadata["NWBFile"]["source_script_file_name"]
 
-        assert test_metadata == expected_metadata
+        expected_ecephys_metadata = expected_metadata["Ecephys"]
+        test_ecephys_metadata = test_metadata["Ecephys"]
+
+        device_metadata = test_ecephys_metadata.pop("Device")
+        expected_device_metadata = expected_ecephys_metadata.pop("Device")
+
+        assert device_metadata == expected_device_metadata
+
+        assert test_ecephys_metadata == expected_ecephys_metadata
 
         nwbfile_path = self.tmpdir / "test_multi_probe_spikeglx_converter.nwb"
         converter.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)

--- a/tests/test_on_data/test_metadata/test_spikeglx_metadata.py
+++ b/tests/test_on_data/test_metadata/test_spikeglx_metadata.py
@@ -32,17 +32,16 @@ def test_spikelgx_recording_property_addition():
     n_channels = probe.device_channel_indices.size
     probe_name = "Imec0"
 
-    expected_shank_electrode_number = [int(contact_id.split("e")[1]) for contact_id in probe.contact_ids]
-    expected_group_name = [f"{probe_name}{contact_id.split('e')[0]}" for contact_id in probe.contact_ids]
+    shank_ids = probe.shank_ids
+    expected_group_name = [f"{probe_name}{shank_id}" for shank_id in shank_ids]
+
     expected_contact_shapes = ["square"] * n_channels
 
     # Initialize the interface and get the added properties
     interface = SpikeGLXRecordingInterface(file_path=ap_file_path)
-    shank_electrode_number = interface.recording_extractor.get_property("shank_electrode_number")
     group_name = interface.recording_extractor.get_property("group_name")
     contact_shapes = interface.recording_extractor.get_property("contact_shapes")
 
-    assert_array_equal(shank_electrode_number, expected_shank_electrode_number)
     assert_array_equal(group_name, expected_group_name)
     assert_array_equal(contact_shapes, expected_contact_shapes)
 

--- a/tests/test_on_data/test_metadata/test_spikeglx_metadata.py
+++ b/tests/test_on_data/test_metadata/test_spikeglx_metadata.py
@@ -32,18 +32,22 @@ def test_spikelgx_recording_property_addition():
     n_channels = probe.device_channel_indices.size
     probe_name = "Imec0"
 
-    shank_ids = probe.shank_ids
-    expected_group_name = [f"{probe_name}{shank_id}" for shank_id in shank_ids]
-
+    expected_shank_ids = probe.shank_ids
+    expected_group_name = [f"{probe_name}{shank_id}" for shank_id in expected_shank_ids]
     expected_contact_shapes = ["square"] * n_channels
+    expected_contact_ids = probe.contact_ids
 
     # Initialize the interface and get the added properties
     interface = SpikeGLXRecordingInterface(file_path=ap_file_path)
     group_name = interface.recording_extractor.get_property("group_name")
     contact_shapes = interface.recording_extractor.get_property("contact_shapes")
+    shank_ids = interface.recording_extractor.get_property("shank_ids")
+    contact_ids = interface.recording_extractor.get_property("contact_ids")
 
     assert_array_equal(group_name, expected_group_name)
     assert_array_equal(contact_shapes, expected_contact_shapes)
+    assert_array_equal(shank_ids, expected_shank_ids)
+    assert_array_equal(contact_ids, expected_contact_ids)
 
 
 @pytest.mark.skip(reason="Legacy spikeextractors cannot read new GIN file.")


### PR DESCRIPTION
In place of https://github.com/catalystneuro/neuroconv/pull/977
- Add shank id when available
- Add contact ids which contain a reference to the shank when it exists
- Remove references to shank when the probe does not have shanks in the probeinterface sense.