### PR TITLE
Github CI only run doctests when tests are not run

### DIFF
--- a/.github/workflows/assess-file-changes.yml
+++ b/.github/workflows/assess-file-changes.yml
@@ -41,7 +41,7 @@ jobs:
           echo "CHANGELOG_UPDATED=false" >> $GITHUB_OUTPUT
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             echo $file
-            if [[ $file == "src/"* || $file == "tests/"* || $file == "requirements-minimal.txt" || $file == "requirements-testing.txt" || $file == "setup.py" || $file == ".github/"* ]]
+            if [[ $file == "src/"* || $file == "tests/"* || $file == "pyproject.toml"   || $file == "setup.py" || $file == ".github/"* ]]
             then
               echo "Source changed"
               echo "SOURCE_CHANGED=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -57,7 +57,7 @@ jobs:
 
   run-doctests-only:
     needs: assess-file-changes
-    if: ${{ needs.assess-file-changes.outputs.CONVERSION_GALLERY_CHANGED == 'true' || needs.assess-file-changes.outputs.SOURCE_CHANGED != 'true' }}
+    if: ${{ needs.assess-file-changes.outputs.CONVERSION_GALLERY_CHANGED == 'true' && needs.assess-file-changes.outputs.SOURCE_CHANGED != 'true' }}
     uses: ./.github/workflows/doctests.yml
 
   check-final-status:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Upcoming
 
 ## Bug Fixes
-Fixed a setup bug introduced in `v0.6.2` where installation process created a directory instead of a file for test configuration file  [PR #1070](https://github.com/catalystneuro/neuroconv/pull/1070)
+* Fixed a setup bug introduced in `v0.6.2` where installation process created a directory instead of a file for test configuration file [PR #1070](https://github.com/catalystneuro/neuroconv/pull/1070)
 
 ## Deprecations
 
 ## Features
 
 ## Improvements
+* Modified the CI to avoid running doctests twice [PR #1077](https://github.com/catalystneuro/neuroconv/pull/#1077)
 
 
 

--- a/docs/conversion_examples_gallery/conftest.py
+++ b/docs/conversion_examples_gallery/conftest.py
@@ -17,5 +17,5 @@ def add_data_space(doctest_namespace, tmp_path):
     doctest_namespace["OPHYS_DATA_PATH"] = OPHYS_DATA_PATH
     doctest_namespace["TEXT_DATA_PATH"] = TEXT_DATA_PATH
 
-    doctest_namespace["path_to_save_nwbfile"] = Path(tmp_path) / "file.nwb"
+    doctest_namespace["path_to_save_nwbfile"] = Path(tmp_path) / "doctest_file.nwb"
     doctest_namespace["output_folder"] = Path(tmp_path)


### PR DESCRIPTION
The full tests also run the doctests so the "doctest only" workflow should only run when the normal tests are not running.