### PR TITLE
Live service test to only use oldest and latest for PR CI

### DIFF
--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -60,7 +60,7 @@ jobs:
     secrets:
       DANDI_API_KEY: ${{ secrets.DANDI_API_KEY }}
     with:  #  Ternary operator: condition && value_if_true || value_if_false
-      python-versions: ${{ github.event.pull_request.draft == true && '["3.9"]' || '["3.9", "3.10", "3.11", "3.12"]' }}
+      python-versions: ${{ github.event.pull_request.draft == true && '["3.9"]' || '["3.9", "3.12"]' }}
       os-versions: ${{ github.event.pull_request.draft == true && '["ubuntu-latest"]' || '["ubuntu-latest", "macos-latest", "macos-13", "windows-latest"]' }}
 
 


### PR DESCRIPTION
Follow up on this:
https://github.com/catalystneuro/neuroconv/pull/1082#discussion_r1759632013

I think there are still situations where we want to test live srivces on the PR (something changing something related to them) so I am just reducing here here to oldest and latest.