### PR TITLE
Update setuptools version on build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=52", "wheel"]
+requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
The latest version of pip just released yesterday breaks editable installs for older versions of setuptools:

https://pip.pypa.io/en/stable/news/#deprecations-and-removals

 I am just pushing the minimal up so this does not break the editable installs of someone.

I am also removing wheel as a depedency which is a legacy behavior:
https://setuptools.pypa.io/en/stable/userguide/quickstart.html#basic-use



