### PR TITLE
[Draft] Make dynamic tables expandable

### DIFF
--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
@@ -212,21 +212,21 @@ class DatasetIOConfiguration(BaseModel, ABC):
                 f"Some dimensions of the {chunk_shape=} exceed the {buffer_shape=} for dataset at "
                 f"location '{location_in_file}'!"
             )
-        # if any(buffer_axis > full_axis for buffer_axis, full_axis in zip(buffer_shape, full_shape)):
-        #     raise ValueError(
-        #         f"Some dimensions of the {buffer_shape=} exceed the {full_shape=} for dataset at "
-        #         f"location '{location_in_file}'!"
-        #     )
+        if any(buffer_axis > full_axis for buffer_axis, full_axis in zip(buffer_shape, full_shape)):
+            raise ValueError(
+                f"Some dimensions of the {buffer_shape=} exceed the {full_shape=} for dataset at "
+                f"location '{location_in_file}'!"
+            )
 
-        # if any(
-        #     buffer_axis % chunk_axis != 0
-        #     for chunk_axis, buffer_axis, full_axis in zip(chunk_shape, buffer_shape, full_shape)
-        #     if buffer_axis != full_axis
-        # ):
-        #     raise ValueError(
-        #         f"Some dimensions of the {chunk_shape=} do not evenly divide the {buffer_shape=} for dataset at "
-        #         f"location '{location_in_file}'!"
-        #     )
+        if any(
+            buffer_axis % chunk_axis != 0
+            for chunk_axis, buffer_axis, full_axis in zip(chunk_shape, buffer_shape, full_shape)
+            if buffer_axis != full_axis
+        ):
+            raise ValueError(
+                f"Some dimensions of the {chunk_shape=} do not evenly divide the {buffer_shape=} for dataset at "
+                f"location '{location_in_file}'!"
+            )
 
         return values
 

--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
@@ -296,7 +296,8 @@ class DatasetIOConfiguration(BaseModel, ABC):
                 compression_method = "gzip"
             else:
 
-                chunk_shape = full_shape  # validate_all_shapes fails if chunk_shape or buffer_shape is None
+                # chunk_shape = (1,) * len(full_shape)  # Worse possible chunking
+                chunk_shape = full_shape
                 buffer_shape = full_shape
                 compression_method = None
                 import warnings

--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_hdf5_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_hdf5_dataset_io.py
@@ -77,4 +77,4 @@ class HDF5DatasetIOConfiguration(DatasetIOConfiguration):
                 compression_opts = list(self.compression_options.values())[0]
             compression_bundle = dict(compression=self.compression_method, compression_opts=compression_opts)
 
-        return dict(chunks=self.chunk_shape, **compression_bundle)
+        return dict(chunks=self.chunk_shape, maxshape=self.full_shape, **compression_bundle)

--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_hdf5_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_hdf5_dataset_io.py
@@ -77,4 +77,4 @@ class HDF5DatasetIOConfiguration(DatasetIOConfiguration):
                 compression_opts = list(self.compression_options.values())[0]
             compression_bundle = dict(compression=self.compression_method, compression_opts=compression_opts)
 
-        return dict(chunks=self.chunk_shape, maxshape=self.full_shape, **compression_bundle)
+        return dict(chunks=self.chunk_shape, **compression_bundle)

--- a/src/neuroconv/tools/nwb_helpers/_configure_backend.py
+++ b/src/neuroconv/tools/nwb_helpers/_configure_backend.py
@@ -27,7 +27,7 @@ def configure_backend(
     is_ndx_events_installed = is_package_installed(package_name="ndx_events")
     ndx_events = importlib.import_module("ndx_events") if is_ndx_events_installed else None
 
-    # A remapping of the object IDs in the backend configuration might necessary
+    # A remapping of the object IDs in the backend configuration might be necessary
     locations_to_remap = backend_configuration.find_locations_requiring_remapping(nwbfile=nwbfile)
     if any(locations_to_remap):
         backend_configuration = backend_configuration.build_remapped_backend(locations_to_remap=locations_to_remap)

--- a/src/neuroconv/tools/nwb_helpers/_dataset_configuration.py
+++ b/src/neuroconv/tools/nwb_helpers/_dataset_configuration.py
@@ -103,8 +103,8 @@ def get_default_dataset_io_configurations(
     known_dataset_fields = ("data", "timestamps")
     for neurodata_object in nwbfile.objects.values():
         if isinstance(neurodata_object, DynamicTable):
-            dynamic_table = neurodata_object  # For readability
 
+            dynamic_table = neurodata_object  # For readability
             for column in (*dynamic_table.columns, dynamic_table.id):
                 dataset_name = "data"
                 candidate_dataset = getattr(column, dataset_name)  # Safer way to access data attribute

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -771,18 +771,6 @@ class TestAddElectrodes(TestCase):
         )
 
         backend_configuration = get_default_backend_configuration(nwbfile=self.nwbfile, backend="hdf5")
-        dataset_configurations = backend_configuration.dataset_configurations
-
-        electrodes_location_dataset = dataset_configurations["electrodes/location/data"]
-        electrodes_group_dataset = dataset_configurations["electrodes/group/data"]
-        electrodes_group_name_dataset = dataset_configurations["electrodes/group_name/data"]
-        electrodes_id_dataset = dataset_configurations["electrodes/id/data"]
-
-        # Make expandable
-        electrodes_location_dataset.full_shape = (None,)
-        electrodes_group_name_dataset.full_shape = (None,)
-        electrodes_id_dataset.full_shape = (None,)
-        electrodes_group_dataset.full_shape = (None,)
 
         configure_backend(nwbfile=self.nwbfile, backend_configuration=backend_configuration)
         with NWBHDF5IO("test.nwb", "w") as io:

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -780,8 +780,6 @@ class TestAddElectrodes(TestCase):
             nwbfile_read = io.read()
 
             add_electrodes_to_nwbfile(recording=self.recording_1, nwbfile=nwbfile_read)
-            backend_configuration = get_default_backend_configuration(nwbfile=self.nwbfile, backend="hdf5")
-            dataset_configurations = backend_configuration.dataset_configurations
 
             expected_ids = [123, 124, 2, 3, 4, 5]
             expected_names = ["123", "124", "a", "b", "c", "d"]


### PR DESCRIPTION
Sup, @bendichter I wanted to write this here so we have an anchor point for discussion next time we meet. Taking the electrodes table as a starting point there are two objects that we are not catching for chunkg at the moment:
* ElectrodeGroups column 
* Ids.

Check the code below for more comments but the gist of where I got stuck is here:

```

<HDF5 dataset "id": shape (2,), type "<i8">
data.chunks
(2,)
data.maxshape
(2,)
data.resize(shape)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/heberto/miniconda3/envs/work/lib/python3.11/site-packages/h5py/_hl/dataset.py", line 679, in resize
    self.id.set_extent(size)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py/h5d.pyx", line 335, in h5py.h5d.DatasetID.set_extent
RuntimeError: Unable to synchronously change a dataset's dimensions (dimension cannot e
```

For the ids, the data was chunk but the maxshape was also so it becomes non-expandable.