### PR TITLE
Enable backend test for zarr

### DIFF
--- a/src/neuroconv/basedatainterface.py
+++ b/src/neuroconv/basedatainterface.py
@@ -125,11 +125,8 @@ class BaseDataInterface(ABC):
         nwbfile: Optional[NWBFile] = None,
         metadata: Optional[dict] = None,
         overwrite: bool = False,
-        # TODO: when all H5DataIO prewraps are gone, introduce Zarr safely
-        # backend: Union[Literal["hdf5", "zarr"]],
-        # backend_configuration: Optional[Union[HDF5BackendConfiguration, ZarrBackendConfiguration]] = None,
-        backend: Optional[Literal["hdf5"]] = None,
-        backend_configuration: Optional[HDF5BackendConfiguration] = None,
+        backend: Literal["hdf5", "zarr"] = "hdf5",
+        backend_configuration: Optional[Union[HDF5BackendConfiguration, ZarrBackendConfiguration]] = None,
         **conversion_options,
     ):
         """
@@ -146,15 +143,15 @@ class BaseDataInterface(ABC):
         overwrite : bool, default: False
             Whether to overwrite the NWBFile if one exists at the nwbfile_path.
             The default is False (append mode).
-        backend : "hdf5", optional
-            The type of backend to use when writing the file.
-            If a `backend_configuration` is not specified, the default type will be "hdf5".
-            If a `backend_configuration` is specified, then the type will be auto-detected.
-        backend_configuration : HDF5BackendConfiguration, optional
-            The configuration model to use when configuring the datasets for this backend.
-            To customize, call the `.get_default_backend_configuration(...)` method, modify the returned
-            BackendConfiguration object, and pass that instead.
-            Otherwise, all datasets will use default configuration settings.
+        backend : {'hdf5', 'zarr'}, default: 'hdf5'
+            The storage backend for the NWB file.
+            If `backend_configuration` is provided, this value is overridden by the configuration's backend type.
+        backend_configuration : HDF5BackendConfiguration or ZarrBackendConfiguration, optional
+            Configuration settings for the chosen backend. If not provided, default settings are used.
+            To customize, obtain the default configuration using `.get_default_backend_configuration(...)`,
+            modify it, and pass the modified configuration here.
+        conversion_options : dict, optional
+            Additional keyword arguments to pass to the `.add_to_nwbfile` method.
         """
 
         backend = _resolve_backend(backend, backend_configuration)
@@ -187,9 +184,7 @@ class BaseDataInterface(ABC):
     @staticmethod
     def get_default_backend_configuration(
         nwbfile: NWBFile,
-        # TODO: when all H5DataIO prewraps are gone, introduce Zarr safely
-        # backend: Union[Literal["hdf5", "zarr"]],
-        backend: Literal["hdf5"] = "hdf5",
+        backend: Literal["hdf5", "zarr"] = "hdf5",
     ) -> Union[HDF5BackendConfiguration, ZarrBackendConfiguration]:
         """
         Fill and return a default backend configuration to serve as a starting point for further customization.
@@ -198,10 +193,9 @@ class BaseDataInterface(ABC):
         ----------
         nwbfile : pynwb.NWBFile
             The in-memory object with this interface's data already added to it.
-        backend : "hdf5", default: "hdf5"
-            The type of backend to use when creating the file.
-            Additional backend types will be added soon.
-
+        backend : {'hdf5', 'zarr'}, default: 'hdf5'
+            The storage backend for the NWB file.
+            If `backend_configuration` is provided, this value is overridden by the configuration's backend type.
         Returns
         -------
         backend_configuration : HDF5BackendConfiguration or ZarrBackendConfiguration

--- a/src/neuroconv/nwbconverter.py
+++ b/src/neuroconv/nwbconverter.py
@@ -177,11 +177,8 @@ class NWBConverter:
         nwbfile: Optional[NWBFile] = None,
         metadata: Optional[dict] = None,
         overwrite: bool = False,
-        # TODO: when all H5DataIO prewraps are gone, introduce Zarr safely
-        # backend: Union[Literal["hdf5", "zarr"]],
-        # backend_configuration: Optional[Union[HDF5BackendConfiguration, ZarrBackendConfiguration]] = None,
-        backend: Optional[Literal["hdf5"]] = None,
-        backend_configuration: Optional[HDF5BackendConfiguration] = None,
+        backend: Literal["hdf5", "zarr"] = "hdf5",
+        backend_configuration: Optional[Union[HDF5BackendConfiguration, ZarrBackendConfiguration]] = None,
         conversion_options: Optional[dict] = None,
     ) -> None:
         """
@@ -199,15 +196,13 @@ class NWBConverter:
         overwrite : bool, default: False
             Whether to overwrite the NWBFile if one exists at the nwbfile_path.
             The default is False (append mode).
