### PR TITLE
Fix live service tests

### DIFF
--- a/.github/workflows/live-service-testing.yml
+++ b/.github/workflows/live-service-testing.yml
@@ -25,11 +25,6 @@ on:
 env:
   DANDI_API_KEY: ${{ secrets.DANDI_API_KEY }}
 
-# We are adding concurrency here to avoid concurrent writes to the dandi API.
-concurrency:
-  group: live-service-testing
-  cancel-in-progress: false
-
 jobs:
   run:
     name: ${{ matrix.os }} Python ${{ matrix.python-version }}


### PR DESCRIPTION
Removing concurrency check for live service tests so that they don't interfere in multiple commits on the same PR.