### PR TITLE
Remove broken links from developer docs

### DIFF
--- a/docs/developer_guide/testing_suite.rst
+++ b/docs/developer_guide/testing_suite.rst
@@ -39,12 +39,9 @@ Minimal
 
 These test internal functionality using only minimal dependencies or pre-downloaded data.
 
-Sub-folders: `tests/test_minimal <https://github.com/catalystneuro/neuroconv/tree/main/tests/test_minimal>`_ and
-`tests/test_internals <https://github.com/catalystneuro/neuroconv/tree/main/tests/test_internals>`_
+Sub-folders: `tests/test_minimal <https://github.com/catalystneuro/neuroconv/tree/main/tests/test_minimal>`
 
-These can be run using only ``pip install -e neuroconv[test]`` and calling ``pytest tests/test_minimal`` and
-``pytest tests/test_internal``.
-
+These can be run using only ``pip install -e neuroconv[test]`` and calling ``pytest tests/test_minimal``
 
 
 Modality


### PR DESCRIPTION
The schema tests were moved to minimal on this https://github.com/catalystneuro/neuroconv/pull/1049 and a link in the developer docs no longer exists.

The link tests did not detect that on the spot because until the change is merged the link still exists. An edge case, I don't know if it is worth it to automatize it. Probably not.