### PR TITLE
Add concurrency at the job level for live service tests

### DIFF
--- a/.github/workflows/live-service-testing.yml
+++ b/.github/workflows/live-service-testing.yml
@@ -29,6 +29,10 @@ jobs:
   run:
     name: ${{ matrix.os }} Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    # We are adding concurrency here to avoid concurrent writes to the dandi API.
+    concurrency:  # This avoids two tests within the matrix running at the same time
+      group: live-service-testing
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/live-service-testing.yml
+++ b/.github/workflows/live-service-testing.yml
@@ -34,6 +34,8 @@ jobs:
       group: live-service-testing
       cancel-in-progress: false
     strategy:
+      # This is crucial - it forces jobs to run sequentially
+      max-parallel: 1
       fail-fast: false
       matrix:
         python-version: ${{ fromJson(inputs.python-versions) }}

--- a/.github/workflows/live-service-testing.yml
+++ b/.github/workflows/live-service-testing.yml
@@ -25,16 +25,17 @@ on:
 env:
   DANDI_API_KEY: ${{ secrets.DANDI_API_KEY }}
 
+# We are adding concurrency here to avoid concurrent writes to the dandi API.
+concurrency:
+  group: live-service-testing
+  cancel-in-progress: false
+
 jobs:
   run:
     name: ${{ matrix.os }} Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
-    # We are adding concurrency here to avoid concurrent writes to the dandi API.
-    concurrency:  # This avoids two tests within the matrix running at the same time
-      group: live-service-testing
-      cancel-in-progress: false
     strategy:
-      # This is crucial - it forces jobs to run sequentially
+      # This avoids two tests within the matrix running at the same time
       max-parallel: 1
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Change `np.NAN` to `np.nan` to support numpy 2.0 [PR #1245](https://github.com/catalystneuro/neuroconv/pull/1245)
 * Testing: only run tests for oldest and newest versions of python [#1249](https://github.com/catalystneuro/neuroconv/pull/1249)
 * Improve error display on scan image interfaces [PR #1246](https://github.com/catalystneuro/neuroconv/pull/1246)
-* Added concurrency to live-service-testing GitHub Actions workflow to prevent simultaneous write to the dandiset.
+* Added concurrency to live-service-testing GitHub Actions workflow to prevent simultaneous write to the dandiset. [#1252](https://github.com/catalystneuro/neuroconv/pull/1252)g
 
 # v0.7.1 (March 5, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Change `np.NAN` to `np.nan` to support numpy 2.0 [PR #1245](https://github.com/catalystneuro/neuroconv/pull/1245)
 * Testing: only run tests for oldest and newest versions of python [#1249](https://github.com/catalystneuro/neuroconv/pull/1249)
 * Improve error display on scan image interfaces [PR #1246](https://github.com/catalystneuro/neuroconv/pull/1246)
+* Added concurrency to live-service-testing GitHub Actions workflow to prevent simultaneous write to the dandiset.
 
 # v0.7.1 (March 5, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Change `np.NAN` to `np.nan` to support numpy 2.0 [PR #1245](https://github.com/catalystneuro/neuroconv/pull/1245)
 * Testing: only run tests for oldest and newest versions of python [#1249](https://github.com/catalystneuro/neuroconv/pull/1249)
 * Improve error display on scan image interfaces [PR #1246](https://github.com/catalystneuro/neuroconv/pull/1246)
-* Added concurrency to live-service-testing GitHub Actions workflow to prevent simultaneous write to the dandiset. [#1252](https://github.com/catalystneuro/neuroconv/pull/1252)g
+* Added concurrency to live-service-testing GitHub Actions workflow to prevent simultaneous write to the dandiset. [#1252](https://github.com/catalystneuro/neuroconv/pull/1252)
 
 # v0.7.1 (March 5, 2025)
 


### PR DESCRIPTION
They have been failing for a while. We believe this is a consequence of concurrent write access to the DANDI database. If this is correct, this should eliminate the problem.

That said, this solution may be too strong. A more precise alternative would be to have DANDI files that are OS- and Python-version-dependent, preventing overwriting of the same object. However, this approach is easier to implement, and the live service tests are not that long, so perhaps we should opt for the lower-effort solution.