### PR TITLE
Change deprecated `get_schema_from_method_signature` to `get_json_schema_from_method_signature`

### DIFF
--- a/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposeconverter.py
+++ b/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposeconverter.py
@@ -10,7 +10,7 @@ from neuroconv.tools.nwb_helpers import make_or_load_nwbfile
 from neuroconv.utils import (
     DeepDict,
     dict_deep_update,
-    get_schema_from_method_signature,
+    get_json_schema_from_method_signature,
 )
 
 
@@ -24,7 +24,7 @@ class LightningPoseConverter(NWBConverter):
 
     @classmethod
     def get_source_schema(cls):
-        return get_schema_from_method_signature(cls)
+        return get_json_schema_from_method_signature(cls)
 
     @validate_call
     def __init__(
@@ -71,7 +71,7 @@ class LightningPoseConverter(NWBConverter):
             self.data_interface_objects.update(dict(LabeledVideo=VideoInterface(file_paths=[labeled_video_file_path])))
 
     def get_conversion_options_schema(self) -> dict:
-        conversion_options_schema = get_schema_from_method_signature(
+        conversion_options_schema = get_json_schema_from_method_signature(
             method=self.add_to_nwbfile, exclude=["nwbfile", "metadata"]
         )
 

--- a/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
@@ -12,7 +12,7 @@ from ..baselfpextractorinterface import BaseLFPExtractorInterface
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ....basedatainterface import BaseDataInterface
 from ....tools.nwb_helpers import get_module
-from ....utils import get_schema_from_method_signature
+from ....utils import get_json_schema_from_method_signature
 
 
 class AxonaRecordingInterface(BaseRecordingExtractorInterface):
@@ -186,7 +186,7 @@ class AxonaPositionDataInterface(BaseDataInterface):
 
     @classmethod
     def get_source_schema(cls) -> dict:
-        return get_schema_from_method_signature(cls.__init__)
+        return get_json_schema_from_method_signature(cls.__init__)
 
     def __init__(self, file_path: str):
         """

--- a/src/neuroconv/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -6,7 +6,7 @@ from pydantic import FilePath
 from .header_tools import _parse_nev_basic_header, _parse_nsx_basic_header
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
-from ....utils import get_schema_from_method_signature
+from ....utils import get_json_schema_from_method_signature
 
 
 class BlackrockRecordingInterface(BaseRecordingExtractorInterface):
@@ -19,7 +19,7 @@ class BlackrockRecordingInterface(BaseRecordingExtractorInterface):
 
     @classmethod
     def get_source_schema(cls):
-        source_schema = get_schema_from_method_signature(method=cls.__init__, exclude=["block_index", "seg_index"])
+        source_schema = get_json_schema_from_method_signature(method=cls.__init__, exclude=["block_index", "seg_index"])
         source_schema["properties"]["file_path"][
             "description"
         ] = "Path to the Blackrock file with suffix being .ns1, .ns2, .ns3, .ns4m .ns4, or .ns6."
@@ -85,7 +85,7 @@ class BlackrockSortingInterface(BaseSortingExtractorInterface):
 
     @classmethod
     def get_source_schema(cls) -> dict:
-        metadata_schema = get_schema_from_method_signature(method=cls.__init__)
+        metadata_schema = get_json_schema_from_method_signature(method=cls.__init__)
         metadata_schema["additionalProperties"] = True
         metadata_schema["properties"]["file_path"].update(description="Path to Blackrock .nev file.")
         return metadata_schema

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
@@ -3,7 +3,7 @@ from typing import Optional
 from pydantic import DirectoryPath
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
-from ....utils import get_schema_from_method_signature
+from ....utils import get_json_schema_from_method_signature
 
 
 class OpenEphysBinaryRecordingInterface(BaseRecordingExtractorInterface):
@@ -29,7 +29,7 @@ class OpenEphysBinaryRecordingInterface(BaseRecordingExtractorInterface):
     @classmethod
     def get_source_schema(cls) -> dict:
         """Compile input schema for the RecordingExtractor."""
-        source_schema = get_schema_from_method_signature(
+        source_schema = get_json_schema_from_method_signature(
             method=cls.__init__, exclude=["recording_id", "experiment_id", "stub_test"]
         )
         source_schema["properties"]["folder_path"][

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephyssortingdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephyssortingdatainterface.py
@@ -1,7 +1,7 @@
 from pydantic import DirectoryPath, validate_call
 
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
-from ....utils import get_schema_from_method_signature
+from ....utils import get_json_schema_from_method_signature
 
 
 class OpenEphysSortingInterface(BaseSortingExtractorInterface):
@@ -14,7 +14,7 @@ class OpenEphysSortingInterface(BaseSortingExtractorInterface):
     @classmethod
     def get_source_schema(cls) -> dict:
         """Compile input schema for the SortingExtractor."""
-        metadata_schema = get_schema_from_method_signature(
+        metadata_schema = get_json_schema_from_method_signature(
             method=cls.__init__, exclude=["recording_id", "experiment_id"]
         )
         metadata_schema["properties"]["folder_path"].update(

--- a/src/neuroconv/datainterfaces/ecephys/spike2/spike2datainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spike2/spike2datainterface.py
@@ -4,7 +4,7 @@ from pydantic import FilePath, validate_call
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ....tools import get_package
-from ....utils import get_schema_from_method_signature
+from ....utils import get_json_schema_from_method_signature
 
 
 def _test_sonpy_installation() -> None:
@@ -29,7 +29,7 @@ class Spike2RecordingInterface(BaseRecordingExtractorInterface):
 
     @classmethod
     def get_source_schema(cls) -> dict:
-        source_schema = get_schema_from_method_signature(method=cls.__init__, exclude=["smrx_channel_ids"])
+        source_schema = get_json_schema_from_method_signature(method=cls.__init__, exclude=["smrx_channel_ids"])
         source_schema.update(additionalProperties=True)
         source_schema["properties"]["file_path"].update(description="Path to .smrx file.")
         return source_schema

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxconverter.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxconverter.py
@@ -6,7 +6,7 @@ from pydantic import DirectoryPath, validate_call
 from .spikeglxdatainterface import SpikeGLXRecordingInterface
 from .spikeglxnidqinterface import SpikeGLXNIDQInterface
 from ....nwbconverter import ConverterPipe
-from ....utils import get_schema_from_method_signature
+from ....utils import get_json_schema_from_method_signature
 
 
 class SpikeGLXConverterPipe(ConverterPipe):
@@ -23,7 +23,7 @@ class SpikeGLXConverterPipe(ConverterPipe):
 
     @classmethod
     def get_source_schema(cls):
-        source_schema = get_schema_from_method_signature(method=cls.__init__, exclude=["streams"])
+        source_schema = get_json_schema_from_method_signature(method=cls.__init__, exclude=["streams"])
         source_schema["properties"]["folder_path"]["description"] = "Path to the folder containing SpikeGLX streams."
         return source_schema
 

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
@@ -6,7 +6,7 @@ from pydantic import ConfigDict, FilePath, validate_call
 from .spikeglx_utils import get_session_start_time
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ....tools.signal_processing import get_rising_frames_from_ttl
-from ....utils import get_schema_from_method_signature
+from ....utils import get_json_schema_from_method_signature
 
 
 class SpikeGLXNIDQInterface(BaseRecordingExtractorInterface):
@@ -22,7 +22,7 @@ class SpikeGLXNIDQInterface(BaseRecordingExtractorInterface):
 
     @classmethod
     def get_source_schema(cls) -> dict:
-        source_schema = get_schema_from_method_signature(method=cls.__init__, exclude=["x_pitch", "y_pitch"])
+        source_schema = get_json_schema_from_method_signature(method=cls.__init__, exclude=["x_pitch", "y_pitch"])
         source_schema["properties"]["file_path"]["description"] = "Path to SpikeGLX .nidq file."
         return source_schema
 

--- a/src/neuroconv/datainterfaces/icephys/baseicephysinterface.py
+++ b/src/neuroconv/datainterfaces/icephys/baseicephysinterface.py
@@ -7,9 +7,9 @@ from pynwb import NWBFile
 from ...baseextractorinterface import BaseExtractorInterface
 from ...tools.nwb_helpers import make_nwbfile_from_metadata
 from ...utils import (
+    get_json_schema_from_method_signature,
     get_metadata_schema_for_icephys,
     get_schema_from_hdmf_class,
-    get_schema_from_method_signature,
 )
 
 
@@ -22,7 +22,7 @@ class BaseIcephysInterface(BaseExtractorInterface):
 
     @classmethod
     def get_source_schema(cls) -> dict:
-        source_schema = get_schema_from_method_signature(method=cls.__init__, exclude=[])
+        source_schema = get_json_schema_from_method_signature(method=cls.__init__, exclude=[])
         return source_schema
 
     @validate_call

--- a/src/neuroconv/datainterfaces/ophys/brukertiff/brukertiffconverter.py
+++ b/src/neuroconv/datainterfaces/ophys/brukertiff/brukertiffconverter.py
@@ -9,7 +9,7 @@ from ... import (
 )
 from ....nwbconverter import NWBConverter
 from ....tools.nwb_helpers import make_or_load_nwbfile
-from ....utils import get_schema_from_method_signature
+from ....utils import get_json_schema_from_method_signature
 
 
 class BrukerTiffMultiPlaneConverter(NWBConverter):
@@ -24,7 +24,7 @@ class BrukerTiffMultiPlaneConverter(NWBConverter):
 
     @classmethod
     def get_source_schema(cls):
-        source_schema = get_schema_from_method_signature(cls)
+        source_schema = get_json_schema_from_method_signature(cls)
         source_schema["properties"]["folder_path"][
             "description"
         ] = "The folder that contains the Bruker TIF image files (.ome.tif) and configuration files (.xml, .env)."
@@ -138,7 +138,7 @@ class BrukerTiffSinglePlaneConverter(NWBConverter):
 
     @classmethod
     def get_source_schema(cls):
-        return get_schema_from_method_signature(cls)
+        return get_json_schema_from_method_signature(cls)
 
     def get_conversion_options_schema(self):
         interface_name = list(self.data_interface_objects.keys())[0]

--- a/src/neuroconv/datainterfaces/ophys/miniscope/miniscopeconverter.py
+++ b/src/neuroconv/datainterfaces/ophys/miniscope/miniscopeconverter.py
@@ -6,7 +6,7 @@ from pynwb import NWBFile
 from ... import MiniscopeBehaviorInterface, MiniscopeImagingInterface
 from ....nwbconverter import NWBConverter
 from ....tools.nwb_helpers import make_or_load_nwbfile
-from ....utils import get_schema_from_method_signature
+from ....utils import get_json_schema_from_method_signature
 
 
 class MiniscopeConverter(NWBConverter):
@@ -19,7 +19,7 @@ class MiniscopeConverter(NWBConverter):
 
     @classmethod
     def get_source_schema(cls):
-        source_schema = get_schema_from_method_signature(cls)
+        source_schema = get_json_schema_from_method_signature(cls)
         source_schema["properties"]["folder_path"]["description"] = "The path to the main Miniscope folder."
         return source_schema
 

--- a/src/neuroconv/tools/testing/mock_interfaces.py
+++ b/src/neuroconv/tools/testing/mock_interfaces.py
@@ -20,7 +20,7 @@ from ...datainterfaces.ophys.baseimagingextractorinterface import (
 from ...datainterfaces.ophys.basesegmentationextractorinterface import (
     BaseSegmentationExtractorInterface,
 )
-from ...utils import ArrayType, get_schema_from_method_signature
+from ...utils import ArrayType, get_json_schema_from_method_signature
 
 
 class MockBehaviorEventInterface(BaseTemporalAlignmentInterface):
@@ -30,7 +30,7 @@ class MockBehaviorEventInterface(BaseTemporalAlignmentInterface):
 
     @classmethod
     def get_source_schema(cls) -> dict:
-        source_schema = get_schema_from_method_signature(method=cls.__init__, exclude=["event_times"])
+        source_schema = get_json_schema_from_method_signature(method=cls.__init__, exclude=["event_times"])
         source_schema["additionalProperties"] = True
         return source_schema
 
@@ -74,7 +74,7 @@ class MockSpikeGLXNIDQInterface(SpikeGLXNIDQInterface):
 
     @classmethod
     def get_source_schema(cls) -> dict:
-        source_schema = get_schema_from_method_signature(method=cls.__init__, exclude=["ttl_times"])
+        source_schema = get_json_schema_from_method_signature(method=cls.__init__, exclude=["ttl_times"])
         source_schema["additionalProperties"] = True
         return source_schema
 

--- a/src/neuroconv/utils/__init__.py
+++ b/src/neuroconv/utils/__init__.py
@@ -12,7 +12,7 @@ from .json_schema import (
     get_base_schema,
     get_metadata_schema_for_icephys,
     get_schema_from_hdmf_class,
-    get_schema_from_method_signature,
+    get_json_schema_from_method_signature,
     unroot_schema,
     get_json_schema_from_method_signature,
 )

--- a/tests/test_minimal/test_utils/test_get_json_schema_from_method_signature.py
+++ b/tests/test_minimal/test_utils/test_get_json_schema_from_method_signature.py
@@ -110,7 +110,7 @@ def test_get_json_schema_from_method_signature_exclude():
     assert test_json_schema == expected_json_schema
 
 
-def test_get_schema_from_method_signature_init():
+def test_get_json_schema_from_method_signature_init():
     """Test that 'self' is automatically skipped."""
 
     class TestClass:
@@ -141,7 +141,7 @@ def test_get_schema_from_method_signature_init():
     assert test_json_schema == expected_json_schema
 
 
-def test_get_schema_from_method_signature_class_static():
+def test_get_json_schema_from_method_signature_class_static():
     """Ensuring that signature assembly prior to passing to Pydantic is not affected by bound or static methods."""
 
     class TestClass:
@@ -165,7 +165,7 @@ def test_get_schema_from_method_signature_class_static():
     assert test_json_schema == expected_json_schema
 
 
-def test_get_schema_from_method_signature_class_method():
+def test_get_json_schema_from_method_signature_class_method():
     """Test that 'cls' is automatically skipped."""
 
     class TestClass:


### PR DESCRIPTION
The method was deprecated but we are still using it in many places. This PR corrects that oversight. 