### PR TITLE
Add missing typing to `NWBConverter` backend and backend options 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 * Use pytest format for dandi tests to avoid window permission error on teardown [PR #1151](https://github.com/catalystneuro/neuroconv/pull/1151)
 * Added many docstrings for public functions [PR #1063](https://github.com/catalystneuro/neuroconv/pull/1063)
 * Clean up with warnings and deprecations in the testing framework [PR #1158](https://github.com/catalystneuro/neuroconv/pull/1158)
-
+* Enhance the typing of the signature on the `NWBConverter` by adding zarr as a literal option on the backend and backend configuration [PR #1160](https://github.com/catalystneuro/neuroconv/pull/1160)
 
 # v0.6.5 (November 1, 2024)
 

--- a/docs/conversion_examples_gallery/fiberphotometry/tdt_fp.rst
+++ b/docs/conversion_examples_gallery/fiberphotometry/tdt_fp.rst
@@ -207,15 +207,13 @@ Convert TDT Fiber Photometry data to NWB using
     >>> LOCAL_PATH = Path(".") # Path to neuroconv
     >>> editable_metadata_path = LOCAL_PATH / "tests" / "test_on_data" / "ophys" / "fiber_photometry_metadata.yaml"
 
-    >>> interface = TDTFiberPhotometryInterface(folder_path=folder_path, verbose=True)
-    Source data is valid!
+    >>> interface = TDTFiberPhotometryInterface(folder_path=folder_path, verbose=False)
     >>> metadata = interface.get_metadata()
     >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("US/Pacific"))
     >>> editable_metadata = load_dict_from_file(editable_metadata_path)
     >>> metadata = dict_deep_update(metadata, editable_metadata)
 
     >>> # Choose a path for saving the nwb file and run the conversion
-    >>> nwbfile_path = LOCAL_PATH / "example_tdtfp.nwb"
+    >>> nwbfile_path =  f"{path_to_save_nwbfile}"
     >>> # t1 and t2 are optional arguments to specify the start and end times for the conversion
     >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata, t1=0.0, t2=1.0)
-    NWB file saved at example_tdtfp.nwb!

--- a/src/neuroconv/nwbconverter.py
+++ b/src/neuroconv/nwbconverter.py
@@ -231,7 +231,7 @@ class NWBConverter:
             The configuration model to use when configuring the datasets for this backend.
             To customize, call the `.get_default_backend_configuration(...)` method, modify the returned
             BackendConfiguration object, and pass that instead.
-            Otherwise, all datasets will use default configuration settings..
+            Otherwise, all datasets will use default configuration settings.
         conversion_options : dict, optional
             Similar to source_data, a dictionary containing keywords for each interface for which non-default
             conversion specification is requested.

--- a/src/neuroconv/nwbconverter.py
+++ b/src/neuroconv/nwbconverter.py
@@ -204,11 +204,8 @@ class NWBConverter:
         nwbfile: Optional[NWBFile] = None,
         metadata: Optional[dict] = None,
         overwrite: bool = False,
-        # TODO: when all H5DataIO prewraps are gone, introduce Zarr safely
-        # backend: Union[Literal["hdf5", "zarr"]],
-        # backend_configuration: Optional[Union[HDF5BackendConfiguration, ZarrBackendConfiguration]] = None,
-        backend: Optional[Literal["hdf5"]] = None,
-        backend_configuration: Optional[HDF5BackendConfiguration] = None,
+        backend: Optional[Literal["hdf5", "zarr"]] = None,
+        backend_configuration: Optional[Union[HDF5BackendConfiguration, ZarrBackendConfiguration]] = None,
         conversion_options: Optional[dict] = None,
     ) -> None:
         """
@@ -226,15 +223,15 @@ class NWBConverter:
         overwrite : bool, default: False
             Whether to overwrite the NWBFile if one exists at the nwbfile_path.
             The default is False (append mode).
-        backend : "hdf5", optional
+        backend : {"hdf5", "zarr"}, optional
             The type of backend to use when writing the file.
             If a `backend_configuration` is not specified, the default type will be "hdf5".
             If a `backend_configuration` is specified, then the type will be auto-detected.
-        backend_configuration : HDF5BackendConfiguration, optional
+        backend_configuration : HDF5BackendConfiguration or ZarrBackendConfiguration, optional
             The configuration model to use when configuring the datasets for this backend.
             To customize, call the `.get_default_backend_configuration(...)` method, modify the returned
             BackendConfiguration object, and pass that instead.
-            Otherwise, all datasets will use default configuration settings.
+            Otherwise, all datasets will use default configuration settings..
         conversion_options : dict, optional
             Similar to source_data, a dictionary containing keywords for each interface for which non-default
             conversion specification is requested.

--- a/tests/test_on_data/ophys/test_miniscope_converter.py
+++ b/tests/test_on_data/ophys/test_miniscope_converter.py
@@ -159,8 +159,8 @@ class TestMiniscopeConverter(TestCase):
             nwbfile = io.read()
 
             self.assertEqual(
-                nwbfile.session_start_time,
-                datetime(2021, 10, 7, 15, 3, 28, 635).astimezone(),
+                nwbfile.session_start_time.replace(tzinfo=None),
+                datetime(2021, 10, 7, 15, 3, 28, 635),
             )
 
             self.assertIn(self.device_name, nwbfile.devices)


### PR DESCRIPTION
Running local tests for the next release I noticed and changed three things:

1) The converter was missing the zarr option in the signature for typing. I added the typing and modified the docstring accordingly.
2) The miniscope tests were comparing session start time  with time zone included. This only works on the CI but fails locally if someone is not in the time zone of the CI server. I made the comparison on the naive datetime object only.
3) The TDT interface for fiber photometry is outputting files on the repo directory. I changed the conversion gallery so it uses the same machinery as all the other interfaces (where the output of the gallery is written to a temporary directory).

