### PR TITLE
Add default call to metadata in `BaseRecordingInterface`  `add_to_nwb` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * The `DeeplabcutInterface` now skips inferring timestamps from movie when timestamps are specified, running faster. [PR #967](https://github.com/catalystneuro/neuroconv/pull/967)
 * Improve metadata writing for SpikeGLX data interface. Added contact ids, shank ids and, remove references to shanks for neuropixels 1.0. Also deprecated the previous neuroconv exclusive property "electrode_shank_number` [PR #986](https://github.com/catalystneuro/neuroconv/pull/986)
 * Add tqdm with warning to DeepLabCut interface [PR #1006](https://github.com/catalystneuro/neuroconv/pull/1006)
+* `BaseRecordingInterface` now calls default metadata when metadata is not passing mimicking `run_conversion` behavior. [PR #1012](https://github.com/catalystneuro/neuroconv/pull/1012)
 
 
 ## v0.5.0 (July 17, 2024)

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -299,7 +299,7 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
         write_electrical_series: bool = True,
         compression: Optional[str] = None,  # TODO: remove completely after 10/1/2024
         compression_opts: Optional[int] = None,
-        iterator_type: str = "v2",
+        iterator_type: Optional[str] = "v2",
         iterator_opts: Optional[dict] = None,
     ):
         """
@@ -324,10 +324,9 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
         write_electrical_series : bool, default: True
             Electrical series are written in acquisition. If False, only device, electrode_groups,
             and electrodes are written to NWB.
-        iterator_type : {'v2', 'v1'}
+        iterator_type : {'v2'}
             The type of DataChunkIterator to use.
-            'v1' is the original DataChunkIterator of the hdmf data_utils.
-            'v2' is the locally developed RecordingExtractorDataChunkIterator, which offers full control over chunking.
+            'v2' is the locally developed RecordingExtractorDataChunkIterator, which offers full control over chunking
         iterator_opts : dict, optional
             Dictionary of options for the RecordingExtractorDataChunkIterator (iterator_type='v2').
             Valid options are:
@@ -356,6 +355,9 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
             recording = self.subset_recording(stub_test=stub_test)
         else:
             recording = self.recording_extractor
+
+        if metadata is None:
+            metadata = self.get_metadata()
 
         add_recording(
             recording=recording,


### PR DESCRIPTION
As in the title.

Also, removed a deprecated option from the docstring.