### PR TITLE
Fix `VideoInterface` when metadata is not passed

### DIFF
--- a/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
@@ -348,8 +348,10 @@ class VideoInterface(BaseDataInterface):
 
         # Transform metadata from list format to nested dictionary format
         metadata_reformatted = deepcopy(metadata)
-        video_name = videos_metadata[0].pop("name")
+        if "Behavior" not in metadata_reformatted:
+            metadata_reformatted["Behavior"] = dict()
 
+        video_name = videos_metadata[0].pop("name")
         # Use appropriate metadata key based on external_mode
         if external_mode:
             metadata_reformatted["Behavior"]["ExternalVideos"] = {video_name: videos_metadata[0]}

--- a/tests/test_behavior/test_video_interface.py
+++ b/tests/test_behavior/test_video_interface.py
@@ -4,9 +4,19 @@ import numpy as np
 import pytest
 from dateutil.tz import gettz
 from pynwb import NWBHDF5IO
+from pynwb.testing.mock.file import mock_NWBFile
 
 from neuroconv import NWBConverter
 from neuroconv.datainterfaces import VideoInterface
+
+
+def test_video_interface_without_metadata(video_files):
+    """Test that the VideoInterface class can be imported."""
+
+    interface = VideoInterface(file_paths=[video_files[0]])
+
+    nwbfile = mock_NWBFile()
+    interface.add_to_nwbfile(nwbfile=nwbfile)
 
 
 @pytest.fixture

--- a/tests/test_behavior/test_video_interface.py
+++ b/tests/test_behavior/test_video_interface.py
@@ -11,7 +11,7 @@ from neuroconv.datainterfaces import VideoInterface
 
 
 def test_video_interface_without_metadata(video_files):
-    """Test that the VideoInterface class can be imported."""
+    """Test that the VideoInterface class can add data to nwbfile without metadata being passed."""
 
     interface = VideoInterface(file_paths=[video_files[0]])
 


### PR DESCRIPTION
I think this is another regression caused by the recent changes. If metadata is not passed to the VideoInterface, it fails because the dictionary doesn't contain the expected behavior when reformatting the metadata.

No changelog for this either.