### PR TITLE
Do not convert non-neural channels to ElectricalSeries on `OpenEphysBinaryRecordingInterface`

### DIFF
--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
@@ -86,6 +86,13 @@ class OpenEphysBinaryRecordingInterface(BaseRecordingExtractorInterface):
         if stub_test:
             self.subset_channels = [0, 1]
 
+        # Check if the recording has ADC channels
+        recording = self.recording_extractor
+        channel_ids = recording.get_channel_ids()
+        neural_channels = [id for id in channel_ids if "ADC" not in id]
+        if len(neural_channels) < len(channel_ids):
+            self.recording_extractor = recording.select_channels(channel_ids=neural_channels)
+
     def get_metadata(self) -> dict:
         from ._openephys_utils import _get_session_start_time
 

--- a/tests/test_on_data/ecephys/test_recording_interfaces.py
+++ b/tests/test_on_data/ecephys/test_recording_interfaces.py
@@ -541,6 +541,26 @@ class TestOpenEphysBinaryRecordingInterfaceWithBlocks_version_0_6_block_1_stream
         assert metadata["NWBFile"]["session_start_time"] == datetime(2022, 5, 3, 10, 52, 24)
 
 
+class TestOpenEphysBinaryRecordingInterfaceNonNeuralDatExcluded(RecordingExtractorInterfaceTestMixin):
+    """Test that non-neural channels are not written as ElectricalSeries"""
+
+    data_interface_cls = OpenEphysBinaryRecordingInterface
+    interface_kwargs = dict(
+        folder_path=str(ECEPHY_DATA_PATH / "openephysbinary" / "neural_and_non_neural_data_mixed"),
+        stream_name="Rhythm_FPGA-100.0",
+    )
+    save_directory = OUTPUT_PATH
+
+    def test_non_neural_channels_not_added(self, setup_interface):
+        interface, test_name = setup_interface
+        nwbfile = interface.create_nwbfile()
+
+        written_channels = nwbfile.acquisition["ElectricalSeries"].electrodes["channel_name"].data
+        # Note the absence of "ADC1" and "ADC2"
+        assert all("ADC" not in channel for channel in written_channels)
+        assert np.array_equal(written_channels, np.asarray(["CH1", "CH2", "CH3", "CH4"]))
+
+
 class TestOpenEphysLegacyRecordingInterface(RecordingExtractorInterfaceTestMixin):
     data_interface_cls = OpenEphysLegacyRecordingInterface
     interface_kwargs = dict(folder_path=str(ECEPHY_DATA_PATH / "openephys" / "OpenEphys_SampleData_1"))


### PR DESCRIPTION
Should close https://github.com/catalystneuro/neuroconv/issues/1023

Part of an effort like the one in:

https://github.com/catalystneuro/neuroconv/pull/1152

Will add another PR at some point to transform the non-neural channels to a TimeSeries automatically.