### PR TITLE
Fix parsing of group names with numpy 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Deprecations and Changes
 
 ## Bug Fixes
+* Fix parsing of group_names in `tools.spikeinterface`
 
 ## Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Deprecations and Changes
 
 ## Bug Fixes
-* Fix parsing of group_names in `tools.spikeinterface`
+* Fix parsing of group_names in `tools.spikeinterface` [PR #1234](https://github.com/catalystneuro/neuroconv/pull/1234/files)
 
 ## Features
 

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -1817,7 +1817,7 @@ def _get_electrode_group_indices(recording, nwbfile):
     if "group_name" in recording.get_property_keys():
         group_names = np.unique(recording.get_property("group_name"))
     elif "group" in recording.get_property_keys():
-        group_names = np.unique(recording.get_property("group").astype(str))
+        group_names = np.unique(recording.get_property("group"))
     else:
         group_names = None
 

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -1815,14 +1815,15 @@ def write_sorting_analyzer_to_nwbfile(
 def _get_electrode_group_indices(recording, nwbfile):
     """ """
     if "group_name" in recording.get_property_keys():
-        group_names = list(np.unique(recording.get_property("group_name")))
+        group_names = np.unique(recording.get_property("group_name"))
     elif "group" in recording.get_property_keys():
-        group_names = list(np.unique(recording.get_property("group").astype(str)))
+        group_names = np.unique(recording.get_property("group").astype(str))
     else:
         group_names = None
 
     if group_names is None:
         electrode_group_indices = None
     else:
+        group_names = [str(group_name) for group_name in group_names]
         electrode_group_indices = nwbfile.electrodes.to_dataframe().query(f"group_name in {group_names}").index.values
     return electrode_group_indices


### PR DESCRIPTION
This is a weird behavior with numpy 2.0 in [this function](https://github.com/catalystneuro/neuroconv/blob/main/src/neuroconv/tools/spikeinterface/spikeinterface.py#L1815).

In the current implementation, applying `list` to `np.unique` [here](https://github.com/catalystneuro/neuroconv/blob/main/src/neuroconv/tools/spikeinterface/spikeinterface.py#L1820) results in:
```
print(group_names)

>>> [np.str_('ProbeA')]
```
This messes up the [pandas query](`https://github.com/catalystneuro/neuroconv/blob/main/src/neuroconv/tools/spikeinterface/spikeinterface.py#L1827`), which doesn't recognize the `np.` symbol.

This is a simple fix to make sure all elements of the `group_names` are parsed to python `str`