### PR TITLE
Move imports of extensions to the init of the interfaces

### DIFF
--- a/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
@@ -46,6 +46,7 @@ class AudioInterface(BaseTemporalAlignmentInterface):
 
         verbose : bool, default: False
         """
+
         suffixes = [suffix for file_path in file_paths for suffix in Path(file_path).suffixes]
         format_is_not_supported = [
             suffix for suffix in suffixes if suffix not in [".wav"]

--- a/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
@@ -46,6 +46,8 @@ class AudioInterface(BaseTemporalAlignmentInterface):
 
         verbose : bool, default: False
         """
+        # This import is to assure that the ndx_pose is in the global namespace when an pynwb.io object is created
+        import ndx_sound  # noqa: F401
 
         suffixes = [suffix for file_path in file_paths for suffix in Path(file_path).suffixes]
         format_is_not_supported = [
@@ -167,7 +169,6 @@ class AudioInterface(BaseTemporalAlignmentInterface):
         stub_frames: int = 1000,
         write_as: Literal["stimulus", "acquisition"] = "stimulus",
         iterator_options: Optional[dict] = None,
-        compression_options: Optional[dict] = None,  # TODO: remove completely after 10/1/2024
         overwrite: bool = False,
         verbose: bool = True,
     ):
@@ -225,7 +226,6 @@ class AudioInterface(BaseTemporalAlignmentInterface):
                 write_as=write_as,
                 starting_time=starting_times[file_index],
                 iterator_options=iterator_options,
-                compression_options=compression_options,  # TODO: remove completely after 10/1/2024; still passing for deprecation warning
             )
 
         return nwbfile