-        backend : "hdf5", optional
-            The type of backend to use when writing the file.
-            If a `backend_configuration` is not specified, the default type will be "hdf5".
-            If a `backend_configuration` is specified, then the type will be auto-detected.
-        backend_configuration : HDF5BackendConfiguration, optional
-            The configuration model to use when configuring the datasets for this backend.
-            To customize, call the `.get_default_backend_configuration(...)` method, modify the returned
-            BackendConfiguration object, and pass that instead.
-            Otherwise, all datasets will use default configuration settings.
+        backend : {'hdf5', 'zarr'}, default: 'hdf5'
+            The storage backend for the NWB file.
+            If `backend_configuration` is provided, this value is overridden by the configuration's backend type.
+        backend_configuration : HDF5BackendConfiguration or ZarrBackendConfiguration, optional
+            Configuration settings for the chosen backend. If not provided, default settings are used.
+            To customize, obtain the default configuration using `.get_default_backend_configuration(...)`,
+            modify it, and pass the modified configuration here.
         conversion_options : dict, optional
             Similar to source_data, a dictionary containing keywords for each interface for which non-default
             conversion specification is requested.

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -242,11 +242,10 @@ class DataInterfaceTestMixin:
 
                 self.check_read_nwb(nwbfile_path=self.nwbfile_path)
 
-                # TODO: enable when all H5DataIO prewraps are gone
-                # self.nwbfile_path = str(self.save_directory / f"{self.__class__.__name__}_{num}.nwb.zarr")
-                # self.check_run_conversion(nwbfile_path=self.nwbfile_path, backend="zarr")
-                # self.check_run_conversion_custom_backend(nwbfile_path=self.nwbfile_path, backend="zarr")
-                # self.check_basic_zarr_read(nwbfile_path=self.nwbfile_path)
+                self.nwbfile_path = str(self.save_directory / f"{self.__class__.__name__}_{num}.nwb.zarr")
+                self.check_run_conversion(nwbfile_path=self.nwbfile_path, backend="zarr")
+                self.check_run_conversion_custom_backend(nwbfile_path=self.nwbfile_path, backend="zarr")
+                self.check_basic_zarr_read(nwbfile_path=self.nwbfile_path)
 
                 # Any extra custom checks to run
                 self.run_custom_checks()
@@ -1031,11 +1030,10 @@ class MedPCInterfaceMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
 
                 self.check_read_nwb(nwbfile_path=self.nwbfile_path)
 
-                # TODO: enable when all H5DataIO prewraps are gone
-                # self.nwbfile_path = str(self.save_directory / f"{self.__class__.__name__}_{num}.nwb.zarr")
-                # self.check_run_conversion(nwbfile_path=self.nwbfile_path, backend="zarr")
-                # self.check_run_conversion_custom_backend(nwbfile_path=self.nwbfile_path, backend="zarr")
-                # self.check_basic_zarr_read(nwbfile_path=self.nwbfile_path)
+                self.nwbfile_path = str(self.save_directory / f"{self.__class__.__name__}_{num}.nwb.zarr")
+                self.check_run_conversion(nwbfile_path=self.nwbfile_path, backend="zarr")
+                self.check_run_conversion_custom_backend(nwbfile_path=self.nwbfile_path, backend="zarr")
+                self.check_basic_zarr_read(nwbfile_path=self.nwbfile_path)
 
                 # Any extra custom checks to run
                 self.run_custom_checks()
@@ -1353,11 +1351,10 @@ class TDTFiberPhotometryInterfaceMixin(DataInterfaceTestMixin, TemporalAlignment
 
                 self.check_read_nwb(nwbfile_path=self.nwbfile_path)
 
-                # TODO: enable when all H5DataIO prewraps are gone
-                # self.nwbfile_path = str(self.save_directory / f"{self.__class__.__name__}_{num}.nwb.zarr")
-                # self.check_run_conversion(nwbfile_path=self.nwbfile_path, backend="zarr")
-                # self.check_run_conversion_custom_backend(nwbfile_path=self.nwbfile_path, backend="zarr")
-                # self.check_basic_zarr_read(nwbfile_path=self.nwbfile_path)
+                self.nwbfile_path = str(self.save_directory / f"{self.__class__.__name__}_{num}.nwb.zarr")
+                self.check_run_conversion(nwbfile_path=self.nwbfile_path, backend="zarr")
+                self.check_run_conversion_custom_backend(nwbfile_path=self.nwbfile_path, backend="zarr")
+                self.check_basic_zarr_read(nwbfile_path=self.nwbfile_path)
 
                 # Any extra custom checks to run
                 self.run_custom_checks()


### PR DESCRIPTION
Now that all the wrappers for data have been removed we are enablign both typing and testing for the zarr backend at the run_conversion level.