### PR TITLE
Call `get_metadata` when no metadata is passed on segmentation interfaces 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ as used by hdmf >= 3.14.6.
 * Simple writing no longer uses a context manager [PR #1180](https://github.com/catalystneuro/neuroconv/pull/1180)
 * Added Returns section to all getter docstrings [PR #1185](https://github.com/catalystneuro/neuroconv/pull/1185)
 * ElectricalSeries have better chunking defaults when data is passed as plain array [PR #1184](https://github.com/catalystneuro/neuroconv/pull/1184)
-* Ophys interfaces now call `get_metadata` by default when no metadata is passed [PR #1200](https://github.com/catalystneuro/neuroconv/pull/1200)
+* Ophys interfaces now call `get_metadata` by default when no metadata is passed [PR #1200](https://github.com/catalystneuro/neuroconv/pull/1200) and PR [#1232](https://github.com/catalystneuro/neuroconv/pull/1232)
 
 
 

--- a/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
@@ -192,6 +192,8 @@ class BaseSegmentationExtractorInterface(BaseExtractorInterface):
         else:
             segmentation_extractor = self.segmentation_extractor
 
+        metadata = metadata or self.get_metadata()
+
         add_segmentation_to_nwbfile(
             segmentation_extractor=segmentation_extractor,
             nwbfile=nwbfile,


### PR DESCRIPTION
Follow up on #1200. Explanation can be found there.