### PR TITLE
Improve error on `ScanImageImagingInterface` with multiple channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Improvements
 * Change `np.NAN` to `np.nan` to support numpy 2.0 [PR #1245](https://github.com/catalystneuro/neuroconv/pull/1245)
-* Improve error display on scan image interfaces [PR #1246(https://github.com/catalystneuro/neuroconv/pull/1246)
+* Improve error display on scan image interfaces [PR #1246](https://github.com/catalystneuro/neuroconv/pull/1246)
 
 # v0.7.1 (March 5, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Improvements
 * Change `np.NAN` to `np.nan` to support numpy 2.0 [PR #1245](https://github.com/catalystneuro/neuroconv/pull/1245)
+* Improve error display on scan image [PR #1245](https://github.com/catalystneuro/neuroconv/pull/1245)
 
 # v0.7.1 (March 5, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Improvements
 * Change `np.NAN` to `np.nan` to support numpy 2.0 [PR #1245](https://github.com/catalystneuro/neuroconv/pull/1245)
-* Improve error display on scan image [PR #1245](https://github.com/catalystneuro/neuroconv/pull/1245)
+* Improve error display on scan image interfaces [PR #1246(https://github.com/catalystneuro/neuroconv/pull/1246)
 
 # v0.7.1 (March 5, 2025)
 

--- a/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterfaces.py
+++ b/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterfaces.py
@@ -407,7 +407,7 @@ class ScanImageMultiPlaneMultiFileImagingInterface(BaseImagingExtractorInterface
         file_pattern : str
             Pattern for the TIFF files to read -- see pathlib.Path.glob for details.
         channel_name : str
-            The name of the channel to load, to determine what channels are available use ScanImageTiffSinglePlaneImagingExtractor.get_avaliable_channels(file_path=...).
+            The name of the channel to load, to determine what channels are available use ScanImageTiffSinglePlaneImagingExtractor.get_available_channels(file_path=...).
         extract_all_metadata : bool
             If True, extract metadata from every file in the folder. If False, only extract metadata from the first
             file in the folder. The default is False.

--- a/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterfaces.py
+++ b/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterfaces.py
@@ -308,9 +308,8 @@ class ScanImageMultiPlaneImagingInterface(BaseImagingExtractorInterface):
         if channel_name is None:
             if len(avaliable_channels) > 1:
                 raise ValueError(
-                    "More than one channel is detected! Please specify which channel you wish to load "
-                    "with the `channel_name` argument. To see which channels are available, use "
-                    "`ScanImageTiffSinglePlaneImagingExtractor.get_available_channels(file_path=...)`"
+                    "More than one channel is detected! Please specify which channel you wish to load with the `channel_name` argument "
+                    f"available chanenls are: {avaliable_channels}"
                 )
             channel_name = avaliable_channels[0]
         assert channel_name in avaliable_channels, f"Channel '{channel_name}' not found in the tiff file."
@@ -405,7 +404,7 @@ class ScanImageMultiPlaneMultiFileImagingInterface(BaseImagingExtractorInterface
         file_pattern : str
             Pattern for the TIFF files to read -- see pathlib.Path.glob for details.
         channel_name : str
-            The name of the channel to load, to determine what channels are available use ScanImageTiffSinglePlaneImagingExtractor.get_available_channels(file_path=...).
+            The name of the channel to load, to determine what channels are available use ScanImageTiffSinglePlaneImagingExtractor.get_avaliable_channels(file_path=...).
         extract_all_metadata : bool
             If True, extract metadata from every file in the folder. If False, only extract metadata from the first
             file in the folder. The default is False.
@@ -436,9 +435,8 @@ class ScanImageMultiPlaneMultiFileImagingInterface(BaseImagingExtractorInterface
         if channel_name is None:
             if len(avaliable_channels) > 1:
                 raise ValueError(
-                    "More than one channel is detected! Please specify which channel you wish to load "
-                    "with the `channel_name` argument. To see which channels are available, use "
-                    "`ScanImageTiffSinglePlaneImagingExtractor.get_available_channels(file_path=...)`"
+                    "More than one channel is detected! Please specify which channel you wish to load with the `channel_name` argument "
+                    f"available chanenls are: {avaliable_channels}"
                 )
             channel_name = avaliable_channels[0]
         assert channel_name in avaliable_channels, f"Channel '{channel_name}' not found in the tiff file."
@@ -535,7 +533,7 @@ class ScanImageSinglePlaneImagingInterface(BaseImagingExtractorInterface):
         file_path : FilePath
             Path to the TIFF file.
         channel_name : str
-            The name of the channel to load, to determine what channels are available use ScanImageTiffSinglePlaneImagingExtractor.get_available_channels(file_path=...).
+            The name of the channel to load, to determine what channels are available use ScanImageTiffSinglePlaneImagingExtractor.get_avaliable_channels(file_path=...).
         plane_name : str
             The name of the plane to load, to determine what planes are available use ScanImageTiffSinglePlaneImagingExtractor.get_available_planes(file_path=...).
         """
@@ -556,9 +554,8 @@ class ScanImageSinglePlaneImagingInterface(BaseImagingExtractorInterface):
         if channel_name is None:
             if len(avaliable_channels) > 1:
                 raise ValueError(
-                    "More than one channel is detected! Please specify which channel you wish to load "
-                    "with the `channel_name` argument. To see which channels are available, use "
-                    "`ScanImageTiffSinglePlaneImagingExtractor.get_available_channels(file_path=...)`"
+                    "More than one channel is detected! Please specify which channel you wish to load with the `channel_name` argument "
+                    f"available chanenls are: {avaliable_channels}"
                 )
             channel_name = avaliable_channels[0]
         assert channel_name in avaliable_channels, f"Channel '{channel_name}' not found in the tiff file."
@@ -696,9 +693,8 @@ class ScanImageSinglePlaneMultiFileImagingInterface(BaseImagingExtractorInterfac
         if channel_name is None:
             if len(avaliable_channels) > 1:
                 raise ValueError(
-                    "More than one channel is detected! Please specify which channel you wish to load "
-                    "with the `channel_name` argument. To see which channels are available, use "
-                    "`ScanImageTiffSinglePlaneImagingExtractor.get_available_channels(file_path=...)`"
+                    "More than one channel is detected! Please specify which channel you wish to load with the `channel_name` argument "
+                    f"available chanenls are {available_channels}"
                 )
             channel_name = avaliable_channels[0]
         assert channel_name in avaliable_channels, f"Channel '{channel_name}' not found in the tiff file."

--- a/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterfaces.py
+++ b/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterfaces.py
@@ -304,21 +304,21 @@ class ScanImageMultiPlaneImagingInterface(BaseImagingExtractorInterface):
                 "Only one plane detected. For single plane imaging data use ScanImageSinglePlaneImagingInterface instead."
             )
 
-        avaliable_channels = parsed_metadata["channel_names"]
+        available_channels = parsed_metadata["channel_names"]
         if channel_name is None:
-            if len(avaliable_channels) > 1:
+            if len(available_channels) > 1:
                 raise ValueError(
                     "More than one channel is detected! \n "
                     "Please specify which channel you wish to load with the `channel_name` argument \n "
-                    f"Available channels are: {avaliable_channels}"
+                    f"Available channels are: {available_channels}"
                 )
-            channel_name = avaliable_channels[0]
+            channel_name = available_channels[0]
         assert (
-            channel_name in avaliable_channels
-        ), f"Channel '{channel_name}' not found! \n Available channels are: {avaliable_channels}"
+            channel_name in available_channels
+        ), f"Channel '{channel_name}' not found! \n Available channels are: {available_channels}"
 
         two_photon_series_name_suffix = None
-        if len(avaliable_channels) > 1:
+        if len(available_channels) > 1:
             two_photon_series_name_suffix = f"{channel_name.replace(' ', '')}"
         self.two_photon_series_name_suffix = two_photon_series_name_suffix
 
@@ -436,21 +436,21 @@ class ScanImageMultiPlaneMultiFileImagingInterface(BaseImagingExtractorInterface
                 "Only one plane detected. For single plane imaging data use ScanImageSinglePlaneMultiFileImagingInterface instead."
             )
 
-        avaliable_channels = parsed_metadata["channel_names"]
+        available_channels = parsed_metadata["channel_names"]
         if channel_name is None:
-            if len(avaliable_channels) > 1:
+            if len(available_channels) > 1:
                 raise ValueError(
                     "More than one channel is detected! \n "
                     "Please specify which channel you wish to load with the `channel_name` argument \n "
-                    f"Available channels are: {avaliable_channels}"
+                    f"Available channels are: {available_channels}"
                 )
-            channel_name = avaliable_channels[0]
+            channel_name = available_channels[0]
         assert (
-            channel_name in avaliable_channels
-        ), f"Channel '{channel_name}' not found! \n Available channels are: {avaliable_channels}"
+            channel_name in available_channels
+        ), f"Channel '{channel_name}' not found! \n Available channels are: {available_channels}"
 
         two_photon_series_name_suffix = None
-        if len(avaliable_channels) > 1:
+        if len(available_channels) > 1:
             two_photon_series_name_suffix = f"{channel_name.replace(' ', '')}"
         self.two_photon_series_name_suffix = two_photon_series_name_suffix
 
@@ -541,7 +541,7 @@ class ScanImageSinglePlaneImagingInterface(BaseImagingExtractorInterface):
         file_path : FilePath
             Path to the TIFF file.
         channel_name : str
-            The name of the channel to load, to determine what channels are available use ScanImageTiffSinglePlaneImagingExtractor.get_avaliable_channels(file_path=...).
+            The name of the channel to load, to determine what channels are available use ScanImageTiffSinglePlaneImagingExtractor.get_available_channels(file_path=...).
         plane_name : str
             The name of the plane to load, to determine what planes are available use ScanImageTiffSinglePlaneImagingExtractor.get_available_planes(file_path=...).
         """
@@ -560,18 +560,18 @@ class ScanImageSinglePlaneImagingInterface(BaseImagingExtractorInterface):
             )
 
         parsed_metadata = parsed_metadata or parse_metadata(metadata=image_metadata)
-        avaliable_channels = parsed_metadata["channel_names"]
+        available_channels = parsed_metadata["channel_names"]
         if channel_name is None:
-            if len(avaliable_channels) > 1:
+            if len(available_channels) > 1:
                 raise ValueError(
                     "More than one channel is detected! \n "
                     "Please specify which channel you wish to load with the `channel_name` argument \n "
-                    f"Available channels are: {avaliable_channels}"
+                    f"Available channels are: {available_channels}"
                 )
-            channel_name = avaliable_channels[0]
+            channel_name = available_channels[0]
         assert (
-            channel_name in avaliable_channels
-        ), f"Channel '{channel_name}' not found! \n Available channels are: {avaliable_channels}"
+            channel_name in available_channels
+        ), f"Channel '{channel_name}' not found! \n Available channels are: {available_channels}"
 
         available_planes = [f"{i}" for i in range(parsed_metadata["num_planes"])]
         if plane_name is None:
@@ -587,7 +587,7 @@ class ScanImageSinglePlaneImagingInterface(BaseImagingExtractorInterface):
         ), f"Plane '{plane_name}' not found! \n Available planes are: {available_planes}"
 
         two_photon_series_name_suffix = None
-        if len(avaliable_channels) > 1:
+        if len(available_channels) > 1:
             two_photon_series_name_suffix = f"{channel_name.replace(' ', '')}"
         if len(available_planes) > 1:
             two_photon_series_name_suffix = f"{two_photon_series_name_suffix}Plane{plane_name}"
@@ -706,18 +706,18 @@ class ScanImageSinglePlaneMultiFileImagingInterface(BaseImagingExtractorInterfac
             )
 
         parsed_metadata = parsed_metadata or parse_metadata(metadata=image_metadata)
-        avaliable_channels = parsed_metadata["channel_names"]
+        available_channels = parsed_metadata["channel_names"]
         if channel_name is None:
-            if len(avaliable_channels) > 1:
+            if len(available_channels) > 1:
                 raise ValueError(
                     "More than one channel is detected! \n "
                     "Please specify which channel you wish to load with the `channel_name` argument \n "
-                    f"Available channels are: {avaliable_channels}"
+                    f"Available channels are: {available_channels}"
                 )
-            channel_name = avaliable_channels[0]
+            channel_name = available_channels[0]
         assert (
-            channel_name in avaliable_channels
-        ), f"Channel '{channel_name}' not found! \n Available channels are: {avaliable_channels}"
+            channel_name in available_channels
+        ), f"Channel '{channel_name}' not found! \n Available channels are: {available_channels}"
 
         available_planes = [f"{i}" for i in range(parsed_metadata["num_planes"])]
         if plane_name is None:
@@ -733,7 +733,7 @@ class ScanImageSinglePlaneMultiFileImagingInterface(BaseImagingExtractorInterfac
         ), f"Plane '{plane_name}' not found! \n Available planes are: {available_planes}"
 
         two_photon_series_name_suffix = None
-        if len(avaliable_channels) > 1:
+        if len(available_channels) > 1:
             two_photon_series_name_suffix = f"{channel_name.replace(' ', '')}"
         if len(available_planes) > 1:
             two_photon_series_name_suffix = f"{two_photon_series_name_suffix}Plane{plane_name}"

--- a/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterfaces.py
+++ b/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterfaces.py
@@ -308,11 +308,14 @@ class ScanImageMultiPlaneImagingInterface(BaseImagingExtractorInterface):
         if channel_name is None:
             if len(avaliable_channels) > 1:
                 raise ValueError(
-                    "More than one channel is detected! Please specify which channel you wish to load with the `channel_name` argument "
-                    f"available chanenls are: {avaliable_channels}"
+                    "More than one channel is detected! \n "
+                    "Please specify which channel you wish to load with the `channel_name` argument \n "
+                    f"Available channels are: {avaliable_channels}"
                 )
             channel_name = avaliable_channels[0]
-        assert channel_name in avaliable_channels, f"Channel '{channel_name}' not found in the tiff file."
+        assert (
+            channel_name in avaliable_channels
+        ), f"Channel '{channel_name}' not found! \n Available channels are: {avaliable_channels}"
 
         two_photon_series_name_suffix = None
         if len(avaliable_channels) > 1:
@@ -423,7 +426,9 @@ class ScanImageMultiPlaneMultiFileImagingInterface(BaseImagingExtractorInterface
 
         version = get_scanimage_major_version(scanimage_metadata=image_metadata)
         if version == "3.8":
-            raise ValueError("ScanImage version 3.8 is not supported. Please use ScanImageImagingInterface instead.")
+            raise ValueError(
+                "ScanImage version 3.8 is not supported. \n " "Please use ScanImageImagingInterface instead."
+            )
 
         parsed_metadata = parsed_metadata or parse_metadata(metadata=image_metadata)
         if parsed_metadata["num_planes"] == 1:
@@ -435,11 +440,14 @@ class ScanImageMultiPlaneMultiFileImagingInterface(BaseImagingExtractorInterface
         if channel_name is None:
             if len(avaliable_channels) > 1:
                 raise ValueError(
-                    "More than one channel is detected! Please specify which channel you wish to load with the `channel_name` argument "
-                    f"available chanenls are: {avaliable_channels}"
+                    "More than one channel is detected! \n "
+                    "Please specify which channel you wish to load with the `channel_name` argument \n "
+                    f"Available channels are: {avaliable_channels}"
                 )
             channel_name = avaliable_channels[0]
-        assert channel_name in avaliable_channels, f"Channel '{channel_name}' not found in the tiff file."
+        assert (
+            channel_name in avaliable_channels
+        ), f"Channel '{channel_name}' not found! \n Available channels are: {avaliable_channels}"
 
         two_photon_series_name_suffix = None
         if len(avaliable_channels) > 1:
@@ -547,29 +555,36 @@ class ScanImageSinglePlaneImagingInterface(BaseImagingExtractorInterface):
 
         version = get_scanimage_major_version(scanimage_metadata=image_metadata)
         if version == "3.8":
-            raise ValueError("ScanImage version 3.8 is not supported. Please use ScanImageImagingInterface instead.")
+            raise ValueError(
+                "ScanImage version 3.8 is not supported. \n " "Please use ScanImageImagingInterface instead."
+            )
 
         parsed_metadata = parsed_metadata or parse_metadata(metadata=image_metadata)
         avaliable_channels = parsed_metadata["channel_names"]
         if channel_name is None:
             if len(avaliable_channels) > 1:
                 raise ValueError(
-                    "More than one channel is detected! Please specify which channel you wish to load with the `channel_name` argument "
-                    f"available chanenls are: {avaliable_channels}"
+                    "More than one channel is detected! \n "
+                    "Please specify which channel you wish to load with the `channel_name` argument \n "
+                    f"Available channels are: {avaliable_channels}"
                 )
             channel_name = avaliable_channels[0]
-        assert channel_name in avaliable_channels, f"Channel '{channel_name}' not found in the tiff file."
+        assert (
+            channel_name in avaliable_channels
+        ), f"Channel '{channel_name}' not found! \n Available channels are: {avaliable_channels}"
 
         available_planes = [f"{i}" for i in range(parsed_metadata["num_planes"])]
         if plane_name is None:
             if len(available_planes) > 1:
                 raise ValueError(
-                    "More than one plane is detected! Please specify which plane you wish to load "
-                    "with the `plane_name` argument. To see which planes are available, use "
-                    "`ScanImageTiffSinglePlaneImagingExtractor.get_available_planes(file_path=...)`"
+                    "More than one plane is detected! \n "
+                    "Please specify which plane you wish to load with the `plane_name` argument \n "
+                    f"Available planes are: {available_planes}"
                 )
             plane_name = available_planes[0]
-        assert plane_name in available_planes, f"Plane '{plane_name}' not found in the tiff file."
+        assert (
+            plane_name in available_planes
+        ), f"Plane '{plane_name}' not found! \n Available planes are: {available_planes}"
 
         two_photon_series_name_suffix = None
         if len(avaliable_channels) > 1:
@@ -686,29 +701,36 @@ class ScanImageSinglePlaneMultiFileImagingInterface(BaseImagingExtractorInterfac
 
         version = get_scanimage_major_version(scanimage_metadata=image_metadata)
         if version == "3.8":
-            raise ValueError("ScanImage version 3.8 is not supported. Please use ScanImageImagingInterface instead.")
+            raise ValueError(
+                "ScanImage version 3.8 is not supported. \n " "Please use ScanImageImagingInterface instead."
+            )
 
         parsed_metadata = parsed_metadata or parse_metadata(metadata=image_metadata)
         avaliable_channels = parsed_metadata["channel_names"]
         if channel_name is None:
             if len(avaliable_channels) > 1:
                 raise ValueError(
-                    "More than one channel is detected! Please specify which channel you wish to load with the `channel_name` argument "
-                    f"available chanenls are {available_channels}"
+                    "More than one channel is detected! \n "
+                    "Please specify which channel you wish to load with the `channel_name` argument \n "
+                    f"Available channels are: {avaliable_channels}"
                 )
             channel_name = avaliable_channels[0]
-        assert channel_name in avaliable_channels, f"Channel '{channel_name}' not found in the tiff file."
+        assert (
+            channel_name in avaliable_channels
+        ), f"Channel '{channel_name}' not found! \n Available channels are: {avaliable_channels}"
 
         available_planes = [f"{i}" for i in range(parsed_metadata["num_planes"])]
         if plane_name is None:
             if len(available_planes) > 1:
                 raise ValueError(
-                    "More than one plane is detected! Please specify which plane you wish to load "
-                    "with the `plane_name` argument. To see which planes are available, use "
-                    "`ScanImageTiffSinglePlaneImagingExtractor.get_available_planes(file_path=...)`"
+                    "More than one plane is detected! \n "
+                    "Please specify which plane you wish to load with the `plane_name` argument \n "
+                    f"Available planes are: {available_planes}"
                 )
             plane_name = available_planes[0]
-        assert plane_name in available_planes, f"Plane '{plane_name}' not found in the tiff file."
+        assert (
+            plane_name in available_planes
+        ), f"Plane '{plane_name}' not found! \n Available planes are: {available_planes}"
 
         two_photon_series_name_suffix = None
         if len(avaliable_channels) > 1:

--- a/tests/test_on_data/ophys/test_imaging_interfaces.py
+++ b/tests/test_on_data/ophys/test_imaging_interfaces.py
@@ -314,10 +314,11 @@ class TestScanImageMultiFileImagingInterfacesAssertions(hdmf_TestCase):
         """Test that the interface raises ValueError for older ScanImage format and suggests to use a different interface."""
         folder_path = str(OPHYS_DATA_PATH / "imaging_datasets" / "Tif")
         file_pattern = "sample_scanimage.tiff"
-        with self.assertRaisesRegex(
-            ValueError, "ScanImage version 3.8 is not supported. Please use ScanImageImagingInterface instead."
-        ):
-            ScanImageMultiPlaneMultiFileImagingInterface(folder_path=folder_path, file_pattern=file_pattern)
+        with self.assertRaisesRegex(ValueError, r"ScanImage version 3.8 is not supported."):
+            # Code here should invoke the functionality that triggers the exception
+            # Example:
+            interface = ScanImageMultiFileImagingInterface(folder_path=folder_path, file_pattern=file_pattern)
+            interface.get_metadata()
 
     def test_non_volumetric_data(self):
         """Test that ValueError is raised for non-volumetric imaging data."""

--- a/tests/test_on_data/ophys/test_imaging_interfaces.py
+++ b/tests/test_on_data/ophys/test_imaging_interfaces.py
@@ -185,7 +185,9 @@ class TestScanImageImagingInterfacesAssertions(hdmf_TestCase):
         """Test that ValueError is raised when incorrect channel name is specified."""
         file_path = str(OPHYS_DATA_PATH / "imaging_datasets" / "ScanImage" / "scanimage_20220923_roi.tif")
         channel_name = "Channel 2"
-        with self.assertRaisesRegex(AssertionError, "Channel 'Channel 2' not found in the tiff file."):
+        with self.assertRaisesRegex(
+            AssertionError, "Channel 'Channel 2' not found! Available channels are: \['Channel 1', 'Channel 4'\]"
+        ):
             self.data_interface_cls(file_path=file_path, channel_name=channel_name)
 
     def test_incorrect_plane_name(self):

--- a/tests/test_on_data/ophys/test_imaging_interfaces.py
+++ b/tests/test_on_data/ophys/test_imaging_interfaces.py
@@ -186,14 +186,17 @@ class TestScanImageImagingInterfacesAssertions(hdmf_TestCase):
         file_path = str(OPHYS_DATA_PATH / "imaging_datasets" / "ScanImage" / "scanimage_20220923_roi.tif")
         channel_name = "Channel 2"
         with self.assertRaisesRegex(
-            AssertionError, "Channel 'Channel 2' not found! Available channels are: \['Channel 1', 'Channel 4'\]"
+            AssertionError, r"Channel 'Channel 2' not found![\s\n]+Available channels are: \['Channel 1', 'Channel 4'\]"
         ):
             self.data_interface_cls(file_path=file_path, channel_name=channel_name)
 
     def test_incorrect_plane_name(self):
         """Test that ValueError is raised when incorrect plane name is specified."""
         file_path = str(OPHYS_DATA_PATH / "imaging_datasets" / "ScanImage" / "scanimage_20220801_volume.tif")
-        with self.assertRaisesRegex(AssertionError, "Plane '20' not found in the tiff file"):
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"Plane '20' not found![\s\n]+Available planes are: \['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19'\]",
+        ):
             self.data_interface_cls(file_path=file_path, plane_name="20")
 
     def test_non_volumetric_data(self):


### PR DESCRIPTION
This came up working with the Kim Lab for the Cohen group conversion.

When using `ScanImageImagingInterface` with data with more than one channel or plane we throw an error indicating that we need to choose the channel. However, instead of just presenting the available channels to the user we tell them to use another method. 

This is unnecessary work for them, let's just give them the options on the spot. No point on making them do more work.