### PR TITLE
Filter out warning for missing timezone in the CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Support roiextractors 0.5.11 [PR #1236](https://github.com/catalystneuro/neuroconv/pull/1236)
 
 ## Improvements
-
+* Filter out warnings for missing timezone information in continuous integration [PR #1240](https://github.com/catalystneuro/neuroconv/pull/1240)
 
 # v0.7.1 (March 5, 2025)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -360,7 +360,9 @@ minversion = "6.0"
 addopts = "-ra --doctest-glob='*.rst'"
 testpaths = ["docs/conversion_examples_gallery/", "tests"]
 doctest_optionflags = "ELLIPSIS"
-
+filterwarnings = [
+    "ignore:Date is missing timezone information. Updating to local timezone.:UserWarning:pynwb.file"
+]
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
Having many warnings on the CI makes navigating the CI log harder. For many tests, we artificially add a timezone because one isn't available, making the warning pointless in the CI context. I'd like to filter these warnings out of the CI. If there are cases where the timezone is critical, I believe we should have explicit test failures rather than warnings.

What do you think?