### PR TITLE
Support numpy 2.0 in the testing suite.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Features
 
 ## Improvements
+* Testing suite now supports numpy 2.0. [PR #1235](https://github.com/catalystneuro/neuroconv/pull/1235)
 
 
 # v0.7.0 (March 03, 2025)

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -706,6 +706,8 @@ def _report_variable_offset(channel_offsets, channel_ids):
     # Group the different offsets per channel IDs
     offset_to_channel_ids = {}
     for offset, channel_id in zip(channel_offsets, channel_ids):
+        offset = offset.item() if isinstance(offset, np.generic) else offset
+        channel_id = channel_id.item() if isinstance(channel_id, np.generic) else channel_id
         if offset not in offset_to_channel_ids:
             offset_to_channel_ids[offset] = []
         offset_to_channel_ids[offset].append(channel_id)

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -295,7 +295,7 @@ class TemporalAlignmentMixin:
         self.interface.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
 
         retrieved_aligned_timestamps = self.interface.get_timestamps()
-        assert_array_equal(x=retrieved_aligned_timestamps, y=aligned_timestamps)
+        assert_array_equal(retrieved_aligned_timestamps, aligned_timestamps)
 
     def check_shift_timestamps_by_start_time(self):
         """Ensure that internal mechanisms for shifting timestamps by a starting time work as expected."""
@@ -307,7 +307,7 @@ class TemporalAlignmentMixin:
 
         aligned_timestamps = self.interface.get_timestamps()
         expected_timestamps = unaligned_timestamps + aligned_starting_time
-        assert_array_equal(x=aligned_timestamps, y=expected_timestamps)
+        assert_array_equal(aligned_timestamps, expected_timestamps)
 
     def check_interface_original_timestamps_inmutability(self):
         """Check aligning the timestamps for the interface does not change the value of .get_original_timestamps()."""
@@ -318,7 +318,7 @@ class TemporalAlignmentMixin:
         self.interface.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
 
         post_alignment_original_timestamps = self.interface.get_original_timestamps()
-        assert_array_equal(x=post_alignment_original_timestamps, y=pre_alignment_original_timestamps)
+        assert_array_equal(post_alignment_original_timestamps, pre_alignment_original_timestamps)
 
     def check_nwbfile_temporal_alignment(self):
         """Check the temporally aligned timing information makes it into the NWB file."""
@@ -473,7 +473,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
             self.interface.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
 
             retrieved_aligned_timestamps = self.interface.get_timestamps()
-            assert_array_equal(x=retrieved_aligned_timestamps, y=aligned_timestamps)
+            assert_array_equal(retrieved_aligned_timestamps, aligned_timestamps)
         else:
             with pytest.raises(
                 AssertionError,
@@ -500,7 +500,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
             self.interface.set_aligned_segment_timestamps(aligned_segment_timestamps=all_aligned_segment_timestamps)
 
             retrieved_aligned_timestamps = self.interface.get_timestamps()
-            assert_array_equal(x=retrieved_aligned_timestamps, y=all_aligned_segment_timestamps[0])
+            assert_array_equal(retrieved_aligned_timestamps, all_aligned_segment_timestamps[0])
         else:
             all_unaligned_timestamps = self.interface.get_timestamps()
             all_aligned_segment_timestamps = [
@@ -513,7 +513,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
             for retrieved_aligned_timestamps, aligned_segment_timestamps in zip(
                 all_retrieved_aligned_timestamps, all_aligned_segment_timestamps
             ):
-                assert_array_equal(x=retrieved_aligned_timestamps, y=aligned_segment_timestamps)
+                assert_array_equal(retrieved_aligned_timestamps, aligned_segment_timestamps)
 
     def check_shift_timestamps_by_start_time(self):
         self.setUpFreshInterface()
@@ -525,7 +525,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
         if self.interface._number_of_segments == 1:
             retrieved_aligned_timestamps = self.interface.get_timestamps()
             expected_timestamps = all_unaligned_timestamps + aligned_starting_time
-            assert_array_equal(x=retrieved_aligned_timestamps, y=expected_timestamps)
+            assert_array_equal(retrieved_aligned_timestamps, expected_timestamps)
         else:
             all_retrieved_aligned_timestamps = self.interface.get_timestamps()
             all_expected_timestamps = [
@@ -534,7 +534,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
             for retrieved_aligned_timestamps, expected_timestamps in zip(
                 all_retrieved_aligned_timestamps, all_expected_timestamps
             ):
-                assert_array_equal(x=retrieved_aligned_timestamps, y=expected_timestamps)
+                assert_array_equal(retrieved_aligned_timestamps, expected_timestamps)
 
     def check_shift_segment_timestamps_by_starting_times(self):
         self.setUpFreshInterface()
@@ -549,7 +549,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
 
             retrieved_aligned_timestamps = self.interface.get_timestamps()
             expected_aligned_timestamps = unaligned_timestamps + aligned_segment_starting_times[0]
-            assert_array_equal(x=retrieved_aligned_timestamps, y=expected_aligned_timestamps)
+            assert_array_equal(retrieved_aligned_timestamps, expected_aligned_timestamps)
         else:
             all_unaligned_timestamps = self.interface.get_timestamps()
 
@@ -565,7 +565,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
             for retrieved_aligned_timestamps, expected_aligned_timestamps in zip(
                 all_retrieved_aligned_timestamps, all_expected_aligned_timestamps
             ):
-                assert_array_equal(x=retrieved_aligned_timestamps, y=expected_aligned_timestamps)
+                assert_array_equal(retrieved_aligned_timestamps, expected_aligned_timestamps)
 
     def check_interface_original_timestamps_inmutability(self):
         """Check aligning the timestamps for the interface does not change the value of .get_original_timestamps()."""
@@ -578,7 +578,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
             self.interface.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
 
             post_alignment_original_timestamps = self.interface.get_original_timestamps()
-            assert_array_equal(x=post_alignment_original_timestamps, y=pre_alignment_original_timestamps)
+            assert_array_equal(post_alignment_original_timestamps, pre_alignment_original_timestamps)
         else:
             with pytest.raises(
                 AssertionError,
@@ -661,7 +661,7 @@ class SortingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
                 self.interface.set_aligned_segment_timestamps(aligned_segment_timestamps=all_aligned_segment_timestamps)
 
                 retrieved_aligned_timestamps = self.interface.get_timestamps()
-                assert_array_equal(x=retrieved_aligned_timestamps, y=all_aligned_segment_timestamps[0])
+                assert_array_equal(retrieved_aligned_timestamps, all_aligned_segment_timestamps[0])
             else:
                 all_unaligned_timestamps = self.interface.get_timestamps()
                 all_aligned_segment_timestamps = [
@@ -674,7 +674,7 @@ class SortingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
                 for retrieved_aligned_timestamps, aligned_segment_timestamps in zip(
                     all_retrieved_aligned_timestamps, all_aligned_segment_timestamps
                 ):
-                    assert_array_equal(x=retrieved_aligned_timestamps, y=aligned_segment_timestamps)
+                    assert_array_equal(retrieved_aligned_timestamps, aligned_segment_timestamps)
 
     def check_shift_segment_timestamps_by_starting_times(self):
         self.setUpFreshInterface()
@@ -689,7 +689,7 @@ class SortingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
 
             retrieved_aligned_timestamps = self.interface.get_timestamps()
             expected_aligned_timestamps = unaligned_timestamps + aligned_segment_starting_times[0]
-            assert_array_equal(x=retrieved_aligned_timestamps, y=expected_aligned_timestamps)
+            assert_array_equal(retrieved_aligned_timestamps, expected_aligned_timestamps)
         else:
             all_unaligned_timestamps = self.interface.get_timestamps()
 
@@ -707,7 +707,7 @@ class SortingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
             for retrieved_aligned_timestamps, expected_aligned_timestamps in zip(
                 all_retrieved_aligned_timestamps, all_expected_aligned_timestamps
             ):
-                assert_array_equal(x=retrieved_aligned_timestamps, y=expected_aligned_timestamps)
+                assert_array_equal(retrieved_aligned_timestamps, expected_aligned_timestamps)
 
     def test_interface_alignment(self, setup_interface):
 
@@ -761,7 +761,7 @@ class VideoInterfaceMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
         self.interface.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
 
         retrieved_aligned_timestamps = self.interface.get_timestamps()
-        assert_array_equal(x=retrieved_aligned_timestamps, y=aligned_timestamps)
+        assert_array_equal(retrieved_aligned_timestamps, aligned_timestamps)
 
     def check_shift_timestamps_by_start_time(self):
         self.setUpFreshInterface()
@@ -774,7 +774,7 @@ class VideoInterfaceMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
         unaligned_timestamps = self.interface.get_original_timestamps()
         all_expected_timestamps = [timestamps + aligned_starting_time for timestamps in unaligned_timestamps]
         [
-            assert_array_equal(x=aligned_timestamps, y=expected_timestamps)
+            assert_array_equal(aligned_timestamps, expected_timestamps)
             for aligned_timestamps, expected_timestamps in zip(all_aligned_timestamps, all_expected_timestamps)
         ]
 
@@ -793,7 +793,7 @@ class VideoInterfaceMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
             for timestamps, segment_starting_time in zip(unaligned_timestamps, aligned_segment_starting_times)
         ]
         for aligned_timestamps, expected_timestamps in zip(all_aligned_timestamps, all_expected_timestamps):
-            assert_array_equal(x=aligned_timestamps, y=expected_timestamps)
+            assert_array_equal(aligned_timestamps, expected_timestamps)
 
     def check_interface_original_timestamps_inmutability(self):
         self.setUpFreshInterface()
@@ -810,7 +810,7 @@ class VideoInterfaceMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):
         for post_alignment_original_timestamps, pre_alignment_original_timestamps in zip(
             all_post_alignment_original_timestamps, all_pre_alignment_original_timestamps
         ):
-            assert_array_equal(x=post_alignment_original_timestamps, y=pre_alignment_original_timestamps)
+            assert_array_equal(post_alignment_original_timestamps, pre_alignment_original_timestamps)
 
 
 class MedPCInterfaceMixin(DataInterfaceTestMixin, TemporalAlignmentMixin):

--- a/tests/test_behavior/test_audio_interface.py
+++ b/tests/test_behavior/test_audio_interface.py
@@ -166,7 +166,7 @@ class TestAudioInterface(AudioInterfaceTestMixin):
             aligned_segment_starting_times=aligned_segment_starting_times
         )
 
-        assert_array_equal(x=self.interface._segment_starting_times, y=self.aligned_segment_starting_times)
+        assert_array_equal(self.interface._segment_starting_times, self.aligned_segment_starting_times)
 
     def test_set_aligned_starting_time(self):
         fresh_interface = AudioInterface(file_paths=self.file_paths[:2])
@@ -179,7 +179,7 @@ class TestAudioInterface(AudioInterfaceTestMixin):
         expecting_starting_times = [
             relative_starting_time + aligned_starting_time for relative_starting_time in relative_starting_times
         ]
-        assert_array_equal(x=fresh_interface._segment_starting_times, y=expecting_starting_times)
+        assert_array_equal(fresh_interface._segment_starting_times, expecting_starting_times)
 
     def test_run_conversion(self):
         file_paths = self.nwb_converter.data_interface_objects["Audio"].source_data["file_paths"]

--- a/tests/test_minimal/test_testing/test_mocks/test_mock_ttl.py
+++ b/tests/test_minimal/test_testing/test_mocks/test_mock_ttl.py
@@ -104,7 +104,7 @@ class TestMockTTLSignals(TestCase):
     def test_default(self):
         ttl_signal = generate_mock_ttl_signal()
 
-        assert_array_equal(x=ttl_signal, y=self.nwbfile.acquisition["DefaultTTLSignal"].data)
+        assert_array_equal(ttl_signal, self.nwbfile.acquisition["DefaultTTLSignal"].data)
 
     def test_irregular_short_pulses(self):
         ttl_signal = generate_mock_ttl_signal(
@@ -114,7 +114,7 @@ class TestMockTTLSignals(TestCase):
             sampling_frequency_hz=self.sampling_frequency_hz,
         )
 
-        assert_array_equal(x=ttl_signal, y=self.nwbfile.acquisition["IrregularShortPulses"].data)
+        assert_array_equal(ttl_signal, self.nwbfile.acquisition["IrregularShortPulses"].data)
 
     def test_non_default_regular(self):
         ttl_signal = generate_mock_ttl_signal(
@@ -124,7 +124,7 @@ class TestMockTTLSignals(TestCase):
             sampling_frequency_hz=self.sampling_frequency_hz,
         )
 
-        assert_array_equal(x=ttl_signal, y=self.nwbfile.acquisition["NonDefaultRegular"].data)
+        assert_array_equal(ttl_signal, self.nwbfile.acquisition["NonDefaultRegular"].data)
 
     def test_non_default_regular_adjusted_means(self):
         ttl_signal = generate_mock_ttl_signal(
@@ -136,7 +136,7 @@ class TestMockTTLSignals(TestCase):
             signal_mean=20000,
         )
 
-        assert_array_equal(x=ttl_signal, y=self.nwbfile.acquisition["NonDefaultRegularAdjustedMeans"].data)
+        assert_array_equal(ttl_signal, self.nwbfile.acquisition["NonDefaultRegularAdjustedMeans"].data)
 
     def test_irregular_short_pulses_adjusted_noise(self):
         ttl_signal = generate_mock_ttl_signal(
@@ -147,7 +147,7 @@ class TestMockTTLSignals(TestCase):
             channel_noise=2,
         )
 
-        assert_array_equal(x=ttl_signal, y=self.nwbfile.acquisition["IrregularShortPulsesAdjustedNoise"].data)
+        assert_array_equal(ttl_signal, self.nwbfile.acquisition["IrregularShortPulsesAdjustedNoise"].data)
 
     def test_non_default_regular_floats(self):
         ttl_signal = generate_mock_ttl_signal(
@@ -158,7 +158,7 @@ class TestMockTTLSignals(TestCase):
             dtype="float32",
         )
 
-        assert_array_equal(x=ttl_signal, y=self.nwbfile.acquisition["NonDefaultRegularFloats"].data)
+        assert_array_equal(ttl_signal, self.nwbfile.acquisition["NonDefaultRegularFloats"].data)
 
     def test_non_default_regular_as_uint16(self):
         ttl_signal = generate_mock_ttl_signal(
@@ -169,7 +169,7 @@ class TestMockTTLSignals(TestCase):
             dtype="uint16",
         )
 
-        assert_array_equal(x=ttl_signal, y=self.nwbfile.acquisition["NonDefaultRegularUInt16"].data)
+        assert_array_equal(ttl_signal, self.nwbfile.acquisition["NonDefaultRegularUInt16"].data)
 
     def test_non_default_regular_floats_adjusted_means_and_noise(self):
         ttl_signal = generate_mock_ttl_signal(
@@ -183,7 +183,7 @@ class TestMockTTLSignals(TestCase):
             channel_noise=0.4,
         )
 
-        assert_array_equal(x=ttl_signal, y=self.nwbfile.acquisition["FloatsAdjustedMeansAndNoise"].data)
+        assert_array_equal(ttl_signal, self.nwbfile.acquisition["FloatsAdjustedMeansAndNoise"].data)
 
     def test_irregular_short_pulses_different_seed(self):
         ttl_signal = generate_mock_ttl_signal(
@@ -194,4 +194,4 @@ class TestMockTTLSignals(TestCase):
             random_seed=1,
         )
 
-        assert_array_equal(x=ttl_signal, y=self.nwbfile.acquisition["IrregularShortPulsesDifferentSeed"].data)
+        assert_array_equal(ttl_signal, self.nwbfile.acquisition["IrregularShortPulsesDifferentSeed"].data)

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_configure_backend_defaults.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_configure_backend_defaults.py
@@ -81,7 +81,7 @@ def test_simple_time_series(
         elif backend == "zarr":
             assert written_data.compressor == numcodecs.GZip(level=1)
 
-        assert_array_equal(x=integer_array, y=written_data[:])
+        assert_array_equal(integer_array, written_data[:])
 
 
 @pytest.mark.parametrize("backend", ["hdf5", "zarr"])
@@ -114,7 +114,7 @@ def test_simple_dynamic_table(tmpdir: Path, integer_array: np.ndarray, backend: 
         elif backend == "zarr":
             assert written_data.compressor == numcodecs.GZip(level=1)
 
-        assert_array_equal(x=integer_array, y=written_data[:])
+        assert_array_equal(integer_array, written_data[:])
 
 
 @pytest.mark.parametrize(
@@ -177,7 +177,7 @@ def test_time_series_timestamps_linkage(
             assert written_data_1.compression == "gzip"
         elif backend == "zarr":
             assert written_data_1.compressor == numcodecs.GZip(level=1)
-        assert_array_equal(x=integer_array, y=written_data_1[:])
+        assert_array_equal(integer_array, written_data_1[:])
 
         written_data_2 = written_nwbfile.acquisition["TestTimeSeries2"].data
         assert written_data_2.chunks == dataset_configuration_2.chunk_shape
@@ -185,7 +185,7 @@ def test_time_series_timestamps_linkage(
             assert written_data_2.compression == "gzip"
         elif backend == "zarr":
             assert written_data_2.compressor == numcodecs.GZip(level=1)
-        assert_array_equal(x=integer_array, y=written_data_2[:])
+        assert_array_equal(integer_array, written_data_2[:])
 
         written_timestamps_1 = written_nwbfile.acquisition["TestTimeSeries1"].timestamps
         assert written_timestamps_1.chunks == timestamps_configuration_1.chunk_shape
@@ -193,7 +193,7 @@ def test_time_series_timestamps_linkage(
             assert written_timestamps_1.compression == "gzip"
         elif backend == "zarr":
             assert written_timestamps_1.compressor == numcodecs.GZip(level=1)
-        assert_array_equal(x=timestamps_array, y=written_timestamps_1[:])
+        assert_array_equal(timestamps_array, written_timestamps_1[:])
 
         written_timestamps_2 = written_nwbfile.acquisition["TestTimeSeries2"].timestamps
         assert written_timestamps_2 == written_timestamps_1

--- a/tests/test_minimal/test_tools/test_signal_processing.py
+++ b/tests/test_minimal/test_tools/test_signal_processing.py
@@ -28,10 +28,10 @@ class TestGetRisingAndFallingTimesFromTTL(TestCase):
         falling_frames = get_falling_frames_from_ttl(trace=ttl_signal)
 
         expected_rising_frames = np.array([25_000, 75_000, 125_000])
-        assert_array_equal(x=rising_frames, y=expected_rising_frames)
+        assert_array_equal(rising_frames, expected_rising_frames)
 
         expected_falling_frames = np.array([50_000, 100_000, 150_000])
-        assert_array_equal(x=falling_frames, y=expected_falling_frames)
+        assert_array_equal(falling_frames, expected_falling_frames)
 
     def test_explicit_original_defaults(self):
         ttl_signal = generate_mock_ttl_signal(
@@ -50,10 +50,10 @@ class TestGetRisingAndFallingTimesFromTTL(TestCase):
         falling_frames = get_falling_frames_from_ttl(trace=ttl_signal)
 
         expected_rising_frames = np.array([25_000, 75_000, 125_000])
-        assert_array_equal(x=rising_frames, y=expected_rising_frames)
+        assert_array_equal(rising_frames, expected_rising_frames)
 
         expected_falling_frames = np.array([50_000, 100_000, 150_000])
-        assert_array_equal(x=falling_frames, y=expected_falling_frames)
+        assert_array_equal(falling_frames, expected_falling_frames)
 
     def test_start_during_on_pulse_int16(self):
         """
@@ -67,10 +67,10 @@ class TestGetRisingAndFallingTimesFromTTL(TestCase):
         falling_frames = get_falling_frames_from_ttl(trace=ttl_signal)
 
         expected_rising_frames = np.empty(shape=0)
-        assert_array_equal(x=rising_frames, y=expected_rising_frames)
+        assert_array_equal(rising_frames, expected_rising_frames)
 
         expected_falling_frames = np.array([25_000])
-        assert_array_equal(x=falling_frames, y=expected_falling_frames)
+        assert_array_equal(falling_frames, expected_falling_frames)
 
     def test_end_during_on_pulse_int16(self):
         """
@@ -84,10 +84,10 @@ class TestGetRisingAndFallingTimesFromTTL(TestCase):
         falling_frames = get_falling_frames_from_ttl(trace=ttl_signal)
 
         expected_rising_frames = np.array([62_500])
-        assert_array_equal(x=rising_frames, y=expected_rising_frames)
+        assert_array_equal(rising_frames, expected_rising_frames)
 
         expected_falling_frames = np.empty(shape=0)
-        assert_array_equal(x=falling_frames, y=expected_falling_frames)
+        assert_array_equal(falling_frames, expected_falling_frames)
 
     def test_end_during_off_pulse_int16(self):
         """A couple of normal TTL pulses at the specified time."""
@@ -97,10 +97,10 @@ class TestGetRisingAndFallingTimesFromTTL(TestCase):
         falling_frames = get_falling_frames_from_ttl(trace=ttl_signal)
 
         expected_rising_frames = np.array([27_500, 155_000])
-        assert_array_equal(x=rising_frames, y=expected_rising_frames)
+        assert_array_equal(rising_frames, expected_rising_frames)
 
         expected_falling_frames = np.array([77_500, 205_000])
-        assert_array_equal(x=falling_frames, y=expected_falling_frames)
+        assert_array_equal(falling_frames, expected_falling_frames)
 
     def test_start_during_on_pulse_floats(self):
         """
@@ -114,10 +114,10 @@ class TestGetRisingAndFallingTimesFromTTL(TestCase):
         falling_frames = get_falling_frames_from_ttl(trace=ttl_signal)
 
         expected_rising_frames = np.empty(shape=0)
-        assert_array_equal(x=rising_frames, y=expected_rising_frames)
+        assert_array_equal(rising_frames, expected_rising_frames)
 
         expected_falling_frames = np.array([25_000])
-        assert_array_equal(x=falling_frames, y=expected_falling_frames)
+        assert_array_equal(falling_frames, expected_falling_frames)
 
     def test_end_during_on_pulse_floats(self):
         """
@@ -131,10 +131,10 @@ class TestGetRisingAndFallingTimesFromTTL(TestCase):
         falling_frames = get_falling_frames_from_ttl(trace=ttl_signal)
 
         expected_rising_frames = np.array([62_500])
-        assert_array_equal(x=rising_frames, y=expected_rising_frames)
+        assert_array_equal(rising_frames, expected_rising_frames)
 
         expected_falling_frames = np.empty(shape=0)
-        assert_array_equal(x=falling_frames, y=expected_falling_frames)
+        assert_array_equal(falling_frames, expected_falling_frames)
 
     def test_end_during_off_pulse_floats(self):
         """A couple of normal TTL pulses at the specified time."""
@@ -146,10 +146,10 @@ class TestGetRisingAndFallingTimesFromTTL(TestCase):
         falling_frames = get_falling_frames_from_ttl(trace=ttl_signal)
 
         expected_rising_frames = np.array([27_500, 155_000])
-        assert_array_equal(x=rising_frames, y=expected_rising_frames)
+        assert_array_equal(rising_frames, expected_rising_frames)
 
         expected_falling_frames = np.array([77_500, 205_000])
-        assert_array_equal(x=falling_frames, y=expected_falling_frames)
+        assert_array_equal(falling_frames, expected_falling_frames)
 
     def test_custom_threshold_floats(self):
         ttl_signal = generate_mock_ttl_signal(
@@ -160,7 +160,7 @@ class TestGetRisingAndFallingTimesFromTTL(TestCase):
         falling_frames = get_falling_frames_from_ttl(trace=ttl_signal, threshold=1.5)
 
         expected_rising_frames = np.array([27_500, 155_000])
-        assert_array_equal(x=rising_frames, y=expected_rising_frames)
+        assert_array_equal(rising_frames, expected_rising_frames)
 
         expected_falling_frames = np.array([77_500, 205_000])
-        assert_array_equal(x=falling_frames, y=expected_falling_frames)
+        assert_array_equal(falling_frames, expected_falling_frames)

--- a/tests/test_on_data/test_temporal_alignment/test_temporal_alignment_methods.py
+++ b/tests/test_on_data/test_temporal_alignment/test_temporal_alignment_methods.py
@@ -79,15 +79,15 @@ class TestNIDQInterfacePulseTimesAlignment(TestCase):
 
             # Aligned data was written
             assert_array_almost_equal(
-                x=nwbfile.acquisition["BehaviorEvents"]["event_time"][:],
-                y=self.aligned_behavior_event_timestamps,
+                nwbfile.acquisition["BehaviorEvents"]["event_time"][:],
+                self.aligned_behavior_event_timestamps,
             )
             assert_array_almost_equal(
-                x=nwbfile.intervals["trials"]["start_time"][:], y=self.aligned_trial_start_times, decimal=4
+                nwbfile.intervals["trials"]["start_time"][:], self.aligned_trial_start_times, decimal=4
             )
             assert_array_almost_equal(
-                x=nwbfile.intervals["trials"]["stop_time"][:],
-                y=self.aligned_trial_start_times + self.regular_trial_length,
+                nwbfile.intervals["trials"]["stop_time"][:],
+                self.aligned_trial_start_times + self.regular_trial_length,
                 decimal=4,
             )
 
@@ -109,27 +109,27 @@ class TestNIDQInterfacePulseTimesAlignment(TestCase):
         )
 
         assert_array_equal(
-            x=self.trial_interface.get_timestamps(column="start_time"), y=inferred_aligned_trial_start_timestamps
+            self.trial_interface.get_timestamps(column="start_time"), inferred_aligned_trial_start_timestamps
         )
         assert_array_almost_equal(
-            x=self.trial_interface.get_timestamps(column="stop_time"),
-            y=inferred_aligned_trial_start_timestamps + self.regular_trial_length,
+            self.trial_interface.get_timestamps(column="stop_time"),
+            inferred_aligned_trial_start_timestamps + self.regular_trial_length,
             decimal=2,
         )
-        assert_array_almost_equal(x=self.behavior_interface.get_timestamps(), y=self.aligned_behavior_event_timestamps)
+        assert_array_almost_equal(self.behavior_interface.get_timestamps(), self.aligned_behavior_event_timestamps)
 
         # Check original unaltered timestamps are the same
         assert_array_equal(
-            x=self.trial_interface.get_original_timestamps(column="start_time"),
-            y=self.expected_unaligned_trial_start_times,
+            self.trial_interface.get_original_timestamps(column="start_time"),
+            self.expected_unaligned_trial_start_times,
         )
         assert_array_equal(
-            x=self.trial_interface.get_original_timestamps(column="stop_time"),
-            y=self.expected_unaligned_trial_start_times + self.regular_trial_length,
+            self.trial_interface.get_original_timestamps(column="stop_time"),
+            self.expected_unaligned_trial_start_times + self.regular_trial_length,
         )
         assert_array_equal(
-            x=self.behavior_interface.get_original_timestamps(),
-            y=self.unaligned_behavior_event_timestamps,
+            self.behavior_interface.get_original_timestamps(),
+            self.unaligned_behavior_event_timestamps,
         )
 
         converter = ConverterPipe(data_interfaces=[self.nidq_interface, self.trial_interface, self.behavior_interface])
@@ -250,16 +250,16 @@ class TestExternalPulseTimesAlignment(TestNIDQInterfacePulseTimesAlignment):
 
             # Aligned data was written
             assert_array_almost_equal(
-                x=nwbfile.acquisition["BehaviorEvents"]["event_time"][:],
-                y=self.aligned_behavior_event_timestamps,
+                nwbfile.acquisition["BehaviorEvents"]["event_time"][:],
+                self.aligned_behavior_event_timestamps,
                 decimal=4,
             )
             assert_array_almost_equal(
-                x=nwbfile.intervals["trials"]["start_time"][:], y=self.aligned_trial_start_times, decimal=5
+                nwbfile.intervals["trials"]["start_time"][:], self.aligned_trial_start_times, decimal=5
             )
             assert_array_almost_equal(
-                x=nwbfile.intervals["trials"]["stop_time"][:],
-                y=self.aligned_trial_start_times + self.regular_trial_length,
+                nwbfile.intervals["trials"]["stop_time"][:],
+                self.aligned_trial_start_times + self.regular_trial_length,
                 decimal=5,
             )
 
@@ -281,27 +281,27 @@ class TestExternalPulseTimesAlignment(TestNIDQInterfacePulseTimesAlignment):
             aligned_timestamps=externally_aligned_timestamps,
         )
 
-        assert_array_equal(x=self.trial_interface.get_timestamps(column="start_time"), y=externally_aligned_timestamps)
+        assert_array_equal(self.trial_interface.get_timestamps(column="start_time"), externally_aligned_timestamps)
         assert_array_equal(
-            x=self.trial_interface.get_timestamps(column="stop_time"),
-            y=externally_aligned_timestamps + self.regular_trial_length,
+            self.trial_interface.get_timestamps(column="stop_time"),
+            externally_aligned_timestamps + self.regular_trial_length,
         )
         assert_array_almost_equal(
-            x=self.behavior_interface.get_timestamps(), y=self.aligned_behavior_event_timestamps, decimal=4
+            self.behavior_interface.get_timestamps(), self.aligned_behavior_event_timestamps, decimal=4
         )
 
         # Check original unaltered timestamps are the same
         assert_array_equal(
-            x=self.trial_interface.get_original_timestamps(column="start_time"),
-            y=self.expected_unaligned_trial_start_times,
+            self.trial_interface.get_original_timestamps(column="start_time"),
+            self.expected_unaligned_trial_start_times,
         )
         assert_array_equal(
-            x=self.trial_interface.get_original_timestamps(column="stop_time"),
-            y=self.expected_unaligned_trial_start_times + self.regular_trial_length,
+            self.trial_interface.get_original_timestamps(column="stop_time"),
+            self.expected_unaligned_trial_start_times + self.regular_trial_length,
         )
         assert_array_equal(
-            x=self.behavior_interface.get_original_timestamps(),
-            y=self.unaligned_behavior_event_timestamps,
+            self.behavior_interface.get_original_timestamps(),
+            self.unaligned_behavior_event_timestamps,
         )
 
         converter = ConverterPipe(data_interfaces=[self.trial_interface, self.behavior_interface])
@@ -440,25 +440,25 @@ class TestNIDQInterfaceOnSignalAlignment(TestNIDQInterfacePulseTimesAlignment):
         self.trial_interface.set_aligned_starting_time(aligned_starting_time=inferred_aligned_trial_start_time)
         self.behavior_interface.set_aligned_starting_time(aligned_starting_time=inferred_aligned_trial_start_time)
 
-        assert_array_equal(x=self.trial_interface.get_timestamps(column="start_time"), y=self.aligned_trial_start_times)
+        assert_array_equal(self.trial_interface.get_timestamps(column="start_time"), self.aligned_trial_start_times)
         assert_array_equal(
-            x=self.trial_interface.get_timestamps(column="stop_time"),
-            y=self.aligned_trial_start_times + self.regular_trial_length,
+            self.trial_interface.get_timestamps(column="stop_time"),
+            self.aligned_trial_start_times + self.regular_trial_length,
         )
-        assert_array_almost_equal(x=self.behavior_interface.get_timestamps(), y=self.aligned_behavior_event_timestamps)
+        assert_array_almost_equal(self.behavior_interface.get_timestamps(), self.aligned_behavior_event_timestamps)
 
         # Check original unaltered timestamps are the same
         assert_array_equal(
-            x=self.trial_interface.get_original_timestamps(column="start_time"),
-            y=self.expected_unaligned_trial_start_times,
+            self.trial_interface.get_original_timestamps(column="start_time"),
+            self.expected_unaligned_trial_start_times,
         )
         assert_array_equal(
-            x=self.trial_interface.get_original_timestamps(column="stop_time"),
-            y=self.expected_unaligned_trial_start_times + self.regular_trial_length,
+            self.trial_interface.get_original_timestamps(column="stop_time"),
+            self.expected_unaligned_trial_start_times + self.regular_trial_length,
         )
         assert_array_equal(
-            x=self.behavior_interface.get_original_timestamps(),
-            y=self.unaligned_behavior_event_timestamps,
+            self.behavior_interface.get_original_timestamps(),
+            self.unaligned_behavior_event_timestamps,
         )
 
         converter = ConverterPipe(data_interfaces=[self.nidq_interface, self.trial_interface, self.behavior_interface])


### PR DESCRIPTION
More support for numpy 2.0 in the testing suite.

* I need to change the representation in some warning functions because of this:

https://numpy.org/devdocs/release/2.0.0-notes.html#representation-of-numpy-scalars-changed

* And also:

> Use of keyword arguments x and y with functions assert_array_equal and assert_array_almost_equal has been deprecated. Pass the first two arguments as positional arguments instead.


https://numpy.org/devdocs/release/2.0.0-notes.html#deprecations