--- a/src/neuroconv/datainterfaces/behavior/deeplabcut/_dlc_utils.py
+++ b/src/neuroconv/datainterfaces/behavior/deeplabcut/_dlc_utils.py
@@ -279,13 +279,14 @@ def _write_pes_to_nwbfile(
         else:
             timestamps_cleaned = timestamps
 
+        timestamps = np.asarray(timestamps).astype("float64", copy=False)
         pes = PoseEstimationSeries(
             name=f"{animal}_{keypoint}" if animal else keypoint,
             description=f"Keypoint {keypoint} from individual {animal}.",
             data=data[:, :2],
             unit="pixels",
             reference_frame="(0,0) corresponds to the bottom left corner of the video.",
-            timestamps=timestamps_cleaned,
+            timestamps=timestamps,
             confidence=data[:, 2],
             confidence_definition="Softmax output of the deep neural network.",
         )
@@ -298,6 +299,7 @@ def _write_pes_to_nwbfile(
 
     # TODO, taken from the original implementation, improve it if the video is passed
     dimensions = [list(map(int, image_shape.split(",")))[1::2]]
+    dimensions = np.array(dimensions, dtype="uint32")
     pose_estimation_default_kwargs = dict(
         pose_estimation_series=pose_estimation_series,
         description="2D keypoint coordinates estimated using DeepLabCut.",

--- a/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
@@ -47,6 +47,8 @@ class DeepLabCutInterface(BaseTemporalAlignmentInterface):
         verbose: bool, default: True
             Controls verbosity.
         """
+        # This import is to assure that the ndx_pose is in the global namespace when an pynwb.io object is created
+        from ndx_pose import PoseEstimation, PoseEstimationSeries  # noqa: F401
 
         from ._dlc_utils import _read_config
 

--- a/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
@@ -47,7 +47,6 @@ class DeepLabCutInterface(BaseTemporalAlignmentInterface):
         verbose: bool, default: True
             Controls verbosity.
         """
-        # from ndx_pose import PoseEstimation, PoseEstimationSeries
 
         from ._dlc_utils import _read_config
 

--- a/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
@@ -5,7 +5,6 @@ import numpy as np
 from pydantic import FilePath, validate_call
 from pynwb.file import NWBFile
 
-# import ndx_pose
 from ....basetemporalalignmentinterface import BaseTemporalAlignmentInterface
 
 
@@ -48,6 +47,8 @@ class DeepLabCutInterface(BaseTemporalAlignmentInterface):
         verbose: bool, default: True
             Controls verbosity.
         """
+        # from ndx_pose import PoseEstimation, PoseEstimationSeries
+
         from ._dlc_utils import _read_config
 
         file_path = Path(file_path)

--- a/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposedatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposedatainterface.py
@@ -80,6 +80,7 @@ class LightningPoseDataInterface(BaseTemporalAlignmentInterface):
         verbose : bool, default: True
             controls verbosity. ``True`` by default.
         """
+
         from neuroconv.datainterfaces.behavior.video.video_utils import (
             VideoCaptureContext,
         )

--- a/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposedatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposedatainterface.py
@@ -80,6 +80,8 @@ class LightningPoseDataInterface(BaseTemporalAlignmentInterface):
         verbose : bool, default: True
             controls verbosity. ``True`` by default.
         """
+        # This import is to assure that the ndx_pose is in the global namespace when an pynwb.io object is created
+        import ndx_pose  # noqa: F401
 
         from neuroconv.datainterfaces.behavior.video.video_utils import (
             VideoCaptureContext,

--- a/src/neuroconv/datainterfaces/behavior/medpc/medpcdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/medpc/medpcdatainterface.py
@@ -73,6 +73,7 @@ class MedPCInterface(BaseTemporalAlignmentInterface):
         verbose : bool, optional
             Whether to print verbose output, by default True
         """
+
         if aligned_timestamp_names is None:
             aligned_timestamp_names = []
         super().__init__(

--- a/src/neuroconv/datainterfaces/behavior/medpc/medpcdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/medpc/medpcdatainterface.py
@@ -73,6 +73,8 @@ class MedPCInterface(BaseTemporalAlignmentInterface):
         verbose : bool, optional
             Whether to print verbose output, by default True
         """
+        # This import is to assure that the ndx_events is in the global namespace when an pynwb.io object is created
+        import ndx_events  # noqa: F401
 
         if aligned_timestamp_names is None:
             aligned_timestamp_names = []

--- a/src/neuroconv/datainterfaces/ophys/tdt_fp/tdtfiberphotometrydatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/tdt_fp/tdtfiberphotometrydatainterface.py
@@ -43,6 +43,7 @@ class TDTFiberPhotometryInterface(BaseTemporalAlignmentInterface):
             folder_path=folder_path,
             verbose=verbose,
         )
+        # This module should be here so ndx_fiber_photometry is in the global namespace when an pynwb.io object is created
         import ndx_fiber_photometry  # noqa: F401
 
     def get_metadata(self) -> DeepDict:

--- a/src/neuroconv/tools/audio/audio.py
+++ b/src/neuroconv/tools/audio/audio.py
@@ -15,7 +15,6 @@ def add_acoustic_waveform_series(
     starting_time: float = 0.0,
     write_as: Literal["stimulus", "acquisition"] = "stimulus",
     iterator_options: Optional[dict] = None,
-    compression_options: Optional[dict] = None,  # TODO: remove completely after 10/1/2024
 ) -> NWBFile:
     """
 
@@ -52,17 +51,6 @@ def add_acoustic_waveform_series(
         "stimulus",
         "acquisition",
     ], "Acoustic series can be written either as 'stimulus' or 'acquisition'."
-
-    # TODO: remove completely after 10/1/2024
-    if compression_options is not None:
-        warn(
-            message=(
-                "Specifying compression methods and their options at the level of tool functions has been deprecated. "
-                "Please use the `configure_backend` tool function for this purpose."
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
 
     iterator_options = iterator_options or dict()
 

--- a/tests/test_on_data/behavior/test_behavior_interfaces.py
+++ b/tests/test_on_data/behavior/test_behavior_interfaces.py
@@ -411,7 +411,7 @@ def test_deep_lab_cut_import_pose_extension_bug(clean_pose_extension_import, tmp
 
     interface = DeepLabCutInterface(**interface_kwargs)
     metadata = interface.get_metadata()
-    metadata["NWBFile"]["session_start_time"] = "2021-01-01T12:00:00"
+    metadata["NWBFile"]["session_start_time"] = datetime(2023, 7, 24, 9, 30, 55, 440600, tzinfo=timezone.utc)
 
     nwbfile_path = tmp_path / "test.nwb"
     interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata, overwrite=True)

--- a/tests/test_on_data/behavior/test_behavior_interfaces.py
+++ b/tests/test_on_data/behavior/test_behavior_interfaces.py
@@ -390,7 +390,14 @@ def clean_pose_extension_import():
         del sys.modules[module]
 
 
-def test_ndx_proper_loading_deeplabcut(clean_pose_extension_import, tmp_path):
+def test_deep_lab_cut_import_pose_extension_bug(clean_pose_extension_import, tmp_path):
+    """
+    Test that the DeepLabCutInterface writes correctly without importing the ndx-pose extension.
+    See issues:
+    https://github.com/catalystneuro/neuroconv/issues/1114
+    https://github.com/rly/ndx-pose/issues/36
+
+    """
 
     interface_kwargs = dict(
         file_path=str(
@@ -405,9 +412,9 @@ def test_ndx_proper_loading_deeplabcut(clean_pose_extension_import, tmp_path):
     interface = DeepLabCutInterface(**interface_kwargs)
     metadata = interface.get_metadata()
     metadata["NWBFile"]["session_start_time"] = "2021-01-01T12:00:00"
-    interface.run_conversion(nwbfile_path="test.nwb", metadata=metadata, overwrite=True)
 
     nwbfile_path = tmp_path / "test.nwb"
+    interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata, overwrite=True)
     with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
         read_nwbfile = io.read()
         pose_estimation_container = read_nwbfile.processing["behavior"]["PoseEstimation"]

--- a/tests/test_on_data/behavior/test_lightningpose_converter.py
+++ b/tests/test_on_data/behavior/test_lightningpose_converter.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from warnings import warn
 
 from hdmf.testing import TestCase
-from ndx_pose import PoseEstimation
 from pynwb import NWBHDF5IO
 from pynwb.image import ImageSeries
 
@@ -134,6 +133,8 @@ class TestLightningPoseConverter(TestCase):
         self.assertNWBFileStructure(nwbfile_path=nwbfile_path, **self.conversion_options)
 
     def assertNWBFileStructure(self, nwbfile_path: str, stub_test: bool = False):
+        from ndx_pose import PoseEstimation
+
         with NWBHDF5IO(path=nwbfile_path) as io:
             nwbfile = io.read()
 


### PR DESCRIPTION
Fix #1114.

As discussed in the general meeting. This is the simplest solution. Later, when time allows, we will do  https://github.com/catalystneuro/neuroconv/issues/1143 which should be a more robust solution. 

I added a test to assure myself that this closes #1114
