### PR TITLE
Fix default metadata bug for ExternalVideoInterface

### DIFF
--- a/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
@@ -308,7 +308,8 @@ class ExternalVideoInterface(BaseDataInterface):
 
         # Be sure to copy metadata at this step to avoid mutating in-place
         videos_metadata = deepcopy(metadata).get("Behavior", dict()).get("ExternalVideos", None)
-        if videos_metadata is None:
+        # If no metadata is provided use the default metadata
+        if videos_metadata is None or self.video_name not in videos_metadata:
             videos_metadata = deepcopy(self.get_metadata()["Behavior"]["ExternalVideos"])
         image_series_kwargs = videos_metadata[self.video_name]
         image_series_kwargs["name"] = self.video_name

--- a/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
@@ -310,7 +310,7 @@ class ExternalVideoInterface(BaseDataInterface):
         videos_metadata = deepcopy(metadata).get("Behavior", dict()).get("ExternalVideos", None)
         if videos_metadata is None:
             videos_metadata = deepcopy(self.get_metadata()["Behavior"]["ExternalVideos"])
-        image_series_kwargs = metadata["Behavior"]["ExternalVideos"][self.video_name]
+        image_series_kwargs = videos_metadata
         image_series_kwargs["name"] = self.video_name
 
         timing_type = self.get_timing_type()

--- a/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
@@ -310,7 +310,7 @@ class ExternalVideoInterface(BaseDataInterface):
         videos_metadata = deepcopy(metadata).get("Behavior", dict()).get("ExternalVideos", None)
         if videos_metadata is None:
             videos_metadata = deepcopy(self.get_metadata()["Behavior"]["ExternalVideos"])
-        image_series_kwargs = videos_metadata
+        image_series_kwargs = videos_metadata[self.video_name]
         image_series_kwargs["name"] = self.video_name
 
         timing_type = self.get_timing_type()

--- a/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
@@ -311,7 +311,7 @@ class ExternalVideoInterface(BaseDataInterface):
         videos_metadata = deepcopy(metadata).get("Behavior", dict()).get("ExternalVideo", None)
         if videos_metadata is None:
             videos_metadata = deepcopy(self.get_metadata()["Behavior"]["ExternalVideo"])
-        image_series_kwargs = videos_metadata
+        image_series_kwargs = videos_metadata[self.video_name]
         image_series_kwargs["name"] = self.video_name
 
         timing_type = self.get_timing_type()

--- a/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
@@ -311,7 +311,7 @@ class ExternalVideoInterface(BaseDataInterface):
         videos_metadata = deepcopy(metadata).get("Behavior", dict()).get("ExternalVideo", None)
         if videos_metadata is None:
             videos_metadata = deepcopy(self.get_metadata()["Behavior"]["ExternalVideo"])
-        image_series_kwargs = metadata["Behavior"]["ExternalVideo"][self.video_name]
+        image_series_kwargs = videos_metadata
         image_series_kwargs["name"] = self.video_name
 
         timing_type = self.get_timing_type()

--- a/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
@@ -276,7 +276,8 @@ class InternalVideoInterface(BaseDataInterface):
 
         # Be sure to copy metadata at this step to avoid mutating in-place
         videos_metadata = deepcopy(metadata).get("Behavior", dict()).get("InternalVideos", None)
-        if videos_metadata is None:
+        # If no metadata is provided use the default metadata
+        if videos_metadata is None or self.video_name not in videos_metadata:
             videos_metadata = deepcopy(self.get_metadata()["Behavior"]["InternalVideos"])
         image_series_kwargs = videos_metadata[self.video_name]
         image_series_kwargs["name"] = self.video_name

--- a/tests/test_behavior/test_external_video_interface.py
+++ b/tests/test_behavior/test_external_video_interface.py
@@ -13,6 +13,15 @@ from neuroconv.datainterfaces.behavior.video.externalvideointerface import (
 from neuroconv.utils import dict_deep_update
 
 
+def test_initialization_without_metadata(video_files):
+    from pynwb.testing.mock.file import mock_NWBFile
+
+    nwbfile = mock_NWBFile()
+    interface = ExternalVideoInterface(file_paths=[video_files[0]])
+
+    interface.add_to_nwbfile(nwbfile=nwbfile)
+
+
 @pytest.fixture
 def nwb_converter(video_files):
     """Create and return a test NWBConverter instance."""

--- a/tests/test_behavior/test_internal_video_interface.py
+++ b/tests/test_behavior/test_internal_video_interface.py
@@ -13,6 +13,15 @@ from neuroconv.datainterfaces.behavior.video.internalvideointerface import (
 from neuroconv.utils import dict_deep_update
 
 
+def test_initialization_without_metadata(video_files):
+    from pynwb.testing.mock.file import mock_NWBFile
+
+    nwbfile = mock_NWBFile()
+    interface = InternalVideoInterface(file_paths=[video_files[0]])
+
+    interface.add_to_nwbfile(nwbfile=nwbfile)
+
+
 @pytest.fixture
 def nwb_converter(video_files):
     """Create and return a test NWBConverter instance."""

--- a/tests/test_behavior/test_internal_video_interface.py
+++ b/tests/test_behavior/test_internal_video_interface.py
@@ -17,7 +17,7 @@ def test_initialization_without_metadata(video_files):
     from pynwb.testing.mock.file import mock_NWBFile
 
     nwbfile = mock_NWBFile()
-    interface = InternalVideoInterface(file_paths=[video_files[0]])
+    interface = InternalVideoInterface(file_path=video_files[0])
 
     interface.add_to_nwbfile(nwbfile=nwbfile)
 


### PR DESCRIPTION
This escaped us in the recent merge. This does not need a changelog because is a fix for a bug that has not been released.