### PR TITLE
More numpy 2.0 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Testing: only run tests for oldest and newest versions of python [#1249](https://github.com/catalystneuro/neuroconv/pull/1249)
 * Improve error display on scan image interfaces [PR #1246](https://github.com/catalystneuro/neuroconv/pull/1246)
 * Added concurrency to live-service-testing GitHub Actions workflow to prevent simultaneous write to the dandiset. [#1252](https://github.com/catalystneuro/neuroconv/pull/1252)
+* Replace uses of scipy load_mat and h5storage loadmat with pymat_reader read_mat in CellExplorerSortingInterface
 
 # v0.7.1 (March 5, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Testing: only run tests for oldest and newest versions of python [#1249](https://github.com/catalystneuro/neuroconv/pull/1249)
 * Improve error display on scan image interfaces [PR #1246](https://github.com/catalystneuro/neuroconv/pull/1246)
 * Added concurrency to live-service-testing GitHub Actions workflow to prevent simultaneous write to the dandiset. [#1252](https://github.com/catalystneuro/neuroconv/pull/1252)
-* Replace uses of scipy load_mat and h5storage loadmat with pymat_reader read_mat in CellExplorerSortingInterface
+* Replace uses of scipy load_mat and h5storage loadmat with pymat_reader read_mat in `CellExplorerSortingInterface` [#1254](https://github.com/catalystneuro/neuroconv/pull/1254)
 
 # v0.7.1 (March 5, 2025)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,6 @@ blackrock = [
     "spikeinterface>=0.102",
 ]
 cellexplorer = [
-    "hdf5storage>=0.1.18",
     "neo>=0.13.3",
     "pymatreader>=0.0.32",
     "spikeinterface>=0.102",

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -434,15 +434,16 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
             Path to .spikes.cellinfo.mat file.
         verbose: bool, default: True
         """
+        # Triggers import error at initialization
+        pymatreader = get_package(
+            package_name="pymatreader",
+            installation_instructions="pip install pymatreader",
+        )
 
         file_path = Path(file_path)
         self.session_path = Path(file_path).parent
         self.session_id = self.session_path.stem
 
-        pymatreader = get_package(
-            package_name="pymatreader",
-            installation_instructions="pip install pymatreader",
-        )
         from pymatreader import read_mat
 
         matlab_file = read_mat(file_path)

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -7,6 +7,7 @@ from pynwb import NWBFile
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
+from ....tools import get_package
 
 
 def add_channel_metadata_to_recoder(recording_extractor, folder_path: DirectoryPath):
@@ -438,7 +439,10 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
         self.session_path = Path(file_path).parent
         self.session_id = self.session_path.stem
 
-        # Temporary hack to get sampling frequency from the spikes cellinfo file until next SI release
+        pymatreader = get_package(
+            package_name="pymatreader",
+            installation_instructions="pip install pymatreader",
+        )
         from pymatreader import read_mat
 
         matlab_file = read_mat(file_path)

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -7,7 +7,6 @@ from pynwb import NWBFile
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
-from ....tools import get_package
 
 
 def add_channel_metadata_to_recoder(recording_extractor, folder_path: DirectoryPath):
@@ -434,8 +433,6 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
             Path to .spikes.cellinfo.mat file.
         verbose: bool, default: True
         """
-
-        hdf5storage = get_package(package_name="hdf5storage")
 
         file_path = Path(file_path)
         self.session_path = Path(file_path).parent

--- a/src/neuroconv/datainterfaces/ecephys/sortedrecordinginterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/sortedrecordinginterface.py
@@ -59,8 +59,8 @@ class SortedRecordingConverter(ConverterPipe):
         self.channel_ids = self.recording_interface.channel_ids
         self.unit_ids = self.sorting_interface.units_ids
 
-        # Convert channel_ids to set for comparison
-        available_channels = set(self.channel_ids)
+        # Convert channel_ids to set for comparison (use list to avoid numpy scalar representation issues)
+        available_channels = set(self.channel_ids.tolist())
 
         # Check that all referenced channels exist in recording
         for unit_id, channel_ids in unit_ids_to_channel_ids.items():
@@ -72,7 +72,7 @@ class SortedRecordingConverter(ConverterPipe):
                 )
 
         # Check that all units have a channel mapping
-        available_units = set(self.unit_ids)
+        available_units = set(self.unit_ids.tolist())  # Use tolist() to avoid numpy scalar representation issues
         mapped_units = set(unit_ids_to_channel_ids.keys())
         unmapped_units = available_units - mapped_units
         if unmapped_units:


### PR DESCRIPTION
From https://github.com/catalystneuro/neuroconv/pull/1117

More NumPy representation fixes. Additionally, hdf5storage does not appear to have been updated to the latest version of NumPy. For `CellExplorer` this leads to failures.I am switching to pymatreader, which has the added advantage of providing a unified interface for both MATLAB formats (hdf5 and classic), simplifying the code slightly.