### PR TITLE
Enable zarr backend testing in data tests [1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ Fixed a setup bug introduced in `v0.6.2` where installation process created a di
 * Added Unit Table descriptions for phy and kilosort: [PR #1053](https://github.com/catalystneuro/neuroconv/pull/1053)
 * Using ruff to enforce existence of public functions's docstrings [PR #1062](https://github.com/catalystneuro/neuroconv/pull/1062)
 * Improved device metadata of `IntanRecordingInterface` by adding the type of controller used [PR #1059](https://github.com/catalystneuro/neuroconv/pull/1059)
->>>>>>> main
 
 
 ## v0.6.1 (August 30, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Improvements
 * Using ruff to enforce existence of public classes' docstrings [PR #1034](https://github.com/catalystneuro/neuroconv/pull/1034)
 * Separated tests that use external data by modality [PR #1049](https://github.com/catalystneuro/neuroconv/pull/1049)
-
+* Add writing to zarr test for to the data tests [PR #1056](https://github.com/catalystneuro/neuroconv/pull/1056)
 
 
 ## v0.6.1 (August 30, 2024)

--- a/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
@@ -97,7 +97,7 @@ class VideoInterface(BaseDataInterface):
         metadata = super().get_metadata()
         behavior_metadata = {
             self.metadata_key_name: [
-                dict(name=f"Video: {Path(file_path).stem}", description="Video recorded by camera.", unit="Frames")
+                dict(name=f"Video {Path(file_path).stem}", description="Video recorded by camera.", unit="Frames")
                 for file_path in self.source_data["file_paths"]
             ]
         }

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -220,7 +220,7 @@ class DataInterfaceTestMixin:
     @pytest.mark.parametrize("backend", ["hdf5", "zarr"])
     def test_run_conversion_with_backend(self, setup_interface, tmp_path, backend):
 
-        nwbfile_path = str(tmp_path / f"conversion_with_backend{backend}_{self.test_name}.nwb")
+        nwbfile_path = str(tmp_path / f"conversion_with_backend{backend}-{self.test_name}.nwb")
 
         metadata = self.interface.get_metadata()
         if "session_start_time" not in metadata["NWBFile"]:
@@ -1250,6 +1250,22 @@ class ScanImageMultiPlaneImagingInterfaceMixin(DataInterfaceTestMixin, TemporalA
 
 class TDTFiberPhotometryInterfaceMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
     """Mixin for testing TDT Fiber Photometry interfaces."""
+
+    def test_metadata_schema_valid(self):
+        pass
+
+    def test_no_metadata_mutation(self):
+        pass
+
+    def test_run_conversion_with_backend(self):
+        pass
+
+    def test_no_metadata_mutation(self):
+        pass
+
+    def check_metadata_schema_valid(self):
+        schema = self.interface.get_metadata_schema()
+        Draft7Validator.check_schema(schema=schema)
 
     def check_no_metadata_mutation(self, metadata: dict):
         """Ensure the metadata object was not altered by `add_to_nwbfile` method."""

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -821,7 +821,7 @@ class VideoInterfaceMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
         with NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True) as io:
             nwbfile = io.read()
             video_type = Path(self.interface_kwargs["file_paths"][0]).suffix[1:]
-            assert f"Video: video_{video_type}" in nwbfile.acquisition
+            assert f"Video video_{video_type}" in nwbfile.acquisition
 
     def check_interface_set_aligned_timestamps(self):
         all_unaligned_timestamps = self.interface.get_original_timestamps()

--- a/tests/test_behavior/test_video_interface.py
+++ b/tests/test_behavior/test_video_interface.py
@@ -137,8 +137,8 @@ class TestExternalVideoInterface(TestVideoInterface):
             nwbfile = io.read()
             module = nwbfile.acquisition
             metadata = self.nwb_converter.get_metadata()
-            self.assertListEqual(list1=list(module["Video: test1"].external_file[:]), list2=self.video_files[0:2])
-            self.assertListEqual(list1=list(module["Video: test3"].external_file[:]), list2=[self.video_files[2]])
+            self.assertListEqual(list1=list(module["Video test1"].external_file[:]), list2=self.video_files[0:2])
+            self.assertListEqual(list1=list(module["Video test3"].external_file[:]), list2=[self.video_files[2]])
 
     def test_video_irregular_timestamps(self):
         aligned_timestamps = [np.array([1.0, 2.0, 4.0]), np.array([5.0, 6.0, 7.0])]
@@ -157,7 +157,7 @@ class TestExternalVideoInterface(TestVideoInterface):
         expected_timestamps = timestamps = np.array([1.0, 2.0, 4.0, 55.0, 56.0, 57.0])
         with NWBHDF5IO(path=self.nwbfile_path, mode="r") as io:
             nwbfile = io.read()
-            np.testing.assert_array_equal(expected_timestamps, nwbfile.acquisition["Video: test1"].timestamps[:])
+            np.testing.assert_array_equal(expected_timestamps, nwbfile.acquisition["Video test1"].timestamps[:])
 
     def test_starting_frames_type_error(self):
         timestamps = [np.array([2.2, 2.4, 2.6]), np.array([3.2, 3.4, 3.6])]

--- a/tests/test_on_data/ecephys/test_recording_interfaces.py
+++ b/tests/test_on_data/ecephys/test_recording_interfaces.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from platform import python_version
 from sys import platform
-from typing import Literal
 
 import numpy as np
 import pytest
@@ -16,7 +15,6 @@ from neuroconv.datainterfaces import (
     BiocamRecordingInterface,
     BlackrockRecordingInterface,
     CellExplorerRecordingInterface,
-    EDFRecordingInterface,
     IntanRecordingInterface,
     MaxOneRecordingInterface,
     MCSRawRecordingInterface,
@@ -168,45 +166,49 @@ class TestCellExplorerRecordingInterface(RecordingExtractorInterfaceTestMixin):
                 assert electrode_table_row[key] == value
 
 
-@pytest.mark.skipif(
-    platform == "darwin",
-    reason="Interface unsupported for OSX.",
-)
-class TestEDFRecordingInterface(RecordingExtractorInterfaceTestMixin):
-    data_interface_cls = EDFRecordingInterface
-    interface_kwargs = dict(file_path=str(ECEPHY_DATA_PATH / "edf" / "edf+C.edf"))
-    save_directory = OUTPUT_PATH
+# @pytest.mark.skipif(
+#     platform == "darwin",
+#     reason="Interface unsupported for OSX.",
+# )
+# class TestEDFRecordingInterface(RecordingExtractorInterfaceTestMixin):
+#     data_interface_cls = EDFRecordingInterface
+#     interface_kwargs = dict(file_path=str(ECEPHY_DATA_PATH / "edf" / "edf+C.edf"))
+#     save_directory = OUTPUT_PATH
 
-    def check_extracted_metadata(self, metadata: dict):
-        assert metadata["NWBFile"]["session_start_time"] == datetime(2022, 3, 2, 10, 42, 19)
+#     def check_extracted_metadata(self, metadata: dict):
+#         assert metadata["NWBFile"]["session_start_time"] == datetime(2022, 3, 2, 10, 42, 19)
 
-    def test_interface_alignment(self):
-        interface_kwargs = self.interface_kwargs
+#     def test_interface_alignment(self):
+#         interface_kwargs = self.interface_kwargs
 
-        # TODO - debug hanging I/O from pyedflib
-        # self.check_interface_get_original_timestamps()
-        # self.check_interface_get_timestamps()
-        # self.check_align_starting_time_internal()
-        # self.check_align_starting_time_external()
-        # self.check_interface_align_timestamps()
-        # self.check_shift_timestamps_by_start_time()
-        # self.check_interface_original_timestamps_inmutability()
+#         # TODO - debug hanging I/O from pyedflib
+#         # self.check_interface_get_original_timestamps()
+#         # self.check_interface_get_timestamps()
+#         # self.check_align_starting_time_internal()
+#         # self.check_align_starting_time_external()
+#         # self.check_interface_align_timestamps()
+#         # self.check_shift_timestamps_by_start_time()
+#         # self.check_interface_original_timestamps_inmutability()
 
-        self.check_nwbfile_temporal_alignment()
+#         self.check_nwbfile_temporal_alignment()
 
-    # EDF has simultaneous access issues; can't have multiple interfaces open on the same file at once...
-    def check_run_conversion_in_nwbconverter_with_backend(
-        self, nwbfile_path: str, backend: Literal["hdf5", "zarr"] = "hdf5"
-    ):
-        pass
+#     # EDF has simultaneous access issues; can't have multiple interfaces open on the same file at once...
+#     def check_run_conversion_in_nwbconverter_with_backend(
+#         self, nwbfile_path: str, backend: Literal["hdf5", "zarr"] = "hdf5"
+#     ):
+#         pass
 
-    def check_run_conversion_in_nwbconverter_with_backend_configuration(
-        self, nwbfile_path: str, backend: Literal["hdf5", "zarr"] = "hdf5"
-    ):
-        pass
+#     def check_run_conversion_in_nwbconverter_with_backend_configuration(
+#         self, nwbfile_path: str, backend: Literal["hdf5", "zarr"] = "hdf5"
+#     ):
+#         pass
 
-    def check_run_conversion_with_backend(self, nwbfile_path: str, backend: Literal["hdf5", "zarr"] = "hdf5"):
-        pass
+#     def check_run_conversion_with_backend(self):
+#         pass
+
+
+#     def test_no_metadata_mutation(self):
+#         pass
 
 
 class TestIntanRecordingInterface(RecordingExtractorInterfaceTestMixin):

--- a/tests/test_on_data/ecephys/test_recording_interfaces.py
+++ b/tests/test_on_data/ecephys/test_recording_interfaces.py
@@ -15,6 +15,7 @@ from neuroconv.datainterfaces import (
     BiocamRecordingInterface,
     BlackrockRecordingInterface,
     CellExplorerRecordingInterface,
+    EDFRecordingInterface,
     IntanRecordingInterface,
     MaxOneRecordingInterface,
     MCSRawRecordingInterface,
@@ -166,49 +167,43 @@ class TestCellExplorerRecordingInterface(RecordingExtractorInterfaceTestMixin):
                 assert electrode_table_row[key] == value
 
 
-# @pytest.mark.skipif(
-#     platform == "darwin",
-#     reason="Interface unsupported for OSX.",
-# )
-# class TestEDFRecordingInterface(RecordingExtractorInterfaceTestMixin):
-#     data_interface_cls = EDFRecordingInterface
-#     interface_kwargs = dict(file_path=str(ECEPHY_DATA_PATH / "edf" / "edf+C.edf"))
-#     save_directory = OUTPUT_PATH
+@pytest.mark.skipif(
+    platform == "darwin",
+    reason="Interface unsupported for OSX.",
+)
+class TestEDFRecordingInterface(RecordingExtractorInterfaceTestMixin):
+    data_interface_cls = EDFRecordingInterface
+    interface_kwargs = dict(file_path=str(ECEPHY_DATA_PATH / "edf" / "edf+C.edf"))
+    save_directory = OUTPUT_PATH
 
-#     def check_extracted_metadata(self, metadata: dict):
-#         assert metadata["NWBFile"]["session_start_time"] == datetime(2022, 3, 2, 10, 42, 19)
+    def check_extracted_metadata(self, metadata: dict):
+        assert metadata["NWBFile"]["session_start_time"] == datetime(2022, 3, 2, 10, 42, 19)
 
-#     def test_interface_alignment(self):
-#         interface_kwargs = self.interface_kwargs
+    def test_all_conversion_checks(self, setup_interface, tmp_path):
+        # Create a unique test name and file path
+        nwbfile_path = str(tmp_path / f"{self.__class__.__name__}.nwb")
+        self.nwbfile_path = nwbfile_path
 
-#         # TODO - debug hanging I/O from pyedflib
-#         # self.check_interface_get_original_timestamps()
-#         # self.check_interface_get_timestamps()
-#         # self.check_align_starting_time_internal()
-#         # self.check_align_starting_time_external()
-#         # self.check_interface_align_timestamps()
-#         # self.check_shift_timestamps_by_start_time()
-#         # self.check_interface_original_timestamps_inmutability()
+        # Now run the checks using the setup objects
+        self.check_conversion_options_schema_valid()
+        self.check_metadata()
 
-#         self.check_nwbfile_temporal_alignment()
+        self.check_run_conversion_with_backend(nwbfile_path=nwbfile_path, backend="hdf5")
 
-#     # EDF has simultaneous access issues; can't have multiple interfaces open on the same file at once...
-#     def check_run_conversion_in_nwbconverter_with_backend(
-#         self, nwbfile_path: str, backend: Literal["hdf5", "zarr"] = "hdf5"
-#     ):
-#         pass
+        self.check_read_nwb(nwbfile_path=nwbfile_path)
 
-#     def check_run_conversion_in_nwbconverter_with_backend_configuration(
-#         self, nwbfile_path: str, backend: Literal["hdf5", "zarr"] = "hdf5"
-#     ):
-#         pass
+    # EDF has simultaneous access issues; can't have multiple interfaces open on the same file at once...
+    def test_metadata_schema_valid(self):
+        pass
 
-#     def check_run_conversion_with_backend(self):
-#         pass
+    def test_no_metadata_mutation(self):
+        pass
 
+    def test_run_conversion_with_backend(self):
+        pass
 
-#     def test_no_metadata_mutation(self):
-#         pass
+    def test_interface_alignment(self):
+        pass
 
 
 class TestIntanRecordingInterface(RecordingExtractorInterfaceTestMixin):


### PR DESCRIPTION
This enables zarr testing for running conversions with backend specified as a string (still missing the building a backend configuration part)

It also makes some metadata checks proper tests on their own which has two advantages:
* They will fail on their own and be identified as such by pytest
* Can be parallelized with xdist.
