### PR TITLE
Eliminate warning about setting timestamps in the ecephys stream

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -150,7 +150,7 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
             self._number_of_segments == 1
         ), "This recording has multiple segments; please use 'align_segment_timestamps' instead."
 
-        self.recording_extractor.set_times(times=aligned_timestamps)
+        self.recording_extractor.set_times(times=aligned_timestamps, with_warning=False)
 
     def set_aligned_segment_timestamps(self, aligned_segment_timestamps: list[np.ndarray]):
         """
@@ -172,7 +172,9 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
 
         for segment_index in range(self._number_of_segments):
             self.recording_extractor.set_times(
-                times=aligned_segment_timestamps[segment_index], segment_index=segment_index
+                times=aligned_segment_timestamps[segment_index],
+                segment_index=segment_index,
+                with_warning=False,
             )
 
     def set_aligned_starting_time(self, aligned_starting_time: float):
@@ -285,7 +287,11 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
             for segment_index, end_frame in zip(range(number_of_segments), end_frame_list)
         ]
         for segment_index in range(number_of_segments):
-            recording_extractor_stubbed.set_times(times=times_stubbed[segment_index], segment_index=segment_index)
+            recording_extractor_stubbed.set_times(
+                times=times_stubbed[segment_index],
+                segment_index=segment_index,
+                with_warning=False,
+            )
 
         return recording_extractor_stubbed
 

--- a/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
@@ -124,7 +124,7 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
         ), "This recording has multiple segments; please use 'set_aligned_segment_timestamps' instead."
 
         if self._number_of_segments == 1:
-            self.sorting_extractor._recording.set_times(times=aligned_timestamps)
+            self.sorting_extractor._recording.set_times(times=aligned_timestamps, with_warning=False)
         else:
             assert isinstance(
                 aligned_timestamps, list
@@ -135,7 +135,9 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
 
             for segment_index in range(self._number_of_segments):
                 self.sorting_extractor._recording.set_times(
-                    times=aligned_timestamps[segment_index], segment_index=segment_index
+                    times=aligned_timestamps[segment_index],
+                    segment_index=segment_index,
+                    with_warning=False,
                 )
 
     def set_aligned_segment_timestamps(self, aligned_segment_timestamps: list[np.ndarray]):
@@ -164,7 +166,9 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
 
         for segment_index in range(self._number_of_segments):
             self.sorting_extractor._recording.set_times(
-                times=aligned_segment_timestamps[segment_index], segment_index=segment_index
+                times=aligned_segment_timestamps[segment_index],
+                segment_index=segment_index,
+                with_warning=False,
             )
 
     def set_aligned_starting_time(self, aligned_starting_time: float):


### PR DESCRIPTION
This is something that @CodyCBakerPhD requested from me a while ago and I forgot to do.

That warning is meant for people who will use this in preprocessing (and I think it should be triggered in a different place) but this should suppress this uninformative warning in our use case.