### PR TITLE
Update video timestamps

### DIFF
--- a/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
@@ -187,13 +187,17 @@ class ExternalVideoInterface(BaseDataInterface):
                 segment_starting_time + aligned_starting_time for segment_starting_time in self._segment_starting_times
             ]
         else:
-            raise ValueError("There are no timestamps or starting times set to shift by a common value!")
+            self._segment_starting_times = [np.nan] * self._number_of_files
+            self._segment_starting_times[0] = aligned_starting_time
 
     def set_aligned_segment_starting_times(self, aligned_segment_starting_times: list[float], stub_test: bool = False):
         """
         Align the individual starting time for each video (segment) in this interface relative to the common session start time.
 
         Must be in units seconds relative to the common 'session_start_time'.
+
+        If the timestamps have not already been set, this method will set them to the original timestamps and then shift
+        them by the aligned segment starting times.
 
         Parameters
         ----------
@@ -211,17 +215,15 @@ class ExternalVideoInterface(BaseDataInterface):
             f"The length of the 'aligned_segment_starting_times' list ({aligned_segment_starting_times_length}) does not match the "
             "number of video files ({self._number_of_files})!"
         )
-        if self._timestamps is not None:
-            self.set_aligned_timestamps(
-                aligned_timestamps=[
-                    timestamps + segment_starting_time
-                    for timestamps, segment_starting_time in zip(
-                        self.get_timestamps(stub_test=stub_test), aligned_segment_starting_times
-                    )
-                ]
-            )
-        else:
-            self._segment_starting_times = aligned_segment_starting_times
+        self._timestamps = self.get_timestamps(stub_test=stub_test)
+        self.set_aligned_timestamps(
+            aligned_timestamps=[
+                timestamps + segment_starting_time
+                for timestamps, segment_starting_time in zip(
+                    self.get_timestamps(stub_test=stub_test), aligned_segment_starting_times
+                )
+            ]
+        )
 
     def align_by_interpolation(self, unaligned_timestamps: np.ndarray, aligned_timestamps: np.ndarray):
         raise NotImplementedError("The `align_by_interpolation` method has not been developed for this interface yet.")

--- a/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
@@ -171,12 +171,10 @@ class ExternalVideoInterface(BaseDataInterface):
             The common starting time for all segments of temporal data in this interface.
         """
         if self._timestamps is not None:
-            raise ValueError(
-                "The timestamps have already been set for this interface. "
-                "You cannot set the starting time after the timestamps have been set."
-                "Use set_aligned_segment_starting_times instead."
-            )
-        self._starting_time = aligned_starting_time
+            aligned_segment_starting_times = [aligned_starting_time] * self._number_of_files
+            self.set_aligned_segment_starting_times(aligned_segment_starting_times=aligned_segment_starting_times)
+        else:
+            self._starting_time = aligned_starting_time
 
     def set_aligned_segment_starting_times(self, aligned_segment_starting_times: list[float], stub_test: bool = False):
         """

--- a/tests/test_behavior/test_external_video_interface.py
+++ b/tests/test_behavior/test_external_video_interface.py
@@ -98,6 +98,26 @@ def test_external_mode_with_timestamps(
         assert list(module["Video test3"].external_file[:]) == [video_files[2]]
 
 
+def test_external_mode_with_starting_time(nwb_converter, nwbfile_path, metadata, video_files):
+    """Test that external mode works correctly with starting time."""
+    interface = nwb_converter.data_interface_objects["Video1"]
+    interface.set_aligned_starting_time(aligned_starting_time=123.0)
+
+    conversion_options = dict(Video1=dict(starting_frames=[0, 4]))
+    nwb_converter.run_conversion(
+        nwbfile_path=nwbfile_path,
+        overwrite=True,
+        conversion_options=conversion_options,
+        metadata=metadata,
+    )
+    with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
+        nwbfile = io.read()
+        module = nwbfile.acquisition
+        assert list(module["Video test1"].external_file[:]) == video_files[0:2]
+        assert list(module["Video test3"].external_file[:]) == [video_files[2]]
+        assert module["Video test1"].starting_time == 123.0
+
+
 def test_irregular_timestamps(nwb_converter, nwbfile_path, metadata, aligned_segment_starting_times):
     """Test that irregular timestamps are handled correctly."""
     aligned_timestamps = [np.array([1.0, 2.0, 4.0]), np.array([5.0, 6.0, 7.0])]
@@ -211,25 +231,30 @@ def test_custom_module(nwb_converter, nwbfile_path, metadata, aligned_segment_st
         assert "Video test3" in nwbfile.processing["behavior"].data_interfaces
 
 
-def test_set_aligned_timestamps_after_segment_starting_times_error(nwb_converter):
-    """Test that setting timestamps after segment_starting_times raises an error."""
+def test_set_aligned_segment_starting_times_alone(nwb_converter):
+    """Test that setting segment_starting_times without setting aligned timestamps automatically sets the timestamps."""
     interface = nwb_converter.data_interface_objects["Video1"]
 
-    # First set segment_starting_times
+    interface._timestamps = None
     interface.set_aligned_segment_starting_times(aligned_segment_starting_times=[10.0, 20.0])
 
-    # Now try to set timestamps - should raise an assertion error
-    with pytest.raises(AssertionError):
-        interface.set_aligned_timestamps(aligned_timestamps=[np.array([1.0, 2.0, 3.0]), np.array([4.0, 5.0, 6.0])])
+    original_timestamps = interface.get_original_timestamps()
+    expected_timestamps = [
+        timestamps + starting_time for timestamps, starting_time in zip(original_timestamps, [10.0, 20.0])
+    ]
+    for (
+        original,
+        expected,
+        starting_time,
+    ) in zip(original_timestamps, expected_timestamps, [10.0, 20.0]):
+        np.testing.assert_array_equal(original + starting_time, expected)
 
 
-def test_set_aligned_starting_time_no_timing_info_error(nwb_converter):
+def test_set_aligned_starting_time_with_timing_info_error(nwb_converter):
     """Test that set_aligned_starting_time raises an error when no timing info exists."""
     interface = nwb_converter.data_interface_objects["Video1"]
 
-    # Mock _timestamps and _segment_starting_times to be None
-    interface._timestamps = None
-    interface._segment_starting_times = None
+    interface._timestamps = interface.get_original_timestamps()
 
     with pytest.raises(ValueError):
         interface.set_aligned_starting_time(aligned_starting_time=10.0)

--- a/tests/test_behavior/test_external_video_interface.py
+++ b/tests/test_behavior/test_external_video_interface.py
@@ -250,16 +250,6 @@ def test_set_aligned_segment_starting_times_alone(nwb_converter):
         np.testing.assert_array_equal(original + starting_time, expected)
 
 
-def test_set_aligned_starting_time_with_timing_info_error(nwb_converter):
-    """Test that set_aligned_starting_time raises an error when no timing info exists."""
-    interface = nwb_converter.data_interface_objects["Video1"]
-
-    interface._timestamps = interface.get_original_timestamps()
-
-    with pytest.raises(ValueError):
-        interface.set_aligned_starting_time(aligned_starting_time=10.0)
-
-
 def test_get_original_timestamps_stub(nwb_converter):
     """Test that get_original_timestamps respects stub_test parameter."""
     interface = nwb_converter.data_interface_objects["Video2"]  # Using Video2 which has a single file


### PR DESCRIPTION
slightly different from what I described in #1279.

Basically, `set_aligned_segment_starting_times` assumes you want to save the full timestamps, and sets them automatically if they haven't been set already. Then, `set_aligned_starting_time` can be used if you want to use starting_time and rate.