### PR TITLE
[Do not merge] Strange bug in MockImagingInterface

### DIFF
--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -232,9 +232,9 @@ class DataInterfaceTestMixin:
         self.check_metadata()
 
         self.check_run_conversion_in_nwbconverter_with_backend(nwbfile_path=nwbfile_path, backend="hdf5")
-        self.check_run_conversion_in_nwbconverter_with_backend_configuration(nwbfile_path=nwbfile_path, backend="hdf5")
 
         self.check_run_conversion_with_backend_configuration(nwbfile_path=nwbfile_path, backend="hdf5")
+        self.check_run_conversion_in_nwbconverter_with_backend_configuration(nwbfile_path=nwbfile_path, backend="hdf5")
 
         self.check_read_nwb(nwbfile_path=nwbfile_path)
 


### PR DESCRIPTION
Writing with converter instead of with interface makes this test fail.  Discovered while working on :

https://github.com/catalystneuro/neuroconv/pull/1094

Probably related to the lack of seed here:
https://github.com/catalystneuro/roiextractors/pull/362

