### PR TITLE
Use a github action to centralize gin data preparation

### DIFF
--- a/.github/actions/load-data/action.yml
+++ b/.github/actions/load-data/action.yml
@@ -1,5 +1,5 @@
 name: 'Prepare Datasets'
-description: 'Restores data form caches or downloads it from S3.'
+description: 'Restores data from caches or downloads it from S3.'
 inputs:
   aws-access-key-id:
     description: 'AWS Access Key ID'
@@ -60,6 +60,7 @@ runs:
 
     - name: Determine if downloads are required
       id: download-check
+      shell: bash  # Added shell property
       run: |
         if [[ "${{ steps.cache-ephys-datasets.outputs.cache-hit }}" != 'true' || \
               "${{ steps.cache-ophys-datasets.outputs.cache-hit }}" != 'true' || \

--- a/.github/actions/load-data/action.yml
+++ b/.github/actions/load-data/action.yml
@@ -1,0 +1,96 @@
+name: 'Prepare Datasets'
+description: 'Restores data form caches or downloads it from S3.'
+inputs:
+  aws-access-key-id:
+    description: 'AWS Access Key ID'
+    required: true
+  aws-secret-access-key:
+    description: 'AWS Secret Access Key'
+    required: true
+  s3-gin-bucket:
+    description: 'S3 GIN Bucket URL'
+    required: true
+  os:
+    description: 'Operating system'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Get ephy_testing_data current head hash
+      id: ephys
+      shell: bash
+      run: |
+        HASH=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)
+        echo "HASH_EPHY_DATASET=$HASH" >> $GITHUB_OUTPUT
+
+    - name: Cache ephys dataset
+      uses: actions/cache@v4
+      id: cache-ephys-datasets
+      with:
+        path: ./ephy_testing_data
+        key: ephys-datasets-${{ inputs.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
+
+    - name: Get ophys_testing_data current head hash
+      id: ophys
+      shell: bash
+      run: |
+        HASH=$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)
+        echo "HASH_OPHYS_DATASET=$HASH" >> $GITHUB_OUTPUT
+
+    - name: Cache ophys dataset
+      uses: actions/cache@v4
+      id: cache-ophys-datasets
+      with:
+        path: ./ophys_testing_data
+        key: ophys-datasets-${{ inputs.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
+
+    - name: Get behavior_testing_data current head hash
+      id: behavior
+      shell: bash
+      run: |
+        HASH=$(git ls-remote https://gin.g-node.org/CatalystNeuro/behavior_testing_data.git HEAD | cut -f1)
+        echo "HASH_BEHAVIOR_DATASET=$HASH" >> $GITHUB_OUTPUT
+
+    - name: Cache behavior dataset
+      uses: actions/cache@v4
+      id: cache-behavior-datasets
+      with:
+        path: ./behavior_testing_data
+        key: behavior-datasets-${{ inputs.os }}-${{ steps.behavior.outputs.HASH_BEHAVIOR_DATASET }}
+
+    - name: Determine if downloads are required
+      id: download-check
+      run: |
+        if [[ "${{ steps.cache-ephys-datasets.outputs.cache-hit }}" != 'true' || \
+              "${{ steps.cache-ophys-datasets.outputs.cache-hit }}" != 'true' || \
+              "${{ steps.cache-behavior-datasets.outputs.cache-hit }}" != 'true' ]]; then
+          echo "DOWNLOAD_REQUIRED=true" >> $GITHUB_OUTPUT
+        else
+          echo "DOWNLOAD_REQUIRED=false" >> $GITHUB_OUTPUT
+        fi
+
+    - if: ${{ steps.download-check.outputs.DOWNLOAD_REQUIRED == 'true' }}
+      name: Install and configure AWS CLI
+      shell: bash
+      run: |
+        pip install awscli
+        aws configure set aws_access_key_id "${{ inputs.aws-access-key-id }}"
+        aws configure set aws_secret_access_key "${{ inputs.aws-secret-access-key }}"
+
+    - if: ${{ steps.cache-ephys-datasets.outputs.cache-hit != 'true' }}
+      name: Download ephys dataset from S3
+      shell: bash
+      run: |
+        aws s3 cp --recursive "${{ inputs.s3-gin-bucket }}/ephy_testing_data" ./ephy_testing_data
+
+    - if: ${{ steps.cache-ophys-datasets.outputs.cache-hit != 'true' }}
+      name: Download ophys dataset from S3
+      shell: bash
+      run: |
+        aws s3 cp --recursive "${{ inputs.s3-gin-bucket }}/ophys_testing_data" ./ophys_testing_data
+
+    - if: ${{ steps.cache-behavior-datasets.outputs.cache-hit != 'true' }}
+      name: Download behavior dataset from S3
+      shell: bash
+      run: |
+        aws s3 cp --recursive "${{ inputs.s3-gin-bucket }}/behavior_testing_data" ./behavior_testing_data

--- a/.github/workflows/dev-testing.yml
+++ b/.github/workflows/dev-testing.yml
@@ -72,52 +72,13 @@ jobs:
         run: |
           pip list
 
-      - name: Get ephy_testing_data current head hash
-        id: ephys
-        run: echo "::set-output name=HASH_EPHY_DATASET::$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"
-      - name: Cache ephys dataset - ${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
-        uses: actions/cache@v4
-        id: cache-ephys-datasets
+      - name: Prepare data for tests
+        uses: ./.github/actions/load-data
         with:
-          path: ./ephy_testing_data
-          key: ephys-datasets-2024-08-30-ubuntu-latest-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
-      - name: Get ophys_testing_data current head hash
-        id: ophys
-        run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"
-      - name: Cache ophys dataset - ${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
-        uses: actions/cache@v4
-        id: cache-ophys-datasets
-        with:
-          path: ./ophys_testing_data
-          key: ophys-datasets-2022-08-18-ubuntu-latest-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
-      - name: Get behavior_testing_data current head hash
-        id: behavior
-        run: echo "::set-output name=HASH_BEHAVIOR_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/behavior_testing_data.git HEAD | cut -f1)"
-      - name: Cache behavior dataset - ${{ steps.behavior.outputs.HASH_BEHAVIOR_DATASET }}
-        uses: actions/cache@v4
-        id: cache-behavior-datasets
-        with:
-          path: ./behavior_testing_data
-          key: behavior-datasets-2023-07-26-ubuntu-latest-${{ steps.behavior.outputs.HASH_behavior_DATASET }}
-
-
-
-      - if: steps.cache-ephys-datasets.outputs.cache-hit != 'true' || steps.cache-ophys-datasets.outputs.cache-hit != 'true' || steps.cache-behavior-datasets.outputs.cache-hit != 'true'
-        name: Install and configure AWS CLI
-        run: |
-          pip install awscli
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - if: steps.cache-ephys-datasets.outputs.cache-hit != 'true'
-        name: Download ephys dataset from S3
-        run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data ./ephy_testing_data
-      - if: steps.cache-ophys-datasets.outputs.cache-hit != 'true'
-        name: Download ophys dataset from S3
-        run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/ophys_testing_data ./ophys_testing_data
-      - if: steps.cache-behavior-datasets.outputs.cache-hit != 'true'
-        name: Download behavior dataset from S3
-        run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data ./behavior_testing_data
-
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          s3-gin-bucket: ${{ secrets.S3_GIN_BUCKET }}
+          os: ${{ matrix.os }}
 
 
       - name: Run full pytest

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -46,34 +46,13 @@ jobs:
         with:
           os: ${{ runner.os }}
 
-      - name: Get ephy_testing_data current head hash
-        id: ephys
-        run: echo "::set-output name=HASH_EPHY_DATASET::$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"
-      - name: Cache ephys dataset - ${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
-        uses: actions/cache@v4
-        id: cache-ephys-datasets
+      - name: Prepare data for tests
+        uses: ./.github/actions/load-data
         with:
-          path: ./ephy_testing_data
-          key: ephys-datasets-2024-08-30-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
-      - name: Get ophys_testing_data current head hash
-        id: ophys
-        run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"
-      - name: Cache ophys dataset - ${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
-        uses: actions/cache@v4
-        id: cache-ophys-datasets
-        with:
-          path: ./ophys_testing_data
-          key: ophys-datasets-2022-08-18-${{ matrix.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
-      - name: Get behavior_testing_data current head hash
-        id: behavior
-        run: echo "::set-output name=HASH_BEHAVIOR_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/behavior_testing_data.git HEAD | cut -f1)"
-      - name: Cache behavior dataset - ${{ steps.behavior.outputs.HASH_BEHAVIOR_DATASET }}
-        uses: actions/cache@v4
-        id: cache-behavior-datasets
-        with:
-          path: ./behavior_testing_data
-          key: behavior-datasets-2023-07-26-${{ matrix.os }}-${{ steps.behavior.outputs.HASH_behavior_DATASET }}
-
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          s3-gin-bucket: ${{ secrets.S3_GIN_BUCKET }}
+          os: ${{ matrix.os }}
 
 
       - name: Run doctests

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -93,54 +93,16 @@ jobs:
       #- name: Run icephys tests  # There are no icephys specific tests without data
       #  run: pytest tests/test_icephys -rsx -n auto --dist loadscope
 
+      - name: Prepare data for tests
+        uses: ./.github/actions/load-data
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          s3-gin-bucket: ${{ secrets.S3_GIN_BUCKET }}
+          os: ${{ matrix.os }}
+
       - name: Install full requirements
         run: pip install .[full]
-
-      - name: Get ephy_testing_data current head hash
-        id: ephys
-        run: echo "::set-output name=HASH_EPHY_DATASET::$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"
-      - name: Cache ephys dataset - ${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
-        uses: actions/cache@v4
-        id: cache-ephys-datasets
-        with:
-          path: ./ephy_testing_data
-          key: ephys-datasets-2024-08-30-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
-      - name: Get ophys_testing_data current head hash
-        id: ophys
-        run: echo "::set-output name=HASH_OPHYS_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)"
-      - name: Cache ophys dataset - ${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
-        uses: actions/cache@v4
-        id: cache-ophys-datasets
-        with:
-          path: ./ophys_testing_data
-          key: ophys-datasets-2022-08-18-${{ matrix.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
-      - name: Get behavior_testing_data current head hash
-        id: behavior
-        run: echo "::set-output name=HASH_BEHAVIOR_DATASET::$(git ls-remote https://gin.g-node.org/CatalystNeuro/behavior_testing_data.git HEAD | cut -f1)"
-      - name: Cache behavior dataset - ${{ steps.behavior.outputs.HASH_BEHAVIOR_DATASET }}
-        uses: actions/cache@v4
-        id: cache-behavior-datasets
-        with:
-          path: ./behavior_testing_data
-          key: behavior-datasets-2023-07-26-${{ matrix.os }}-${{ steps.behavior.outputs.HASH_behavior_DATASET }}
-
-
-
-      - if: steps.cache-ephys-datasets.outputs.cache-hit != 'true' || steps.cache-ophys-datasets.outputs.cache-hit != 'true' || steps.cache-behavior-datasets.outputs.cache-hit != 'true'
-        name: Install and configure AWS CLI
-        run: |
-          pip install awscli
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - if: steps.cache-ephys-datasets.outputs.cache-hit != 'true'
-        name: Download ephys dataset from S3
-        run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data ./ephy_testing_data
-      - if: steps.cache-ophys-datasets.outputs.cache-hit != 'true'
-        name: Download ophys dataset from S3
-        run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/ophys_testing_data ./ophys_testing_data
-      - if: steps.cache-behavior-datasets.outputs.cache-hit != 'true'
-        name: Download behavior dataset from S3
-        run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data ./behavior_testing_data
 
       - name: Run full pytest with coverage
         run: pytest -vv -rsx -n auto --dist loadscope --cov=neuroconv --cov-report xml:./codecov.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ## Improvements
 * Run only the most basic testing while a PR is on draft  [PR #1082](https://github.com/catalystneuro/neuroconv/pull/1082)
 * Avoid running link test when the PR is on draft  [PR #1093](https://github.com/catalystneuro/neuroconv/pull/1093)
-
+* Centralize gin data preparation in a github action  [PR #1095](https://github.com/catalystneuro/neuroconv/pull/1095)
 
 # v0.6.4 (September 17, 2024)
 


### PR DESCRIPTION
While working on  #1013 I was having trouble getting the data right from the caches (see the diff in that PR). Centralizing the logic should make this kind of problem easier to deal with.

This is a partial move in the direction of #993.
