### PR TITLE
Get default description for neuropixels probes 

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglx_utils.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglx_utils.py
@@ -107,7 +107,7 @@ def get_device_metadata(meta) -> dict:
             "1030": "NP1.0 NHP",
         }
         probe_type = str(meta["imDatPrb_type"])
-        probe_type_description = probe_type_to_probe_description.get(probe_type, "")
+        probe_type_description = probe_type_to_probe_description.get(probe_type, "Unknown SpikeGLX probe type.")
         metadata_dict.update(probe_type=probe_type, probe_type_description=probe_type_description)
 
     if "imDatFx_pn" in meta:

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglx_utils.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglx_utils.py
@@ -97,7 +97,7 @@ def get_device_metadata(meta) -> dict:
     dict
         a dict containing the metadata necessary for creating the device
     """
-
+    # TODO, get probe metadata from spikeinterface
     metadata_dict = dict()
     if "imDatPrb_type" in meta:
         probe_type_to_probe_description = {
@@ -107,7 +107,7 @@ def get_device_metadata(meta) -> dict:
             "1030": "NP1.0 NHP",
         }
         probe_type = str(meta["imDatPrb_type"])
-        probe_type_description = probe_type_to_probe_description[probe_type]
+        probe_type_description = probe_type_to_probe_description.get(probe_type, "")
         metadata_dict.update(probe_type=probe_type, probe_type_description=probe_type_description)
 
     if "imDatFx_pn" in meta:


### PR DESCRIPTION
Coming from #986.

As discussed there there are many more probe types that we don't have:

https://github.com/SpikeInterface/probeinterface/blob/3728499714f68cfadaf76ef51b19eb8cc813b011/src/probeinterface/io.py#L1081-L1108

This is a temporary patch so the interfaces does not stop in its tracks when this information is missing.

Eventually, we should fetch this from probeinterface.