### PR TITLE
Temporary supress failing plexon

### DIFF
--- a/docs/conversion_examples_gallery/recording/plexon2.rst
+++ b/docs/conversion_examples_gallery/recording/plexon2.rst
@@ -14,22 +14,22 @@ Convert Plexon2 recording data to NWB using :py:class:`~neuroconv.datainterfaces
 
 .. code-block:: python
 
-    >>> from datetime import datetime
-    >>> from zoneinfo import ZoneInfo
-    >>> from pathlib import Path
-    >>> from neuroconv.datainterfaces import Plexon2RecordingInterface
-    >>>
-    >>> file_path = f"{ECEPHY_DATA_PATH}/plexon/4chDemoPL2.pl2"
-    >>> # Change the file_path to the location in your system
-    >>> interface = Plexon2RecordingInterface(file_path=file_path, verbose=False)
-    >>>
-    >>> # Extract what metadata we can from the source files
-    >>> metadata = interface.get_metadata()
-    >>> # For data provenance we add the time zone information to the conversion
-    >>> tzinfo = ZoneInfo("US/Pacific")
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"]
-    >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
-    >>>
-    >>> # Choose a path for saving the nwb file and run the conversion
-    >>> nwbfile_path = f"{path_to_save_nwbfile}"
-    >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+    from pathlib import Path
+    from neuroconv.datainterfaces import Plexon2RecordingInterface
+
+    file_path = f"{ECEPHY_DATA_PATH}/plexon/4chDemoPL2.pl2"
+    # Change the file_path to the location in your system
+    interface = Plexon2RecordingInterface(file_path=file_path, verbose=False)
+
+    # Extract what metadata we can from the source files
+    metadata = interface.get_metadata()
+    # For data provenance we add the time zone information to the conversion
+    tzinfo = ZoneInfo("US/Pacific")
+    session_start_time = metadata["NWBFile"]["session_start_time"]
+    metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
+
+    # Choose a path for saving the nwb file and run the conversion
+    nwbfile_path = f"{path_to_save_nwbfile}"
+    interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)


### PR DESCRIPTION
Plexon 2 is unreliable on its opening and it has been getting on the way of CI doc testing. Steps have already been taken to improve the situation but meanwhile I am disabling this doctest by removing the  code directive `>>>`

https://github.com/NeuralEnsemble/python-neo/pull/1541 