### PR TITLE
Add skip channels to EDF interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Features
 * Using in-house `GenericDataChunkIterator` [PR #1068](https://github.com/catalystneuro/neuroconv/pull/1068)
 * Data interfaces now perform source (argument inputs) validation with the json schema  [PR #1020](https://github.com/catalystneuro/neuroconv/pull/1020)
+* Added `channels_to_skip` to `EDFRecordingInterface` so the user can skip non-neural channels [PR #1110](https://github.com/catalystneuro/neuroconv/pull/1110)
 
 ## Improvements
 * Remove dev test from PR  [PR #1092](https://github.com/catalystneuro/neuroconv/pull/1092)

--- a/src/neuroconv/datainterfaces/ecephys/edf/edfdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/edf/edfdatainterface.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import FilePath
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
@@ -23,7 +25,22 @@ class EDFRecordingInterface(BaseRecordingExtractorInterface):
         source_schema["properties"]["file_path"]["description"] = "Path to the .edf file."
         return source_schema
 
-    def __init__(self, file_path: FilePath, verbose: bool = True, es_key: str = "ElectricalSeries"):
+    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
+
+        extractor_kwargs = source_data.copy()
+        extractor_kwargs.pop("channels_to_skip")
+        extractor_kwargs["all_annotations"] = True
+        extractor_kwargs["use_names_as_ids"] = True
+
+        return extractor_kwargs
+
+    def __init__(
+        self,
+        file_path: FilePath,
+        verbose: bool = True,
+        es_key: str = "ElectricalSeries",
+        channels_to_skip: Optional[list] = None,
+    ):
         """
         Load and prepare data for EDF.
         Currently, only continuous EDF+ files (EDF+C) and original EDF files (EDF) are supported
@@ -36,14 +53,23 @@ class EDFRecordingInterface(BaseRecordingExtractorInterface):
         verbose : bool, default: True
             Allows verbose.
         es_key : str, default: "ElectricalSeries"
+            Key for the ElectricalSeries metadata
+        channels_to_skip : list, default: None
+            Channels to skip when adding the data to the nwbfile. These parameter can be used to skip non-neural
+            channels that are present in the EDF file.
+
         """
         get_package(
             package_name="pyedflib",
-            excluded_platforms_and_python_versions=dict(darwin=dict(arm=["3.8", "3.9"])),
+            excluded_platforms_and_python_versions=dict(darwin=dict(arm=["3.9"])),
         )
 
-        super().__init__(file_path=file_path, verbose=verbose, es_key=es_key)
+        super().__init__(file_path=file_path, verbose=verbose, es_key=es_key, channels_to_skip=channels_to_skip)
         self.edf_header = self.recording_extractor.neo_reader.edf_header
+
+        # We remove the channels that are not neural
+        if channels_to_skip:
+            self.recording_extractor = self.recording_extractor.remove_channels(remove_channel_ids=channels_to_skip)
 
     def extract_nwb_file_metadata(self) -> dict:
         nwbfile_metadata = dict(


### PR DESCRIPTION
Related to #1106

This adds the user to the possibility of skipping non-neural channels on the EDF interface.

Some relevant comments:
* Can't add testing right now. The EDF by neo is blocked when reading the format. That means that it does not work well with the parallel machinery that we have in pytest. I have been meaning to fix this on the neo level or add a hack to our pytest machinery but other priorities come first (see https://github.com/NeuralEnsemble/python-neo/issues/1557).
* Up for debate on how to expose the available channels so the user can pick for them. Ideally, this should be a static or class method but then because of the blocking problem described in the previous point this will not work in a script (getting the channel names requires opening the file). Maybe this is simpler to fix at the neo level by providing a method to closing the objects but I did not want that to get in the way.
* I will open another PR to improve the friendliness of the error for multiple offsets. (Done here https://github.com/catalystneuro/neuroconv/pull/1111)
