### PR TITLE
Call get_metadata when no metadata is passed on ophys interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Added Returns section to all getter docstrings [PR #1185](https://github.com/catalystneuro/neuroconv/pull/1185)
 * ElectricalSeries have better chunking defaults when data is passed as plain array [PR #1184](https://github.com/catalystneuro/neuroconv/pull/1184)
 * Support Spikeinterface 0.102 [PR #1194](https://github.com/catalystneuro/neuroconv/pull/1194)
+* Ophys interfaces now call `get_metadata` by default when no metadata is passed [PR #1194](https://github.com/catalystneuro/neuroconv/pull/1194)
 
 # v0.6.7 (January 20, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Added Returns section to all getter docstrings [PR #1185](https://github.com/catalystneuro/neuroconv/pull/1185)
 * ElectricalSeries have better chunking defaults when data is passed as plain array [PR #1184](https://github.com/catalystneuro/neuroconv/pull/1184)
 * Support Spikeinterface 0.102 [PR #1194](https://github.com/catalystneuro/neuroconv/pull/1194)
-* Ophys interfaces now call `get_metadata` by default when no metadata is passed [PR #1194](https://github.com/catalystneuro/neuroconv/pull/1194)
+* Ophys interfaces now call `get_metadata` by default when no metadata is passed [PR #1200](https://github.com/catalystneuro/neuroconv/pull/1200)
 
 # v0.6.7 (January 20, 2025)
 

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -391,8 +391,7 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
         else:
             recording = self.recording_extractor
 
-        if metadata is None:
-            metadata = self.get_metadata()
+        metadata = metadata or self.get_metadata()
 
         add_recording_to_nwbfile(
             recording=recording,

--- a/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
@@ -179,6 +179,8 @@ class BaseImagingExtractorInterface(BaseExtractorInterface):
         else:
             imaging_extractor = self.imaging_extractor
 
+        metadata = metadata or self.get_metadata()
+
         add_imaging_to_nwbfile(
             imaging=imaging_extractor,
             nwbfile=nwbfile,


### PR DESCRIPTION
For ecephys interfaces, we call `get_metadata` when `metadata = None` in `add_to_nwbfile`. This is convenient because the default metadata is always added ensuring that the file is as complete as it can be with what can be extracted automatically.

This PR unifies the behavior between ophys and ecephys by adding this to ophys.