### PR TITLE
Improve ElectricalSeries units in recording interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # v0.7.3 (Upcoming)
 
 ## Deprecations and Changes
-* `write_scaled` behavior on `add_electrical_series_to_nwbfile` is deprecated and will be removed in or after October 2025 [PR #TBD](https://github.com/catalystneuro/neuroconv/pull/TBD)
+* `write_scaled` behavior on `add_electrical_series_to_nwbfile` is deprecated and will be removed in or after October 2025 [PR #1292](https://github.com/catalystneuro/neuroconv/pull/1292)
+* `add_electrical_series_to_nwbfile` now requires both gain and offsets to write scaling factor for voltage conversion when writing to NWB [PR #1292](https://github.com/catalystneuro/neuroconv/pull/1292)
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.7.3 (Upcoming)
 
 ## Deprecations and Changes
+* `write_scaled` behavior on `add_electrical_series_to_nwbfile` is deprecated and will be removed in or after October 2025 [PR #TBD](https://github.com/catalystneuro/neuroconv/pull/TBD)
 
 ## Bug Fixes
 

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -856,25 +856,25 @@ def add_electrical_series_to_nwbfile(
 
     if recording.has_scaleable_traces():
         # Spikeinterface gains and offsets are gains and offsets to micro volts.
-        # The units of the ElectricalSeries should be volts
+        # The units of the ElectricalSeries should be volts so we scale correspondingly.
         micro_to_volts_conversion_factor = 1e-6
-        channel_gains_to_V = recording.get_channel_gains() * micro_to_volts_conversion_factor
-        channel_offsets_to_V = recording.get_channel_offsets() * micro_to_volts_conversion_factor
+        channel_gains_to_volts = recording.get_channel_gains() * micro_to_volts_conversion_factor
+        channel_offsets_to_volts = recording.get_channel_offsets() * micro_to_volts_conversion_factor
 
-        unique_gains = set(channel_gains_to_V)
+        unique_gains = set(channel_gains_to_volts)
         if len(unique_gains) == 1:
-            conversion_to_volts = channel_gains_to_V[0]
+            conversion_to_volts = channel_gains_to_volts[0]
             eseries_kwargs.update(conversion=conversion_to_volts)
         else:
-            eseries_kwargs.update(channel_conversion=channel_gains_to_V)
+            eseries_kwargs.update(channel_conversion=channel_gains_to_volts)
 
-        unique_offset = set(channel_offsets_to_V)
+        unique_offset = set(channel_offsets_to_volts)
         if len(unique_offset) > 1:
             channel_ids = recording.get_channel_ids()
             # This prints a user friendly error where the user is provided with a map from offset to channels
             _report_variable_offset(recording=recording)
 
-        unique_offset = channel_offsets_to_V[0]
+        unique_offset = channel_offsets_to_volts[0]
         eseries_kwargs.update(offset=unique_offset)
     else:
         warning_message = (

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -352,34 +352,6 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 1e-6
         np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
 
-    # def test_null_offsets_in_recording_extractor(self):
-    #     gains = self.gains_default
-    #     self.test_recording_extractor.set_channel_gains(gains=gains)
-
-    #     add_electrical_series_to_nwbfile(
-    #         recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None
-    #     )
-
-    #     acquisition_module = self.nwbfile.acquisition
-    #     electrical_series = acquisition_module["ElectricalSeriesRaw"]
-
-    #     # Test conversion factor
-    #     conversion_factor_scalar = electrical_series.conversion
-    #     assert conversion_factor_scalar == 1e-6
-
-    #     # Test offset scalar
-    #     offset_scalar = electrical_series.offset
-    #     assert offset_scalar == 0
-
-    #     # Test equality of data in Volts. Data in spikeextractors is in microvolts when scaled
-    #     extracted_data = electrical_series.data[:]
-    #     data_in_volts = extracted_data * conversion_factor_scalar + offset_scalar
-    #     traces_data = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=False)
-    #     gains = self.test_recording_extractor.get_channel_gains()
-    #     traces_data_in_micro_volts = traces_data * gains
-    #     traces_data_in_volts = traces_data_in_micro_volts * 1e-6
-    #     np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
-
     def test_variable_offsets_assertion(self):
         gains = self.gains_default
         offsets = self.offsets_variable


### PR DESCRIPTION
We have been discussing with the SpikeInterface team about improving unit handling [here](https://github.com/SpikeInterface/spikeinterface/pull/3844), and this is the first PR moving in that direction. This PR improves the following:

1) It checks whether the recording has the necessary information to scale to microvolts (gains and offsets). If not, it throws a warning and writes the data as it is. Note that, unlike before, it does not allow partially specified offsets and gains. This is in preparation for a future error that SpikeInterface will raise if units are not properly scalable to microvolts. I might make this an error once we make further changes in SpikeInterface as I don't want to break anything at the moment.

2) This should also fix #1266, which is currently not working and is something we want to discourage anyway.
