### PR TITLE
`np.NaN` to `np.nan`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Support roiextractors 0.5.11 [PR #1236](https://github.com/catalystneuro/neuroconv/pull/1236)
 
 ## Improvements
-* Change `np.NAN` to `np.nan` to support numpy 2.0 [PR #1237](https://github.com/catalystneuro/neuroconv/pull/1237)
+* Change `np.NAN` to `np.nan` to support numpy 2.0 [PR #1245](https://github.com/catalystneuro/neuroconv/pull/1245)
 
 # v0.7.1 (March 5, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Support roiextractors 0.5.11 [PR #1236](https://github.com/catalystneuro/neuroconv/pull/1236)
 
 ## Improvements
-
+* Change `np.NAN` to `np.nan` to support numpy 2.0 [PR #1237](https://github.com/catalystneuro/neuroconv/pull/1237)
 
 # v0.7.1 (March 5, 2025)
 

--- a/tests/test_on_data/ophys/test_imaging_interfaces.py
+++ b/tests/test_on_data/ophys/test_imaging_interfaces.py
@@ -390,13 +390,13 @@ class TestBrukerTiffImagingInterface(ImagingExtractorInterfaceTestMixin):
         cls.device_metadata = dict(name="BrukerFluorescenceMicroscope", description="Version 5.6.64.400")
         cls.optical_channel_metadata = dict(
             name="Ch2",
-            emission_lambda=np.NAN,
+            emission_lambda=np.nan,
             description="An optical channel of the microscope.",
         )
         cls.imaging_plane_metadata = dict(
             name="ImagingPlane",
             description="The imaging plane origin_coords units are in the microscope reference frame.",
-            excitation_lambda=np.NAN,
+            excitation_lambda=np.nan,
             indicator="unknown",
             location="unknown",
             device=cls.device_metadata["name"],
@@ -470,13 +470,13 @@ class TestBrukerTiffImagingInterfaceDualPlaneCase(ImagingExtractorInterfaceTestM
         cls.available_streams = dict(channel_streams=["Ch2"], plane_streams=dict(Ch2=["Ch2_000001"]))
         cls.optical_channel_metadata = dict(
             name="Ch2",
-            emission_lambda=np.NAN,
+            emission_lambda=np.nan,
             description="An optical channel of the microscope.",
         )
         cls.imaging_plane_metadata = dict(
             name="ImagingPlane",
             description="The imaging plane origin_coords units are in the microscope reference frame.",
-            excitation_lambda=np.NAN,
+            excitation_lambda=np.nan,
             indicator="unknown",
             location="unknown",
             device=cls.device_metadata["name"],
@@ -545,13 +545,13 @@ class TestBrukerTiffImagingInterfaceDualPlaneDisjointCase(ImagingExtractorInterf
         cls.available_streams = dict(channel_streams=["Ch2"], plane_streams=dict(Ch2=["Ch2_000001", "Ch2_000002"]))
         cls.optical_channel_metadata = dict(
             name="Ch2",
-            emission_lambda=np.NAN,
+            emission_lambda=np.nan,
             description="An optical channel of the microscope.",
         )
         cls.imaging_plane_metadata = dict(
             name="ImagingPlaneCh2000002",
             description="The imaging plane origin_coords units are in the microscope reference frame.",
-            excitation_lambda=np.NAN,
+            excitation_lambda=np.nan,
             indicator="unknown",
             location="unknown",
             device=cls.device_metadata["name"],
@@ -635,13 +635,13 @@ class TestBrukerTiffImagingInterfaceDualColorCase(ImagingExtractorInterfaceTestM
         cls.available_streams = dict(channel_streams=["Ch1", "Ch2"], plane_streams=dict())
         cls.optical_channel_metadata = dict(
             name="Ch2",
-            emission_lambda=np.NAN,
+            emission_lambda=np.nan,
             description="An optical channel of the microscope.",
         )
         cls.imaging_plane_metadata = dict(
             name="ImagingPlaneCh2",
             description="The imaging plane origin_coords units are in the microscope reference frame.",
-            excitation_lambda=np.NAN,
+            excitation_lambda=np.nan,
             indicator="unknown",
             location="unknown",
             device=cls.device_metadata["name"],
@@ -717,13 +717,13 @@ class TestMicroManagerTiffImagingInterface(ImagingExtractorInterfaceTestMixin):
         cls.device_metadata = dict(name="Microscope")
         cls.optical_channel_metadata = dict(
             name="OpticalChannelDefault",
-            emission_lambda=np.NAN,
+            emission_lambda=np.nan,
             description="An optical channel of the microscope.",
         )
         cls.imaging_plane_metadata = dict(
             name="ImagingPlane",
             description="The plane or volume being imaged by the microscope.",
-            excitation_lambda=np.NAN,
+            excitation_lambda=np.nan,
             indicator="unknown",
             location="unknown",
             device=cls.device_metadata["name"],


### PR DESCRIPTION
This error has appeared on #1238 and #1117. I think it will break other tests on the CI and we should move fix it now. 

Part of the series of numpy 2.0 breaking changes I think.