### PR TITLE
Add more friendly error when writing recording with multiple offsets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 
 -   repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
     -   id: black
         exclude: ^docs/
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.5
+  rev: v0.6.9
   hooks:
   - id: ruff
     args: [ --fix ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Features
 * Using in-house `GenericDataChunkIterator` [PR #1068](https://github.com/catalystneuro/neuroconv/pull/1068)
 * Data interfaces now perform source (argument inputs) validation with the json schema  [PR #1020](https://github.com/catalystneuro/neuroconv/pull/1020)
+* Improve the error message when writing a recording extractor with multiple offsets [PR #1101](https://github.com/catalystneuro/neuroconv/pull/1101)
 
 ## Improvements
 * Remove dev test from PR  [PR #1092](https://github.com/catalystneuro/neuroconv/pull/1092)

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -99,7 +99,8 @@ def add_devices_to_nwbfile(nwbfile: pynwb.NWBFile, metadata: Optional[DeepDict] 
         metadata["Ecephys"]["Device"] = [defaults]
     for device_metadata in metadata["Ecephys"]["Device"]:
         if device_metadata.get("name", defaults["name"]) not in nwbfile.devices:
-            nwbfile.create_device(**dict(defaults, **device_metadata))
+            device_kwargs = dict(defaults, **device_metadata)
+            nwbfile.create_device(**device_kwargs)
 
 
 def add_electrode_groups(recording: BaseRecording, nwbfile: pynwb.NWBFile, metadata: dict = None):

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -778,21 +778,14 @@ def add_electrical_series(
     )
 
 
-def _report_variable_offset(channel_offset, channel_ids):
+def _report_variable_offset(channel_offsets, channel_ids):
     """
     Helper function to report variable offsets per channel IDs.
     Groups the different available offsets per channel IDs and raises a ValueError.
-
-    Parameters:
-    - channel_offset: array-like of channel offsets
-    - channel_ids: array-like of channel IDs
-
-    Raises:
-    - ValueError: if multiple offsets are found
     """
     # Group the different offsets per channel IDs
     offset_to_channel_ids = {}
-    for offset, channel_id in zip(channel_offset, channel_ids):
+    for offset, channel_id in zip(channel_offsets, channel_ids):
         if offset not in offset_to_channel_ids:
             offset_to_channel_ids[offset] = []
         offset_to_channel_ids[offset].append(channel_id)
@@ -934,17 +927,16 @@ def add_electrical_series_to_nwbfile(
     # Spikeinterface guarantees data in micro volts when return_scaled=True. This multiplies by gain and adds offsets
     # In nwb to get traces in Volts we take data*channel_conversion*conversion + offset
     channel_conversion = recording.get_channel_gains()
-    channel_offset = recording.get_channel_offsets()
+    channel_offsets = recording.get_channel_offsets()
 
     unique_channel_conversion = np.unique(channel_conversion)
     unique_channel_conversion = unique_channel_conversion[0] if len(unique_channel_conversion) == 1 else None
 
-    unique_offset = np.unique(channel_offset)
+    unique_offset = np.unique(channel_offsets)
     if unique_offset.size > 1:
         channel_ids = recording.get_channel_ids()
-        # This prints a friendly error where the user is provided with a map from offset to channels
-        _report_variable_offset(channel_offset, channel_ids)
-        raise ValueError("Recording extractors with heterogeneous offsets are not supported")
+        # This prints a user friendly error where the user is provided with a map from offset to channels
+        _report_variable_offset(channel_offsets, channel_ids)
     unique_offset = unique_offset[0] if unique_offset[0] is not None else 0
 
     micro_to_volts_conversion_factor = 1e-6


### PR DESCRIPTION
Related to https://github.com/catalystneuro/neuroconv/issues/1106.

This produces error that look like this which should offer better diagnosis to users on which channels are the source of heterogeneity:

```
        "Recording extractors with heterogeneous offsets are not supported.",
        "Multiple offsets were found per channel IDs:",
        "  Offset 0: Channel IDs ['a', 'b']",
        "  Offset 1: Channel IDs ['c', 'd']",
        "  Offset 2: Channel IDs ['e']",
```