### PR TITLE
Set ceiling for HDMF to avoid failures with the latest release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,13 @@ __pycache__/
 # C extensions
 *.so
 
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+uv.lock
+
 # Distribution / packaging
 .Python
 build/
@@ -127,3 +134,4 @@ venv.bak/
 
 # Spyder
 .spyproject
+

--- a/.gitignore
+++ b/.gitignore
@@ -134,4 +134,3 @@ venv.bak/
 
 # Spyder
 .spyproject
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Small fixes should be here.
 ## Deprecations
 
 ## Bug Fixes
+* Temporary set a ceiling for hdmf to avoid a chunking bug  [PR #1175](https://github.com/catalystneuro/neuroconv/pull/1175)
 
 ## Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "PyYAML>=5.4",
     "scipy>=1.4.1",
     "h5py>=3.9.0",
-    "hdmf>=3.13.0<=3.14.5",  # Chunking bug
+    "hdmf>=3.13.0,<=3.14.5",  # Chunking bug
     "hdmf_zarr>=0.7.0",
     "pynwb>=2.7.0",
     "pydantic>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "PyYAML>=5.4",
     "scipy>=1.4.1",
     "h5py>=3.9.0",
-    "hdmf>=3.13.0",
+    "hdmf>=3.13.0<=3.14.5",  # Chunking bug
     "hdmf_zarr>=0.7.0",
     "pynwb>=2.7.0",
     "pydantic>=2.0.0",

--- a/tests/test_on_data/setup_paths.py
+++ b/tests/test_on_data/setup_paths.py
@@ -19,7 +19,7 @@ else:
     # Override LOCAL_PATH in the `gin_test_config.json` file to a point on your system that contains the dataset folder
     # Use DANDIHub at hub.dandiarchive.org for open, free use of data found in the /shared/catalystneuro/ directory
     project_root_path = Path(__file__).parent.parent.parent
-    test_config_path = project_root_path / "tests" / "test_on_data"/ "gin_test_config.json"
+    test_config_path = project_root_path / "tests" / "test_on_data" / "gin_test_config.json"
     config_file_exists = test_config_path.exists()
     if not config_file_exists:
 

--- a/tests/test_on_data/setup_paths.py
+++ b/tests/test_on_data/setup_paths.py
@@ -18,12 +18,12 @@ if os.getenv("CI"):
 else:
     # Override LOCAL_PATH in the `gin_test_config.json` file to a point on your system that contains the dataset folder
     # Use DANDIHub at hub.dandiarchive.org for open, free use of data found in the /shared/catalystneuro/ directory
-    test_config_path = Path(__file__).parent / "gin_test_config.json"
+    project_root_path = Path(__file__).parent.parent.parent
+    test_config_path = project_root_path / "tests" / "test_on_data"/ "gin_test_config.json"
     config_file_exists = test_config_path.exists()
     if not config_file_exists:
 
-        root = test_config_path.parent.parent
-        base_test_config_path = root / "base_gin_test_config.json"
+        base_test_config_path = project_root_path / "base_gin_test_config.json"
 
         test_config_path.parent.mkdir(parents=True, exist_ok=True)
         copy(src=base_test_config_path, dst=test_config_path)
@@ -40,4 +40,4 @@ BEHAVIOR_DATA_PATH = LOCAL_PATH / "behavior_testing_data"
 ECEPHY_DATA_PATH = LOCAL_PATH / "ephy_testing_data"
 OPHYS_DATA_PATH = LOCAL_PATH / "ophys_testing_data"
 
-TEXT_DATA_PATH = Path(__file__).parent.parent.parent / "tests" / "test_text"
+TEXT_DATA_PATH = project_root_path / "tests" / "test_text"

--- a/tests/test_on_data/setup_paths.py
+++ b/tests/test_on_data/setup_paths.py
@@ -10,7 +10,7 @@ OUTPUT_PATH = Path(tempfile.mkdtemp())
 
 
 # Load the configuration for the data tests
-
+project_root_path = Path(__file__).parent.parent.parent
 
 if os.getenv("CI"):
     LOCAL_PATH = Path(".")  # Must be set to "." for CI
@@ -18,7 +18,6 @@ if os.getenv("CI"):
 else:
     # Override LOCAL_PATH in the `gin_test_config.json` file to a point on your system that contains the dataset folder
     # Use DANDIHub at hub.dandiarchive.org for open, free use of data found in the /shared/catalystneuro/ directory
-    project_root_path = Path(__file__).parent.parent.parent
     test_config_path = project_root_path / "tests" / "test_on_data" / "gin_test_config.json"
     config_file_exists = test_config_path.exists()
     if not config_file_exists:


### PR DESCRIPTION
Currently, there are tests failing due to chunking errors with the latest release of hdmf:

https://github.com/catalystneuro/neuroconv/pull/1168

 I am putting a ceiling on the version right now until we fix that. If I remember well this requires or would be helped by first fixing the PoseEstimation interfaces in other PRs. 