### PR TITLE
[testing] Re-organize data tests showcase

### DIFF
--- a/tests/test_on_data/test_behavior_interfaces.py
+++ b/tests/test_on_data/test_behavior_interfaces.py
@@ -303,16 +303,34 @@ class TestFicTracDataInterfaceTiming(TemporalAlignmentMixin, unittest.TestCase):
     save_directory = OUTPUT_PATH
 
 
-class TestVideoInterface(VideoInterfaceMixin, unittest.TestCase):
+import pytest
+
+
+class TestVideoInterface(VideoInterfaceMixin):
     data_interface_cls = VideoInterface
-    interface_kwargs = [
-        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_avi.avi")]),
-        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_flv.flv")]),
-        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_mov.mov")]),
-        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_mp4.mp4")]),
-        dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_wmv.wmv")]),
-    ]
     save_directory = OUTPUT_PATH
+
+    @pytest.fixture(
+        params=[
+            (dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_avi.avi")])),
+            (dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_flv.flv")])),
+            (dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_mov.mov")])),
+            (dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_mp4.mp4")])),
+            (dict(file_paths=[str(BEHAVIOR_DATA_PATH / "videos" / "CFR" / "video_wmv.wmv")])),
+        ],
+        ids=["avi", "flv", "mov", "mp4", "wmv"],
+    )
+    def setup_interface(self, request):
+        interface_kwargs = request.param
+
+        test_id = request.node.callspec.id
+        self.test_name = test_id
+        self.interface_kwargs = interface_kwargs
+
+        self.interface = self.data_interface_cls(**self.interface_kwargs)
+
+        # Return any necessary objects
+        return self.interface, self.test_name
 
 
 class TestDeepLabCutInterface(DeepLabCutInterfaceMixin, unittest.TestCase):


### PR DESCRIPTION
Currently for tests that are identical but tests different datasets (e.g video) we need to create an internal list and loop over it:

https://github.com/catalystneuro/neuroconv/blob/8e20a25ad30609aefffc5ad6f9b56354ee5e6d10/tests/test_on_data/test_behavior_interfaces.py#L306-L316

https://github.com/catalystneuro/neuroconv/blob/8e20a25ad30609aefffc5ad6f9b56354ee5e6d10/src/neuroconv/tools/testing/data_interface_mixins.py#L216-L220

This makes dififcult to time tests and figure out which specific dataset is problematic with common debuggin tools and the pytest framework.

This PR handles this with [pytest fixture parameterization](https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#fixture-parametrize) and now tests are separated in pytest per case like this:

![image](https://github.com/user-attachments/assets/10ecf541-0371-4373-9575-c8917ccf2106)

This PR limits itself to changing this for the VideoInterface and I will start propagating this to other modalities. At the end, the number of lines will be greatly reduced as that would eliminate a lot of duplicated logic.
