### PR TITLE
Fix live-services tests (dandi) on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,4 @@
-# Upcoming
-
-## Features
-* Added the `rclone_transfer_batch_job` helper function for executing Rclone data transfers in AWS Batch jobs. [PR #1085](https://github.com/catalystneuro/neuroconv/pull/1085)
-
-
-
-## v0.6.4
+# v0.6.6 (Upcoming)
 
 ## Deprecations
 * Completely removed compression settings from most places [PR #1126](https://github.com/catalystneuro/neuroconv/pull/1126)
@@ -18,9 +11,11 @@
 * Propagate the `unit_electrode_indices` argument from the spikeinterface tools to `BaseSortingExtractorInterface`. This allows users to map units to the electrode table when adding sorting data [PR #1124](https://github.com/catalystneuro/neuroconv/pull/1124)
 * Imaging interfaces have a new conversion option `always_write_timestamps` that can be used to force writing timestamps even if neuroconv's heuristics indicates regular sampling rate [PR #1125](https://github.com/catalystneuro/neuroconv/pull/1125)
 * Added .csv support to DeepLabCutInterface [PR #1140](https://github.com/catalystneuro/neuroconv/pull/1140)
+* Added the `rclone_transfer_batch_job` helper function for executing Rclone data transfers in AWS Batch jobs. [PR #1085](https://github.com/catalystneuro/neuroconv/pull/1085)
 
 ## Improvements
 * Use mixing tests for ecephy's mocks [PR #1136](https://github.com/catalystneuro/neuroconv/pull/1136)
+* Use pytest format for dandi tests to avoid window permission error on teardown [PR #1151](https://github.com/catalystneuro/neuroconv/pull/1151)
 
 # v0.6.5 (November 1, 2024)
 

--- a/tests/test_minimal/test_tools/dandi_transfer_tools.py
+++ b/tests/test_minimal/test_tools/dandi_transfer_tools.py
@@ -1,13 +1,9 @@
 import os
 import sys
 from datetime import datetime
-from pathlib import Path
 from platform import python_version as get_python_version
-from shutil import rmtree
-from tempfile import mkdtemp
 
 import pytest
-from hdmf.testing import TestCase
 from pynwb import NWBHDF5IO
 
 from neuroconv.tools.data_transfers import automatic_dandi_upload
@@ -24,80 +20,63 @@ HAVE_DANDI_KEY = DANDI_API_KEY is not None and DANDI_API_KEY != ""  # can be "" 
     not HAVE_DANDI_KEY,
     reason="You must set your DANDI_API_KEY to run this test!",
 )
-class TestAutomaticDANDIUpload(TestCase):
-    def setUp(self):
-        self.tmpdir = Path(mkdtemp())
-        self.nwb_folder_path = self.tmpdir / "test_nwb"
-        self.nwb_folder_path.mkdir()
-        metadata = get_default_nwbfile_metadata()
-        metadata["NWBFile"].update(
-            session_start_time=datetime.now().astimezone(),
-            session_id=f"test-automatic-upload-{sys.platform}-{get_python_version().replace('.', '-')}",
-        )
-        metadata.update(Subject=dict(subject_id="foo", species="Mus musculus", age="P1D", sex="U"))
-        with NWBHDF5IO(path=self.nwb_folder_path / "test_nwb_1.nwb", mode="w") as io:
-            io.write(make_nwbfile_from_metadata(metadata=metadata))
+def test_automatic_dandi_upload(tmp_path):
+    nwb_folder_path = tmp_path / "test_nwb"
+    nwb_folder_path.mkdir()
+    metadata = get_default_nwbfile_metadata()
+    metadata["NWBFile"].update(
+        session_start_time=datetime.now().astimezone(),
+        session_id=f"test-automatic-upload-{sys.platform}-{get_python_version().replace('.', '-')}",
+    )
+    metadata.update(Subject=dict(subject_id="foo", species="Mus musculus", age="P1D", sex="U"))
+    with NWBHDF5IO(path=nwb_folder_path / "test_nwb_1.nwb", mode="w") as io:
+        io.write(make_nwbfile_from_metadata(metadata=metadata))
 
-    def tearDown(self):
-        rmtree(self.tmpdir)
-
-    def test_automatic_dandi_upload(self):
-        automatic_dandi_upload(dandiset_id="200560", nwb_folder_path=self.nwb_folder_path, staging=True)
+    automatic_dandi_upload(dandiset_id="200560", nwb_folder_path=nwb_folder_path, staging=True)
 
 
 @pytest.mark.skipif(
     not HAVE_DANDI_KEY,
     reason="You must set your DANDI_API_KEY to run this test!",
 )
-class TestAutomaticDANDIUploadNonParallel(TestCase):
-    def setUp(self):
-        self.tmpdir = Path(mkdtemp())
-        self.nwb_folder_path = self.tmpdir / "test_nwb"
-        self.nwb_folder_path.mkdir()
-        metadata = get_default_nwbfile_metadata()
-        metadata["NWBFile"].update(
-            session_start_time=datetime.now().astimezone(),
-            session_id=f"test-automatic-upload-{sys.platform}-{get_python_version().replace('.', '-')}-non-parallel",
-        )
-        metadata.update(Subject=dict(subject_id="foo", species="Mus musculus", age="P1D", sex="U"))
-        with NWBHDF5IO(path=self.nwb_folder_path / "test_nwb_2.nwb", mode="w") as io:
-            io.write(make_nwbfile_from_metadata(metadata=metadata))
+def test_automatic_dandi_upload_non_parallel(tmp_path):
+    nwb_folder_path = tmp_path / "test_nwb"
+    nwb_folder_path.mkdir()
+    metadata = get_default_nwbfile_metadata()
+    metadata["NWBFile"].update(
+        session_start_time=datetime.now().astimezone(),
+        session_id=(f"test-automatic-upload-{sys.platform}-" f"{get_python_version().replace('.', '-')}-non-parallel"),
+    )
+    metadata.update(Subject=dict(subject_id="foo", species="Mus musculus", age="P1D", sex="U"))
+    with NWBHDF5IO(path=nwb_folder_path / "test_nwb_2.nwb", mode="w") as io:
+        io.write(make_nwbfile_from_metadata(metadata=metadata))
 
-    def tearDown(self):
-        rmtree(self.tmpdir)
-
-    def test_automatic_dandi_upload_non_parallel(self):
-        automatic_dandi_upload(
-            dandiset_id="200560", nwb_folder_path=self.nwb_folder_path, staging=True, number_of_jobs=1
-        )
+    automatic_dandi_upload(dandiset_id="200560", nwb_folder_path=nwb_folder_path, staging=True, number_of_jobs=1)
 
 
 @pytest.mark.skipif(
     not HAVE_DANDI_KEY,
     reason="You must set your DANDI_API_KEY to run this test!",
 )
-class TestAutomaticDANDIUploadNonParallelNonThreaded(TestCase):
-    def setUp(self):
-        self.tmpdir = Path(mkdtemp())
-        self.nwb_folder_path = self.tmpdir / "test_nwb"
-        self.nwb_folder_path.mkdir()
-        metadata = get_default_nwbfile_metadata()
-        metadata["NWBFile"].update(
-            session_start_time=datetime.now().astimezone(),
-            session_id=f"test-automatic-upload-{sys.platform}-{get_python_version().replace('.', '-')}-non-parallel-non-threaded",
-        )
-        metadata.update(Subject=dict(subject_id="foo", species="Mus musculus", age="P1D", sex="U"))
-        with NWBHDF5IO(path=self.nwb_folder_path / "test_nwb_3.nwb", mode="w") as io:
-            io.write(make_nwbfile_from_metadata(metadata=metadata))
+def test_automatic_dandi_upload_non_parallel_non_threaded(tmp_path):
+    nwb_folder_path = tmp_path / "test_nwb"
+    nwb_folder_path.mkdir()
+    metadata = get_default_nwbfile_metadata()
+    metadata["NWBFile"].update(
+        session_start_time=datetime.now().astimezone(),
+        session_id=(
+            f"test-automatic-upload-{sys.platform}-"
+            f"{get_python_version().replace('.', '-')}-non-parallel-non-threaded"
+        ),
+    )
+    metadata.update(Subject=dict(subject_id="foo", species="Mus musculus", age="P1D", sex="U"))
+    with NWBHDF5IO(path=nwb_folder_path / "test_nwb_3.nwb", mode="w") as io:
+        io.write(make_nwbfile_from_metadata(metadata=metadata))
 
-    def tearDown(self):
-        rmtree(self.tmpdir)
-
-    def test_automatic_dandi_upload_non_parallel_non_threaded(self):
-        automatic_dandi_upload(
-            dandiset_id="200560",
-            nwb_folder_path=self.nwb_folder_path,
-            staging=True,
-            number_of_jobs=1,
-            number_of_threads=1,
-        )
+    automatic_dandi_upload(
+        dandiset_id="200560",
+        nwb_folder_path=nwb_folder_path,
+        staging=True,
+        number_of_jobs=1,
+        number_of_threads=1,
+    )


### PR DESCRIPTION
We are getting failure on dandi tests on windows for well known reasons:

https://github.com/catalystneuro/neuroconv/pull/1086

The teardown mechanism of the unittest structure removes the directory which fails sometimes on windows because of permissions. This PR changes the testing from unittest to pytest so instead of using the ad-hoc teardown it uses pytest tmp_path methods which should be safer.