### PR TITLE
Fix broken link to hdf5 documentation about IO optimization

### DIFF
--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -44,8 +44,8 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
             The upper bound on size in megabytes (MB) of the internal chunk for the HDF5 dataset.
             The chunk_shape will be set implicitly by this argument.
             Cannot be set if `chunk_shape` is also specified.
-            The default is 10MB. For more details, see
-            https://support.hdfgroup.org/HDF5/doc/TechNotes/TechNote-HDF5-ImprovingIOPerformanceCompressedDatasets.pdf
+            The default is 10MB, as recommended by the HDF5 group.
+            For more details, search the hdf5 documentation for "Improving IO Performance Compressed Datasets".
         chunk_shape : tuple, optional
             Manual specification of the internal chunk shape for the HDF5 dataset.
             Cannot be set if `chunk_mb` is also specified.

--- a/src/neuroconv/tools/spikeinterface/spikeinterfacerecordingdatachunkiterator.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterfacerecordingdatachunkiterator.py
@@ -48,8 +48,8 @@ class SpikeInterfaceRecordingDataChunkIterator(GenericDataChunkIterator):
             The upper bound on size in megabytes (MB) of the internal chunk for the HDF5 dataset.
             The chunk_shape will be set implicitly by this argument.
             Cannot be set if `chunk_shape` is also specified.
-            The default is 1MB, as recommended by the HDF5 group. For more details, see
-            https://support.hdfgroup.org/HDF5/doc/TechNotes/TechNote-HDF5-ImprovingIOPerformanceCompressedDatasets.pdf
+            The default is 10MB, as recommended by the HDF5 group.
+            For more details, search the hdf5 documentation for "Improving IO Performance Compressed Datasets".
         chunk_shape : tuple, optional
             Manual specification of the internal chunk shape for the HDF5 dataset.
             Cannot be set if `chunk_mb` is also specified.


### PR DESCRIPTION
This is a link to the pdf that is broken now and even if it comes back might be moved in the future. I think it is better to tell users that they should look for the info in the hdf5 documentation and give them keywords.