### PR TITLE
Expose `configure_and_write_nwbfile` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * Updated GitHub Actions workflows to use Environment Files instead of the deprecated `set-output` command [#1259](https://github.com/catalystneuro/neuroconv/pull/1259)
 * Propagate `verbose` parameter from Converters to Interfaces [#1253](https://github.com/catalystneuro/neuroconv/issues/1253)
 * Replace uses of scipy load_mat and h5storage loadmat with pymat_reader read_mat in `CellExplorerSortingInterface` [#1254](https://github.com/catalystneuro/neuroconv/pull/1254)
-* `configure_backend` is now exposed to be imported as `from neuroconv.tools import configure_and_write_nwbfile` [#TBD](https://github.com/catalystneuro/neuroconv/pull/TBD)
+* `configure_backend` is now exposed to be imported as `from neuroconv.tools import configure_and_write_nwbfile` [#1287](https://github.com/catalystneuro/neuroconv/pull/1287)
 
 # v0.7.1 (March 5, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Updated GitHub Actions workflows to use Environment Files instead of the deprecated `set-output` command [#1259](https://github.com/catalystneuro/neuroconv/pull/1259)
 * Propagate `verbose` parameter from Converters to Interfaces [#1253](https://github.com/catalystneuro/neuroconv/issues/1253)
 * Replace uses of scipy load_mat and h5storage loadmat with pymat_reader read_mat in `CellExplorerSortingInterface` [#1254](https://github.com/catalystneuro/neuroconv/pull/1254)
+* `configure_backend` is now exposed to be imported as `from neuroconv.tools import configure_and_write_nwbfile` [#TBD](https://github.com/catalystneuro/neuroconv/pull/TBD)
 
 # v0.7.1 (March 5, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## Features
 
 ## Improvements
-
+* `configure_backend` is now exposed to be imported as `from neuroconv.tools import configure_and_write_nwbfile` [#1287](https://github.com/catalystneuro/neuroconv/pull/1287)
 
 # v0.7.2 (April 4, 2025)
 
@@ -38,7 +38,6 @@
 * Updated GitHub Actions workflows to use Environment Files instead of the deprecated `set-output` command [#1259](https://github.com/catalystneuro/neuroconv/pull/1259)
 * Propagate `verbose` parameter from Converters to Interfaces [#1253](https://github.com/catalystneuro/neuroconv/issues/1253)
 * Replace uses of scipy load_mat and h5storage loadmat with pymat_reader read_mat in `CellExplorerSortingInterface` [#1254](https://github.com/catalystneuro/neuroconv/pull/1254)
-* `configure_backend` is now exposed to be imported as `from neuroconv.tools import configure_and_write_nwbfile` [#1287](https://github.com/catalystneuro/neuroconv/pull/1287)
 * Added camera device support for ExternalVideoInterface and InternalVideoInterface: [PR #1282](https://github.com/catalystneuro/neuroconv/pull/1282)
 
 

--- a/docs/user_guide/adding_trials.rst
+++ b/docs/user_guide/adding_trials.rst
@@ -23,7 +23,7 @@ Once this information is added, you can write the NWB file to disk:
 
 .. code-block:: python
 
-    from neuroconv.tools.nwb_helpers import configure_and_write_nwbfile
+    from neuroconv.tools import configure_and_write_nwbfile
 
     configure_and_write_nwbfile(
         nwbfile, nwbfile_path="path/to/destination.nwb", backend="hdf5"

--- a/docs/user_guide/backend_configuration.rst
+++ b/docs/user_guide/backend_configuration.rst
@@ -132,7 +132,7 @@ Then we can use this configuration to write the NWB file:
 
 .. code-block:: python
 
-    from neuroconv.tools.nwb_helpers import configure_and_write_nwbfile
+    from neuroconv.tools import configure_and_write_nwbfile
 
     dataset_configurations["acquisition/MyTimeSeries/data"] = dataset_configuration
 

--- a/docs/user_guide/datainterfaces.rst
+++ b/docs/user_guide/datainterfaces.rst
@@ -188,7 +188,7 @@ The following code automatically optimizes datasets for cloud compute and writes
 
 .. code-block:: python
 
-    from neuroconv.tools.nwb_helpers import configure_and_write_nwbfile
+    from neuroconv.tools import configure_and_write_nwbfile
 
     configure_and_write_nwbfile(
         nwbfile, nwbfile_path="path/to/destination.nwb", backend="hdf5"

--- a/src/neuroconv/tools/__init__.py
+++ b/src/neuroconv/tools/__init__.py
@@ -9,3 +9,4 @@ from .importing import (
 from .nwb_helpers import get_module
 from .path_expansion import LocalPathExpander
 from .processes import deploy_process
+from .nwb_helpers import configure_and_write_nwbfile

--- a/src/neuroconv/tools/nwb_helpers/_metadata_and_file_helpers.py
+++ b/src/neuroconv/tools/nwb_helpers/_metadata_and_file_helpers.py
@@ -331,7 +331,7 @@ def make_or_load_nwbfile(
 
 
 def _resolve_backend(
-    backend: Optional[Literal["hdf5"]] = None,
+    backend: Optional[Literal["hdf5", "zarr"]] = None,
     backend_configuration: Optional[BackendConfiguration] = None,
 ) -> Literal["hdf5"]:
     """
@@ -339,12 +339,12 @@ def _resolve_backend(
 
     Parameters
     ----------
-    backend: {"hdf5"}, optional
+    backend: {"hdf5", "zarr"}, optional
     backend_configuration: BackendConfiguration, optional
 
     Returns
     -------
-    backend: {"hdf5"}
+    backend: {"hdf5", "zarr"}
 
     """
 

--- a/tests/imports.py
+++ b/tests/imports.py
@@ -71,6 +71,7 @@ class TestImportStructure(TestCase):
             "data_transfers",
             "LocalPathExpander",
             "get_module",
+            "configure_and_write_nwbfile",
         ]
         assert sorted(current_structure) == sorted(expected_structure)
 


### PR DESCRIPTION
For the Cohen conversion, we're working with a lot of ad-hoc code where we add data directly to the NWBFile. At the end, we call configure_and_write_nwbfile to let users easily specify the backend.

I'd like to make this function importable from the top level of tools, since I often forget its exact location (currently, it's from neuroconv.tools.nwb_helpers import configure_and_write_nwbfile). Given how frequently we use it, I don't see any downside to exposing it at a higher level.