### PR TITLE
Fix use of `nwbfile_path`  in documentation of `configure_and_write_nwbfile`

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -7,3 +7,4 @@
 * always apply Black formatting
 * avoid making any modifications that are not strictly necessary to the task you've been requested to do (including docstrings)
 * if you spot any possible errors or have suggestions for improvement outside of the scope of your requested task, you can add them to your Task Completed message
+* Use `nwbfile_path` as a variable name referring to the path for writing an NWB file to disk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v0.7.2 (Upcoming)
 
 ## Deprecations and Changes
-* `output_filepath` deprecated on `configure_and_write_nwbfile` use `nwbfile_path` instead [PR #TBD](https://github.com/catalystneuro/neuroconv/pull/TBD)
+* `output_filepath` deprecated on `configure_and_write_nwbfile` use `nwbfile_path` instead [PR #1270](https://github.com/catalystneuro/neuroconv/pull/1270)
 
 ## Bug Fixes
 * Fixed a check in `_configure_backend` on neurodata_object ndx_events.Events to work only when ndx-events==0.2.0 is used. [PR #998](https://github.com/catalystneuro/neuroconv/pull/998)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.7.2 (Upcoming)
 
 ## Deprecations and Changes
+* `output_filepath` deprecated on `configure_and_write_nwbfile` use `nwbfile_path` instead [PR #TBD](https://github.com/catalystneuro/neuroconv/pull/TBD)
 
 ## Bug Fixes
 * Fixed a check in `_configure_backend` on neurodata_object ndx_events.Events to work only when ndx-events==0.2.0 is used. [PR #998](https://github.com/catalystneuro/neuroconv/pull/998)

--- a/docs/user_guide/adding_trials.rst
+++ b/docs/user_guide/adding_trials.rst
@@ -26,7 +26,7 @@ Once this information is added, you can write the NWB file to disk:
     from neuroconv.tools.nwb_helpers import configure_and_write_nwbfile
 
     configure_and_write_nwbfile(
-        nwbfile, save_path="path/to/destination.nwb", backend="hdf5"
+        nwbfile, nwbfile_path="path/to/destination.nwb", backend="hdf5"
     )
 
 This will write the NWB file to disk with the added trials information, and optimize the storage settings of large

--- a/docs/user_guide/backend_configuration.rst
+++ b/docs/user_guide/backend_configuration.rst
@@ -136,7 +136,7 @@ Then we can use this configuration to write the NWB file:
 
     dataset_configurations["acquisition/MyTimeSeries/data"] = dataset_configuration
 
-    configure_and_write_nwbfile(nwbfile=nwbfile, backend_configuration=backend_configuration, output_filepath="output.nwb")
+    configure_and_write_nwbfile(nwbfile=nwbfile, backend_configuration=backend_configuration, nwbfile_path="output.nwb")
 
 
 Interfaces and Converters

--- a/docs/user_guide/datainterfaces.rst
+++ b/docs/user_guide/datainterfaces.rst
@@ -191,5 +191,5 @@ The following code automatically optimizes datasets for cloud compute and writes
     from neuroconv.tools.nwb_helpers import configure_and_write_nwbfile
 
     configure_and_write_nwbfile(
-        nwbfile, save_path="path/to/destination.nwb", backend="hdf5"
+        nwbfile, nwbfile_path="path/to/destination.nwb", backend="hdf5"
     )

--- a/src/neuroconv/basedatainterface.py
+++ b/src/neuroconv/basedatainterface.py
@@ -228,7 +228,7 @@ class BaseDataInterface(ABC):
 
             configure_and_write_nwbfile(
                 nwbfile=nwbfile,
-                output_filepath=nwbfile_path,
+                nwbfile_path=nwbfile_path,
                 backend=backend,
                 backend_configuration=backend_configuration,
             )

--- a/src/neuroconv/nwbconverter.py
+++ b/src/neuroconv/nwbconverter.py
@@ -315,7 +315,7 @@ class NWBConverter:
 
             configure_and_write_nwbfile(
                 nwbfile=nwbfile,
-                output_filepath=nwbfile_path,
+                nwbfile_path=nwbfile_path,
                 backend=backend,
                 backend_configuration=backend_configuration,
             )

--- a/src/neuroconv/tools/nwb_helpers/_metadata_and_file_helpers.py
+++ b/src/neuroconv/tools/nwb_helpers/_metadata_and_file_helpers.py
@@ -368,7 +368,7 @@ def _resolve_backend(
 
 def configure_and_write_nwbfile(
     nwbfile: NWBFile,
-    output_filepath: Optional[FilePath],
+    output_filepath: Optional[FilePath] = None,
     nwbfile_path: Optional[FilePath] = None,
     backend: Optional[Literal["hdf5"]] = None,
     backend_configuration: Optional[BackendConfiguration] = None,

--- a/src/neuroconv/tools/nwb_helpers/_metadata_and_file_helpers.py
+++ b/src/neuroconv/tools/nwb_helpers/_metadata_and_file_helpers.py
@@ -385,7 +385,7 @@ def configure_and_write_nwbfile(
     nwbfile: NWBFile
     output_filepath: Optional[FilePath], optional. Deprecated
     nwbfile_path: Optional[FilePath], optional
-    backend: {"hdf5"}, optional
+    backend: {"hdf5", "zarr"}, optional
         The type of backend used to create the file. This option uses the default ``backend_configuration`` for the
         specified backend. If no ``backend`` is specified, the ``backend_configuration`` is used.
     backend_configuration: BackendConfiguration, optional

--- a/src/neuroconv/tools/nwb_helpers/_metadata_and_file_helpers.py
+++ b/src/neuroconv/tools/nwb_helpers/_metadata_and_file_helpers.py
@@ -393,6 +393,12 @@ def configure_and_write_nwbfile(
         ``backend_configuration`` is specified, the default configuration for the specified ``backend`` is used.
 
     """
+
+    if nwbfile_path is not None and output_filepath is not None:
+        raise ValueError(
+            "Both 'output_filepath' and 'nwbfile_path' were specified! " "Please specify only `nwbfile_path`."
+        )
+
     if output_filepath is not None:
         warnings.warn(
             "The 'output_filepath' parameter is deprecated in or after September 2025. " "Use 'nwbfile_path' instead.",
@@ -401,10 +407,8 @@ def configure_and_write_nwbfile(
         )
         nwbfile_path = output_filepath
 
-    if nwbfile_path is not None and output_filepath is not None:
-        raise ValueError(
-            "Both 'output_filepath' and 'nwbfile_path' were specified! " "Please specify only `nwbfile_path`."
-        )
+    if nwbfile_path is None:
+        raise ValueError("The 'nwbfile_path' parameter must be specified.")
 
     backend = _resolve_backend(backend=backend, backend_configuration=backend_configuration)
 

--- a/src/neuroconv/tools/nwb_helpers/_metadata_and_file_helpers.py
+++ b/src/neuroconv/tools/nwb_helpers/_metadata_and_file_helpers.py
@@ -368,7 +368,8 @@ def _resolve_backend(
 
 def configure_and_write_nwbfile(
     nwbfile: NWBFile,
-    output_filepath: str,
+    output_filepath: Optional[FilePath],
+    nwbfile_path: Optional[FilePath] = None,
     backend: Optional[Literal["hdf5"]] = None,
     backend_configuration: Optional[BackendConfiguration] = None,
 ) -> None:
@@ -382,7 +383,8 @@ def configure_and_write_nwbfile(
     Parameters
     ----------
     nwbfile: NWBFile
-    output_filepath: str
+    output_filepath: Optional[FilePath], optional. Deprecated
+    nwbfile_path: Optional[FilePath], optional
     backend: {"hdf5"}, optional
         The type of backend used to create the file. This option uses the default ``backend_configuration`` for the
         specified backend. If no ``backend`` is specified, the ``backend_configuration`` is used.
@@ -391,6 +393,18 @@ def configure_and_write_nwbfile(
         ``backend_configuration`` is specified, the default configuration for the specified ``backend`` is used.
 
     """
+    if output_filepath is not None:
+        warnings.warn(
+            "The 'output_filepath' parameter is deprecated in or after September 2025. " "Use 'nwbfile_path' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        nwbfile_path = output_filepath
+
+    if nwbfile_path is not None and output_filepath is not None:
+        raise ValueError(
+            "Both 'output_filepath' and 'nwbfile_path' were specified! " "Please specify only `nwbfile_path`."
+        )
 
     backend = _resolve_backend(backend=backend, backend_configuration=backend_configuration)
 
@@ -402,5 +416,5 @@ def configure_and_write_nwbfile(
 
     IO = BACKEND_NWB_IO[backend_configuration.backend]
 
-    with IO(output_filepath, mode="w") as io:
+    with IO(nwbfile_path, mode="w") as io:
         io.write(nwbfile)

--- a/src/neuroconv/tools/nwb_helpers/_metadata_and_file_helpers.py
+++ b/src/neuroconv/tools/nwb_helpers/_metadata_and_file_helpers.py
@@ -370,7 +370,7 @@ def configure_and_write_nwbfile(
     nwbfile: NWBFile,
     output_filepath: Optional[FilePath] = None,
     nwbfile_path: Optional[FilePath] = None,
-    backend: Optional[Literal["hdf5"]] = None,
+    backend: Optional[Literal["hdf5", "zarr"]] = None,
     backend_configuration: Optional[BackendConfiguration] = None,
 ) -> None:
     """


### PR DESCRIPTION
In the documentation sometimes `save_path` is used and other times the correct `output_filepath`. I am fixing this and also changing the argument to `nwbfile_path` to unify this with other functions in the library.

