### PR TITLE
Added support for changing names in VideoInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Improvements
 * Change `np.NAN` to `np.nan` to support numpy 2.0 [PR #1245](https://github.com/catalystneuro/neuroconv/pull/1245)
+* Added support for changing names in VideoInterface [PR #1244](https://github.com/catalystneuro/neuroconv/pull/1244)
 
 # v0.7.1 (March 5, 2025)
 

--- a/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
@@ -32,6 +32,7 @@ class VideoInterface(BaseDataInterface):
     def __init__(
         self,
         file_paths: list[FilePath],
+        video_names: list[str] = None,
         verbose: bool = False,
         *,
         metadata_key_name: str = "Videos",
@@ -44,6 +45,9 @@ class VideoInterface(BaseDataInterface):
         file_paths : list of FilePaths
             Many video storage formats segment a sequence of videos over the course of the experiment.
             Pass the file paths for this videos as a list in sorted, consecutive order.
+        video_names : list of str, optional
+            The names of the videos to be used in the metadata.
+            If not provided, the names will be inferred from the file paths.
         metadata_key_name : str, optional
             The key used to identify this video data within the overall experiment metadata.
             Defaults to "Videos".
@@ -75,6 +79,9 @@ class VideoInterface(BaseDataInterface):
         self._timestamps = None
         self._segment_starting_times = None
         self.metadata_key_name = metadata_key_name
+        self._video_names = (
+            video_names if video_names is not None else [Path(file_path).stem for file_path in file_paths]
+        )
         super().__init__(file_paths=file_paths)
 
     def get_metadata_schema(self):
@@ -97,8 +104,7 @@ class VideoInterface(BaseDataInterface):
         metadata = super().get_metadata()
         behavior_metadata = {
             self.metadata_key_name: [
-                dict(name=f"Video {Path(file_path).stem}", description="Video recorded by camera.", unit="Frames")
-                for file_path in self.source_data["file_paths"]
+                dict(name=name, description="Video recorded by camera.", unit="Frames") for name in self._video_names
             ]
         }
         metadata["Behavior"] = behavior_metadata

--- a/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
@@ -82,7 +82,7 @@ class VideoInterface(BaseDataInterface):
         self._segment_starting_times = None
         self.metadata_key_name = metadata_key_name
         self._video_names = (
-            video_names if video_names is not None else [Path(file_path).stem for file_path in file_paths]
+            video_names if video_names is not None else [f"Video {Path(file_path).stem}" for file_path in file_paths]
         )
         super().__init__(file_paths=file_paths)
 

--- a/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
@@ -32,9 +32,9 @@ class VideoInterface(BaseDataInterface):
     def __init__(
         self,
         file_paths: list[FilePath],
-        video_names: list[str] = None,
         verbose: bool = False,
         *,
+        video_names: list[str] = None,
         metadata_key_name: str = "Videos",
     ):
         """
@@ -45,6 +45,8 @@ class VideoInterface(BaseDataInterface):
         file_paths : list of FilePaths
             Many video storage formats segment a sequence of videos over the course of the experiment.
             Pass the file paths for this videos as a list in sorted, consecutive order.
+        verbose : bool, optional
+            If True, display verbose output.
         video_names : list of str, optional
             The names of the videos to be used in the metadata.
             If not provided, the names will be inferred from the file paths.

--- a/tests/test_behavior/test_video_interface.py
+++ b/tests/test_behavior/test_video_interface.py
@@ -98,6 +98,32 @@ class TestVideoInterface(TestCase):
         )
         return VideoTestNWBConverter(source_data=source_data)
 
+    def test_video_names_parameter(self):
+        """Test that the video_names parameter works correctly."""
+        # Test with custom video_names
+        custom_names = ["Custom Video 1", "Custom Video 2", "Custom Video 3"]
+        interface_with_names = VideoInterface(
+            file_paths=self.video_files, video_names=custom_names, metadata_key_name="CustomVideos"
+        )
+        metadata_with_names = interface_with_names.get_metadata()
+
+        # Verify custom names are used in metadata
+        video_metadata = metadata_with_names["Behavior"]["CustomVideos"]
+        self.assertEqual(len(video_metadata), len(custom_names))
+        for i, name in enumerate(custom_names):
+            self.assertEqual(video_metadata[i]["name"], name)
+
+        # Test without video_names (default behavior)
+        interface_without_names = VideoInterface(file_paths=self.video_files, metadata_key_name="DefaultVideos")
+        metadata_without_names = interface_without_names.get_metadata()
+
+        # Verify default names are used in metadata
+        video_metadata = metadata_without_names["Behavior"]["DefaultVideos"]
+        self.assertEqual(len(video_metadata), len(self.video_files))
+        for i, file_path in enumerate(self.video_files):
+            expected_name = f"Video {Path(file_path).stem}"
+            self.assertEqual(video_metadata[i]["name"], expected_name)
+
 
 @unittest.skipIf(skip_test, "cv2 not installed")
 class TestExternalVideoInterface(TestVideoInterface):

--- a/tests/test_behavior/test_video_interface.py
+++ b/tests/test_behavior/test_video_interface.py
@@ -110,8 +110,8 @@ class TestVideoInterface(TestCase):
         # Verify custom names are used in metadata
         video_metadata = metadata_with_names["Behavior"]["CustomVideos"]
         self.assertEqual(len(video_metadata), len(custom_names))
-        for i, name in enumerate(custom_names):
-            self.assertEqual(video_metadata[i]["name"], name)
+        for meta, name in zip(video_metadata, custom_names):
+            self.assertEqual(meta["name"], name)
 
         # Test without video_names (default behavior)
         interface_without_names = VideoInterface(file_paths=self.video_files, metadata_key_name="DefaultVideos")
@@ -120,9 +120,9 @@ class TestVideoInterface(TestCase):
         # Verify default names are used in metadata
         video_metadata = metadata_without_names["Behavior"]["DefaultVideos"]
         self.assertEqual(len(video_metadata), len(self.video_files))
-        for i, file_path in enumerate(self.video_files):
+        for meta, file_path in zip(video_metadata, self.video_files):
             expected_name = f"Video {Path(file_path).stem}"
-            self.assertEqual(video_metadata[i]["name"], expected_name)
+            self.assertEqual(meta["name"], expected_name)
 
 
 @unittest.skipIf(skip_test, "cv2 not installed")


### PR DESCRIPTION
Fixes #1243 

Cline (Claude 3.7 Sonnet) re-initialized memory bank and wrote the new test for $0.37
<details>
Prompt:

```
Follow your custom instructions.

Here is a description of the task we are working on:
I just added the optional video_names argument to VideoInterface and now I need to add a test to make sure that it works. Please add a test to test_video_interface.py following the examples already present in that file.

Initialize the memory bank accordingly
```

</details>