### PR TITLE
Fix bug in Intan interface where extra device is written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Upcoming
 
+### Bug Fixes
+* Fixed a bug where `IntanRecordingInterface` added two devices [PR #1059](https://github.com/catalystneuro/neuroconv/pull/1059)
+
 ### Deprecations
 * The following classes and objects are now private `NWBMetaDataEncoder`, `NWBMetaDataEncoder`, `check_if_imaging_fits_into_memory`, `NoDatesSafeLoader` [PR #1050](https://github.com/catalystneuro/neuroconv/pull/1050)
 
@@ -10,7 +13,7 @@
 ### Improvements
 * Using ruff to enforce existence of public classes' docstrings [PR #1034](https://github.com/catalystneuro/neuroconv/pull/1034)
 * Separated tests that use external data by modality [PR #1049](https://github.com/catalystneuro/neuroconv/pull/1049)
-
+* Improved device metadata of `IntanRecordingInterface` by adding the type of controller used [PR #1059](https://github.com/catalystneuro/neuroconv/pull/1059)
 
 
 ## v0.6.1 (August 30, 2024)

--- a/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
@@ -46,7 +46,7 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
             check performed is that timestamps are continuous. If False, an error will be raised if the check fails.
         """
 
-        self.file_path = file_path
+        self.file_path = Path(file_path)
 
         init_kwargs = dict(
             file_path=self.file_path,

--- a/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from pydantic import FilePath
 from pynwb.ecephys import ElectricalSeries
 

--- a/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
@@ -1,12 +1,7 @@
-import warnings
-from typing import Optional
-
-from packaging.version import Version
 from pydantic import FilePath
 from pynwb.ecephys import ElectricalSeries
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
-from ....tools import get_package_version
 from ....utils import get_schema_from_hdmf_class
 
 
@@ -31,7 +26,6 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
-        stream_id: Optional[str] = None,
         verbose: bool = True,
         es_key: str = "ElectricalSeries",
         ignore_integrity_checks: bool = False,
@@ -43,8 +37,7 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
         ----------
         file_path : FilePathType
             Path to either a rhd or a rhs file
-        stream_id : str, optional
-            The stream of the data for spikeinterface, "0" by default.
+
         verbose : bool, default: True
             Verbose
         es_key : str, default: "ElectricalSeries"
@@ -53,34 +46,16 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
             check performed is that timestamps are continuous. If False, an error will be raised if the check fails.
         """
 
-        if stream_id is not None:
-            warnings.warn(
-                "Use of the 'stream_id' parameter is deprecated and it will be removed after September 2024.",
-                DeprecationWarning,
-            )
-            self.stream_id = stream_id
-        else:
-            self.stream_id = "0"  # These are the amplifier channels or to the stream_name 'RHD2000 amplifier channel'
+        self.file_path = file_path
 
         init_kwargs = dict(
-            file_path=file_path,
+            file_path=self.file_path,
             stream_id=self.stream_id,
             verbose=verbose,
             es_key=es_key,
             all_annotations=True,
+            ignore_integrity_checks=ignore_integrity_checks,
         )
-
-        neo_version = get_package_version(name="neo")
-        spikeinterface_version = get_package_version(name="spikeinterface")
-        if neo_version < Version("0.13.1") or spikeinterface_version < Version("0.100.10"):
-            if ignore_integrity_checks:
-                warnings.warn(
-                    "The 'ignore_integrity_checks' parameter is not supported for neo versions < 0.13.1. "
-                    "or spikeinterface versions < 0.101.0.",
-                    UserWarning,
-                )
-        else:
-            init_kwargs["ignore_integrity_checks"] = ignore_integrity_checks
 
         super().__init__(**init_kwargs)
 
@@ -96,13 +71,20 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
         ecephys_metadata = metadata["Ecephys"]
 
         # Add device
-        device = dict(
+
+        system = self.file_path.suffix  # .rhd or .rhs
+        device_description = {".rhd": "RHD Recording System", ".rhs": "RHS Stim/Recording System"}[system]
+
+        intan_device = dict(
             name="Intan",
-            description="Intan recording",
+            description=device_description,
             manufacturer="Intan",
         )
-        device_list = [device]
+        device_list = [intan_device]
         ecephys_metadata.update(Device=device_list)
+
+        electrode_group_metadata = ecephys_metadata["ElectrodeGroup"]
+        electrode_group_metadata[0]["device"] = intan_device["name"]
 
         # Add electrodes and electrode groups
         ecephys_metadata.update(

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -177,7 +177,7 @@ def add_electrode_groups_to_nwbfile(recording: BaseRecording, nwbfile: pynwb.NWB
             device_name = group_metadata.get("device", defaults[0]["device"])
             if device_name not in nwbfile.devices:
                 new_device_metadata = dict(Ecephys=dict(Device=[dict(name=device_name)]))
-                add_devices(nwbfile=nwbfile, metadata=new_device_metadata)
+                add_devices_to_nwbfile(nwbfile=nwbfile, metadata=new_device_metadata)
                 warnings.warn(
                     f"Device '{device_name}' not detected in "
                     "attempted link to electrode group! Automatically generating."

--- a/tests/test_on_data/ecephys/test_raw_recordings.py
+++ b/tests/test_on_data/ecephys/test_raw_recordings.py
@@ -10,7 +10,6 @@ from spikeinterface.extractors import NwbRecordingExtractor
 
 from neuroconv import NWBConverter
 from neuroconv.datainterfaces import (
-    IntanRecordingInterface,
     Plexon2RecordingInterface,
 )
 
@@ -48,23 +47,6 @@ class TestEcephysRawRecordingsNwbConversions(unittest.TestCase):
             ),
         ),
     ]
-
-    # Intan multiple files format
-    parameterized_recording_list.append(
-        param(
-            data_interface=IntanRecordingInterface,
-            interface_kwargs=dict(file_path=str(DATA_PATH / "intan" / "intan_fpc_test_231117_052630/info.rhd")),
-            case_name="one-file-per-channel",
-        )
-    )
-
-    parameterized_recording_list.append(
-        param(
-            data_interface=IntanRecordingInterface,
-            interface_kwargs=dict(file_path=str(DATA_PATH / "intan" / "intan_fps_test_231117_052500/info.rhd")),
-            case_name="one-file-per-signal",
-        )
-    )
 
     @parameterized.expand(input=parameterized_recording_list, name_func=custom_name_func)
     def test_recording_extractor_to_nwb(self, data_interface, interface_kwargs, case_name=""):

--- a/tests/test_on_data/ecephys/test_recording_interfaces.py
+++ b/tests/test_on_data/ecephys/test_recording_interfaces.py
@@ -209,17 +209,22 @@ class TestEDFRecordingInterface(RecordingExtractorInterfaceTestMixin):
         pass
 
 
-class TestIntanRecordingInterface(RecordingExtractorInterfaceTestMixin):
+class TestIntanRecordingInterfaceRHS(RecordingExtractorInterfaceTestMixin):
     data_interface_cls = IntanRecordingInterface
-    interface_kwargs = []
+    interface_kwargs = dict(file_path=ECEPHY_DATA_PATH / "intan" / "intan_rhs_test_1.rhs")
+
+
+class TestIntanRecordingInterfaceRHD(RecordingExtractorInterfaceTestMixin):
+    data_interface_cls = IntanRecordingInterface
     save_directory = OUTPUT_PATH
 
     @pytest.fixture(
         params=[
-            dict(file_path=str(ECEPHY_DATA_PATH / "intan" / "intan_rhd_test_1.rhd")),
-            dict(file_path=str(ECEPHY_DATA_PATH / "intan" / "intan_rhs_test_1.rhs")),
+            dict(file_path=ECEPHY_DATA_PATH / "intan" / "intan_rhd_test_1.rhd"),
+            dict(file_path=ECEPHY_DATA_PATH / "intan" / "intan_fpc_test_231117_052630/info.rhd"),
+            dict(file_path=ECEPHY_DATA_PATH / "intan" / "intan_fps_test_231117_052500/info.rhd"),
         ],
-        ids=["rhd", "rhs"],
+        ids=["rhd", "one-file-per-channel", "one-file-per-signal"],
     )
     def setup_interface(self, request):
 
@@ -229,6 +234,18 @@ class TestIntanRecordingInterface(RecordingExtractorInterfaceTestMixin):
         self.interface = self.data_interface_cls(**self.interface_kwargs)
 
         return self.interface, self.test_name
+
+    def test_devices_written_correctly(self, setup_interface):
+
+        from pynwb.testing.mock.file import mock_NWBFile
+
+        nwbfile = mock_NWBFile()
+        self.interface.add_to_nwbfile(nwbfile=nwbfile)
+
+        nwbfile.devices["Intan"].name == "Intan"
+        len(nwbfile.devices) == 1
+
+        nwbfile.devices["Intan"].description == "RHD Recording System"
 
 
 @pytest.mark.skip(reason="This interface fails to load the necessary plugin sometimes.")


### PR DESCRIPTION
Because the metadata in metadata["Ecephys"]["ElectrodeGroups"] contains a contains a reference to a device here:

https://github.com/catalystneuro/neuroconv/blob/675ec48966eab421d25c15cd2ce6041ae6e8b34c/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py#L92-L95

When the code hits these lines another device is created:

https://github.com/catalystneuro/neuroconv/blob/675ec48966eab421d25c15cd2ce6041ae6e8b34c/src/neuroconv/tools/spikeinterface/spikeinterface.py#L175-L184

This resulted in me getting an nwbfile with two devices Intan and the generic one that the default metadata included.

This PR fixes this, I added a test and took the opportunity to move the Intan tests to the new format.

Plus, I made a small improvement to the metadata where the specific controller that was used is indicated as a Device Description:

https://intantech.com/RHD_system.html
https://intantech.com/RHS_system.html

Finally, I also removed a bunch of deprecations whose time has come and logic that was only valid when python-neo version requirement was lower.


