### PR TITLE
Only run changelog request when status is not draft

### DIFF
--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
   detect-changelog-updates:
     needs: assess-file-changes
-    if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' && github.event.pull_request.draft == 'false' }}
+    if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' && github.event.pull_request.draft == false }}
     name: Auto-detecting CHANGELOG.md updates
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -2,6 +2,7 @@ name: Deploy tests
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
   merge_group:
   workflow_dispatch:
 
@@ -16,7 +17,7 @@ jobs:
 
   detect-changelog-updates:
     needs: assess-file-changes
-    if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' }}
+    if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' && github.event.pull_request.draft == 'false' }}
     name: Auto-detecting CHANGELOG.md updates
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -2,7 +2,7 @@ name: Deploy tests
 
 on:
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
+    types: [synchronize, opened, reopened, ready_for_review] # defaults + ready_for_review
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
As in the title. 

@pauladkisson Here the idea is that the changelog check is only enforced when someone marks the PR as ready for review and from then onwards. This achieves the following which I find desirable:

* The PR should not be marked immediately as a failure as it is now when is on draft.
* PRs also change when they are in draft and the right point to write a changelog is when the PR is ready for review.
* It will save runners on the CI and currently, we are getting too little on them and waiting too long on our workflows.