### PR TITLE
Make `get_extractor` work with `MockImagingInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Upcoming
 
 ## Bug Fixes
-Fixed a setup bug introduced in `v0.6.2` where installation process created a directory instead of a file for test configuration file  [PR #1070](https://github.com/catalystneuro/neuroconv/pull/1070)
+* Fixed a setup bug introduced in `v0.6.2` where installation process created a directory instead of a file for test configuration file  [PR #1070](https://github.com/catalystneuro/neuroconv/pull/1070)
+* The method `get_extractor` now works for `MockImagingInterface`  [PR #1076](https://github.com/catalystneuro/neuroconv/pull/1076)
 
 ## Deprecations
 

--- a/src/neuroconv/tools/testing/mock_interfaces.py
+++ b/src/neuroconv/tools/testing/mock_interfaces.py
@@ -162,6 +162,9 @@ class MockImagingInterface(BaseImagingExtractorInterface):
     A mock imaging interface for testing purposes.
     """
 
+    ExtractorModuleName = "roiextractors.testing"
+    ExtractorName = "generate_dummy_imaging_extractor"
+
     def __init__(
         self,
         num_frames: int = 30,

--- a/src/neuroconv/tools/testing/mock_interfaces.py
+++ b/src/neuroconv/tools/testing/mock_interfaces.py
@@ -189,8 +189,6 @@ class MockImagingInterface(BaseImagingExtractorInterface):
             The sampling frequency of the mock imaging data in Hz, by default 30.
         dtype : str, optional
             The data type of the generated imaging data (e.g., 'uint16'), by default 'uint16'.
-        verbose : bool, optional
-            If True, prints additional information during processing, by default True.
         seed : int, optional
             Random seed for reproducibility, by default 0.
         photon_series_type : Literal["OnePhotonSeries", "TwoPhotonSeries"], optional

--- a/src/neuroconv/tools/testing/mock_interfaces.py
+++ b/src/neuroconv/tools/testing/mock_interfaces.py
@@ -172,17 +172,42 @@ class MockImagingInterface(BaseImagingExtractorInterface):
         num_columns: int = 10,
         sampling_frequency: float = 30,
         dtype: str = "uint16",
-        verbose: bool = True,
+        verbose: bool = False,
+        seed: int = 0,
         photon_series_type: Literal["OnePhotonSeries", "TwoPhotonSeries"] = "TwoPhotonSeries",
     ):
-        from roiextractors.testing import generate_dummy_imaging_extractor
+        """
+        Parameters
+        ----------
+        num_frames : int, optional
+            The number of frames in the mock imaging data, by default 30.
+        num_rows : int, optional
+            The number of rows (height) in each frame of the mock imaging data, by default 10.
+        num_columns : int, optional
+            The number of columns (width) in each frame of the mock imaging data, by default 10.
+        sampling_frequency : float, optional
+            The sampling frequency of the mock imaging data in Hz, by default 30.
+        dtype : str, optional
+            The data type of the generated imaging data (e.g., 'uint16'), by default 'uint16'.
+        verbose : bool, optional
+            If True, prints additional information during processing, by default True.
+        seed : int, optional
+            Random seed for reproducibility, by default 0.
+        photon_series_type : Literal["OnePhotonSeries", "TwoPhotonSeries"], optional
+            The type of photon series for the mock imaging data, either "OnePhotonSeries" or
+            "TwoPhotonSeries", by default "TwoPhotonSeries".
+        verbose : bool, default False
+            controls verbosity
+        """
 
-        self.imaging_extractor = generate_dummy_imaging_extractor(
+        self.seed = seed
+        super().__init__(
             num_frames=num_frames,
             num_rows=num_rows,
             num_columns=num_columns,
             sampling_frequency=sampling_frequency,
             dtype=dtype,
+            verbose=verbose,
         )
 
         self.verbose = verbose

--- a/tests/test_ophys/test_ophys_interfaces.py
+++ b/tests/test_ophys/test_ophys_interfaces.py
@@ -1,22 +1,9 @@
-import tempfile
-import unittest
-from pathlib import Path
-
-from pynwb.testing.mock.file import mock_NWBFile
-
+from neuroconv.tools.testing.data_interface_mixins import (
+    ImagingExtractorInterfaceTestMixin,
+)
 from neuroconv.tools.testing.mock_interfaces import MockImagingInterface
 
 
-class TestMockImagingInterface(unittest.TestCase):
-    def setUp(self):
-        self.mock_imaging_interface = MockImagingInterface()
-
-    def test_run_conversion(self):
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            nwbfile_path = Path(tmpdir) / "test.nwb"
-            self.mock_imaging_interface.run_conversion(nwbfile_path=nwbfile_path)
-
-    def test_add_to_nwbfile(self):
-        nwbfile = mock_NWBFile()
-        self.mock_imaging_interface.add_to_nwbfile(nwbfile)
+class TestMockImagingInterface(ImagingExtractorInterfaceTestMixin):
+    data_interface_cls = MockImagingInterface
+    interface_kwargs = dict()


### PR DESCRIPTION
These changes are necessary so the `get_extractor` method works with ` MockImagingInterface`

https://github.com/catalystneuro/neuroconv/blob/9a886587aece41b3be0c5951b2d6ed54ece83304/src/neuroconv/baseextractorinterface.py#L21-L31