### PR TITLE
Use `always_write_timestmaps` on the new video interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 * `output_filepath` deprecated on `configure_and_write_nwbfile` use `nwbfile_path` instead [PR #1270](https://github.com/catalystneuro/neuroconv/pull/1270)
 * Temporary set a ceiling on pydantic `<2.11` [PR #1275](https://github.com/catalystneuro/neuroconv/pull/1275)
 
-## Features
-* Added `always_write_timestamps` parameter to ExternalVideoInterface and InternalVideoInterface to force writing timestamps even when they are regular
-
 ## Bug Fixes
 * Fixed a check in `_configure_backend` on neurodata_object ndx_events.Events to work only when ndx-events==0.2.0 is used. [PR #998](https://github.com/catalystneuro/neuroconv/pull/998)
 * Added an `append_on_disk_nwbfile` argumento to `run_conversion`. This changes the semantics of the overwrite parameter from assuming append mode when a file exists to a more conventional `safe writing` mode where confirmation is required to overwrite an existing file. Append mode now is controlled with the `append_on_disk_nwbfile`. [#1256](https://github.com/catalystneuro/neuroconv/pull/1256)
@@ -17,6 +14,7 @@
 * Support roiextractors 0.5.11 [PR #1236](https://github.com/catalystneuro/neuroconv/pull/1236)
 * Added stub_test option to TDTFiberPhotometryInterface [PR #1242](https://github.com/catalystneuro/neuroconv/pull/1242)
 * Added ThorImagingInterface for Thor TIFF files with OME metadata [PR #1238](https://github.com/catalystneuro/neuroconv/pull/1238)
+* Added `always_write_timestamps` parameter to ExternalVideoInterface and InternalVideoInterface to force writing timestamps even when they are regular [#1279](https://github.com/catalystneuro/neuroconv/pull/1279)
 
 ## Improvements
 * Filter out warnings for missing timezone information in continuous integration [PR #1240](https://github.com/catalystneuro/neuroconv/pull/1240)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * `output_filepath` deprecated on `configure_and_write_nwbfile` use `nwbfile_path` instead [PR #1270](https://github.com/catalystneuro/neuroconv/pull/1270)
 * Temporary set a ceiling on pydantic `<2.11` [PR #1275](https://github.com/catalystneuro/neuroconv/pull/1275)
 
+## Features
+* Added `always_write_timestamps` parameter to ExternalVideoInterface and InternalVideoInterface to force writing timestamps even when they are regular
+
 ## Bug Fixes
 * Fixed a check in `_configure_backend` on neurodata_object ndx_events.Events to work only when ndx-events==0.2.0 is used. [PR #998](https://github.com/catalystneuro/neuroconv/pull/998)
 * Added an `append_on_disk_nwbfile` argumento to `run_conversion`. This changes the semantics of the overwrite parameter from assuming append mode when a file exists to a more conventional `safe writing` mode where confirmation is required to overwrite an existing file. Append mode now is controlled with the `append_on_disk_nwbfile`. [#1256](https://github.com/catalystneuro/neuroconv/pull/1256)

--- a/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
@@ -173,7 +173,7 @@ class ExternalVideoInterface(BaseDataInterface):
         """
         Set the aligned starting time for the ImageSeries in this interface.
 
-        This method will not do anything if the timestamps have already been set.
+        If the timestamps have already been set, each segment will be shifted by aligned_starting_time.
 
         Must be in units seconds relative to the common 'session_start_time'.
 
@@ -312,7 +312,7 @@ class ExternalVideoInterface(BaseDataInterface):
             image_series_kwargs["device"] = device
 
         if always_write_timestamps:
-            timestamps = self._timestamps if self._timestamps is not None else self.get_timestamps()
+            timestamps = self.get_timestamps()
             image_series_kwargs.update(timestamps=np.concatenate(timestamps))
         elif self._timestamps is not None:
             # Check if timestamps are regular

--- a/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
@@ -74,7 +74,7 @@ class ExternalVideoInterface(BaseDataInterface):
         self.verbose = verbose
         self._number_of_files = len(file_paths)
         self._timestamps = None
-        self._segment_starting_times = None
+        self._starting_time = None
         self.video_name = video_name if video_name else f"Video {file_paths[0].stem}"
         self._default_device_name = f"{video_name} Camera Device"
         super().__init__(file_paths=file_paths)
@@ -167,14 +167,13 @@ class ExternalVideoInterface(BaseDataInterface):
         aligned_timestamps : list of numpy.ndarray
             The synchronized timestamps for data in this interface.
         """
-        assert (
-            self._segment_starting_times is None
-        ), "If setting both timestamps and starting times, please set the timestamps first so they can be shifted by the starting times."
         self._timestamps = aligned_timestamps
 
-    def set_aligned_starting_time(self, aligned_starting_time: float, stub_test: bool = False):
+    def set_aligned_starting_time(self, aligned_starting_time: float):
         """
-        Align all starting times for all videos in this interface relative to the common session start time.
+        Set the aligned starting time for the ImageSeries in this interface.
+
+        This method will not do anything if the timestamps have already been set.
 
         Must be in units seconds relative to the common 'session_start_time'.
 
@@ -182,30 +181,21 @@ class ExternalVideoInterface(BaseDataInterface):
         ----------
         aligned_starting_time : float
             The common starting time for all segments of temporal data in this interface.
-        stub_test : bool, default: False
-            If timestamps have not been set to this interface, it will attempt to retrieve them
-            using the `.get_original_timestamps` method, which scans through each video;
-            a process which can take some time to complete.
-
-            To limit that scan to a small number of frames, set `stub_test=True`.
         """
         if self._timestamps is not None:
-            aligned_timestamps = [
-                timestamps + aligned_starting_time for timestamps in self.get_timestamps(stub_test=stub_test)
-            ]
-            self.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
-        elif self._segment_starting_times is not None:
-            self._segment_starting_times = [
-                segment_starting_time + aligned_starting_time for segment_starting_time in self._segment_starting_times
-            ]
+            aligned_segment_starting_times = [aligned_starting_time] * self._number_of_files
+            self.set_aligned_segment_starting_times(aligned_segment_starting_times=aligned_segment_starting_times)
         else:
-            raise ValueError("There are no timestamps or starting times set to shift by a common value!")
+            self._starting_time = aligned_starting_time
 
     def set_aligned_segment_starting_times(self, aligned_segment_starting_times: list[float], stub_test: bool = False):
         """
         Align the individual starting time for each video (segment) in this interface relative to the common session start time.
 
         Must be in units seconds relative to the common 'session_start_time'.
+
+        If the timestamps have not already been set, this method will set them to the original timestamps and then shift
+        them by the aligned segment starting times.
 
         Parameters
         ----------
@@ -223,17 +213,15 @@ class ExternalVideoInterface(BaseDataInterface):
             f"The length of the 'aligned_segment_starting_times' list ({aligned_segment_starting_times_length}) does not match the "
             "number of video files ({self._number_of_files})!"
         )
-        if self._timestamps is not None:
-            self.set_aligned_timestamps(
-                aligned_timestamps=[
-                    timestamps + segment_starting_time
-                    for timestamps, segment_starting_time in zip(
-                        self.get_timestamps(stub_test=stub_test), aligned_segment_starting_times
-                    )
-                ]
-            )
-        else:
-            self._segment_starting_times = aligned_segment_starting_times
+        self._timestamps = self.get_timestamps(stub_test=stub_test)
+        self.set_aligned_timestamps(
+            aligned_timestamps=[
+                timestamps + segment_starting_time
+                for timestamps, segment_starting_time in zip(
+                    self.get_timestamps(stub_test=stub_test), aligned_segment_starting_times
+                )
+            ]
+        )
 
     def align_by_interpolation(self, unaligned_timestamps: np.ndarray, aligned_timestamps: np.ndarray):
         raise NotImplementedError("The `align_by_interpolation` method has not been developed for this interface yet.")
@@ -336,12 +324,12 @@ class ExternalVideoInterface(BaseDataInterface):
             else:
                 image_series_kwargs.update(timestamps=timestamps)
         else:
-            if self._number_of_files > 1 and self._segment_starting_times is None:
+            if self._number_of_files > 1 and self._starting_time is None:
                 raise ValueError(
                     f"No timing information is specified and there are {self._number_of_files} total video files! "
                     "Please specify the temporal alignment of each video."
                 )
-            starting_time = self._segment_starting_times[0] if self._segment_starting_times is not None else 0.0
+            starting_time = self._starting_time if self._starting_time is not None else 0.0
             with VideoCaptureContext(file_path=str(file_paths[0])) as video:
                 rate = video.get_video_fps()
             image_series_kwargs.update(starting_time=starting_time, rate=rate)

--- a/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
@@ -347,7 +347,7 @@ class InternalVideoInterface(BaseDataInterface):
         from ....utils import calculate_regular_series_rate
 
         if always_write_timestamps:
-            timestamps = self._timestamps if self._timestamps is not None else self.get_timestamps()
+            timestamps = self.get_timestamps()
             image_series_kwargs.update(timestamps=timestamps)
         elif self._timestamps is not None:
             # Check if timestamps are regular

--- a/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
@@ -125,30 +125,6 @@ class InternalVideoInterface(BaseDataInterface):
             # method is simply returning range(length) / fps 100% of the time for any given format
             return video.get_video_timestamps(max_frames=max_frames)
 
-    def get_timing_type(self) -> Literal["starting_time and rate", "timestamps"]:
-        """
-        Determine the type of timing used by this interface.
-
-        Returns
-        -------
-        Literal["starting_time and rate", "timestamps"]
-            The type of timing that has been set explicitly according to alignment.
-
-            If only timestamps have been set, then only those will be used.
-            If only starting times have been set, then only those will be used.
-
-            If timestamps were set, and then starting times were set, the timestamps will take precedence
-            as they will then be shifted by the corresponding starting times.
-
-            If neither has been set, and there is only one video in the file_paths,
-            it is assumed the video is regularly sampled and pre-aligned with
-            a starting_time of 0.0 relative to the session start time.
-        """
-        if self._timestamps is not None:
-            return "timestamps"
-        else:
-            return "starting_time and rate"  # default behavior assumes data is pre-aligned; starting_times = [0.0]
-
     def get_timestamps(self, stub_test: bool = False) -> np.ndarray:
         """
         Retrieve the timestamps for the data in this interface.
@@ -201,11 +177,10 @@ class InternalVideoInterface(BaseDataInterface):
 
             To limit that scan to a small number of frames, set `stub_test=True`.
         """
-        timing_type = self.get_timing_type()
-        if timing_type == "timestamps":
+        if self._timestamps is not None:
             aligned_timestamps = self.get_timestamps(stub_test=stub_test) + aligned_starting_time
             self.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
-        elif timing_type == "starting_time and rate":
+        else:
             self._starting_time = aligned_starting_time
 
     def align_by_interpolation(self, unaligned_timestamps: np.ndarray, aligned_timestamps: np.ndarray):
@@ -289,7 +264,6 @@ class InternalVideoInterface(BaseDataInterface):
         image_series_kwargs["name"] = self.video_name
 
         stub_frames = 10
-        timing_type = self.get_timing_type()
 
         uncompressed_estimate = file_path.stat().st_size * 70
         available_memory = psutil.virtual_memory().available

--- a/tests/test_behavior/test_internal_video_interface.py
+++ b/tests/test_behavior/test_internal_video_interface.py
@@ -123,7 +123,7 @@ def test_video_stub(nwb_converter, nwbfile_path, metadata):
 
 def test_aligned_timestamps(nwb_converter, nwbfile_path, metadata):
     """Test that aligned timestamps are correctly applied."""
-    aligned_timestamps = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+    aligned_timestamps = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 20.0])
     interface = nwb_converter.data_interface_objects["Video1"]
     interface.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
 
@@ -137,6 +137,31 @@ def test_aligned_timestamps(nwb_converter, nwbfile_path, metadata):
     with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
         nwbfile = io.read()
         np.testing.assert_array_equal(aligned_timestamps, nwbfile.acquisition["Video test1"].timestamps[:])
+
+
+def test_always_write_timestamps(nwb_converter, nwbfile_path, metadata):
+    """Test that always_write_timestamps forces the use of timestamps even when timestamps are regular."""
+    interface = nwb_converter.data_interface_objects["Video1"]
+    # Set regular timestamps
+    aligned_timestamps = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+    interface.set_aligned_timestamps(aligned_timestamps=aligned_timestamps)
+
+    # Run conversion with always_write_timestamps=True
+    conversion_options = dict(Video1=dict(stub_test=True, always_write_timestamps=True))
+    nwb_converter.run_conversion(
+        nwbfile_path=nwbfile_path,
+        overwrite=True,
+        conversion_options=conversion_options,
+        metadata=metadata,
+    )
+
+    # Verify that timestamps were written
+    with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
+        nwbfile = io.read()
+        # Check that timestamps exist in the ImageSeries
+        assert nwbfile.acquisition["Video test1"].timestamps is not None
+        # Verify timestamps are not None and have the expected length
+        assert len(nwbfile.acquisition["Video test1"].timestamps[:]) > 0
 
 
 def test_aligned_starting_time(nwb_converter, nwbfile_path, metadata, aligned_starting_time):

--- a/tests/test_behavior/test_internal_video_interface.py
+++ b/tests/test_behavior/test_internal_video_interface.py
@@ -182,26 +182,6 @@ def test_aligned_starting_time(nwb_converter, nwbfile_path, metadata, aligned_st
         assert nwbfile.acquisition["Video test1"].starting_time == aligned_starting_time
 
 
-def test_get_timing_type_with_timestamps(nwb_converter):
-    """Test that get_timing_type returns 'timestamps' when timestamps are set."""
-    interface = nwb_converter.data_interface_objects["Video1"]
-    interface.set_aligned_timestamps(aligned_timestamps=np.array([1.0, 2.0, 3.0]))
-    assert interface.get_timing_type() == "timestamps"
-
-
-def test_get_timing_type_with_starting_time(nwb_converter):
-    """Test that get_timing_type returns 'starting_time and rate' when only starting time is set."""
-    interface = nwb_converter.data_interface_objects["Video1"]
-    interface.set_aligned_starting_time(aligned_starting_time=10.0)
-    assert interface.get_timing_type() == "starting_time and rate"
-
-
-def test_get_timing_type_default(nwb_converter):
-    """Test that get_timing_type returns 'starting_time and rate' by default."""
-    interface = nwb_converter.data_interface_objects["Video1"]
-    assert interface.get_timing_type() == "starting_time and rate"
-
-
 def test_timestamp_shifting(nwb_converter):
     """Test that timestamps are correctly shifted when setting aligned starting time."""
     interface = nwb_converter.data_interface_objects["Video1"]


### PR DESCRIPTION
@pauladkisson as discussed during https://github.com/catalystneuro/neuroconv/pull/1251

This will unify video with ecehpys and ophys.