### PR TITLE
Add  `add_time_series_to_nwbfile` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # v0.7.3 (Upcoming)
 
 ## Deprecations and Changes
+* `write_scaled` behavior on `add_electrical_series_to_nwbfile` is deprecated and will be removed in or after October 2025 [PR #1292](https://github.com/catalystneuro/neuroconv/pull/1292)
+* `add_electrical_series_to_nwbfile` now requires both gain and offsets to write scaling factor for voltage conversion when writing to NWB [PR #1292](https://github.com/catalystneuro/neuroconv/pull/1292)
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## Bug Fixes
 
 ## Features
-* Added a new `add_time_series_to_nwbfile` function to add recording extractors from SpikeInterface as recording extractors to an nwbfile as time series [#1296]((https://github.com/catalystneuro/neuroconv/pull/1296))
+* Added a new `add_recording_as_time_series_to_nwbfile` function to add recording extractors from SpikeInterface as recording extractors to an nwbfile as time series [#1296]((https://github.com/catalystneuro/neuroconv/pull/1296))
 
 ## Improvements
 * `configure_backend` is now exposed to be imported as `from neuroconv.tools import configure_and_write_nwbfile` [#1287](https://github.com/catalystneuro/neuroconv/pull/1287)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Bug Fixes
 
 ## Features
+* Added a new `add_time_series_to_nwbfile` function to add recording extractors from SpikeInterface as recording extractors to an nwbfile as time series [#TBD]((https://github.com/catalystneuro/neuroconv/pull/TBD))
 
 ## Improvements
 * `configure_backend` is now exposed to be imported as `from neuroconv.tools import configure_and_write_nwbfile` [#1287](https://github.com/catalystneuro/neuroconv/pull/1287)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## Bug Fixes
 
 ## Features
-* Added a new `add_time_series_to_nwbfile` function to add recording extractors from SpikeInterface as recording extractors to an nwbfile as time series [#TBD]((https://github.com/catalystneuro/neuroconv/pull/TBD))
+* Added a new `add_time_series_to_nwbfile` function to add recording extractors from SpikeInterface as recording extractors to an nwbfile as time series [#1296]((https://github.com/catalystneuro/neuroconv/pull/1296))
 
 ## Improvements
 * `configure_backend` is now exposed to be imported as `from neuroconv.tools import configure_and_write_nwbfile` [#1287](https://github.com/catalystneuro/neuroconv/pull/1287)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ test = [
     "ndx-events==0.2.1",  # for special tests to ensure load_namespaces is set to allow NWBFile load at all times
     "parameterized>=0.8.1",
     "ndx-miniscope",
-    "spikeinterface[qualitymetrics]>=0.102.0",
+    "spikeinterface[qualitymetrics]>=0.102.2",
     "zarr",
     "pytest-xdist"
 ]
@@ -85,7 +85,7 @@ docs = [
     "sphinx-toggleprompt==0.2.0",
     "sphinx-copybutton==0.5.0",
     "roiextractors",  # Needed for the API documentation
-    "spikeinterface>=0.102",  # Needed for the API documentation
+    "spikeinterface>=0.102.2",  # Needed for the API documentation
     "pydata_sphinx_theme==0.12.0"
 ]
 
@@ -150,94 +150,94 @@ behavior = [
 ## Ecephys
 alphaomega = [
     "neo>=0.13.3",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 axona = [
     "neo>=0.13.3",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 biocam = [
     "neo>=0.13.3",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 blackrock = [
     "neo>=0.14",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 cellexplorer = [
     "neo>=0.13.3",
     "pymatreader>=0.0.32",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
     "setuptools; python_version >= '3.12'"
 ]
 edf = [
     "neo>=0.13.3",
     "pyedflib>=0.1.36,<0.1.39",  # Remove ceiling after neo 0.14.1 releases
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 intan = [
     "neo>=0.14",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 kilosort = [
     "neo>=0.13.3",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 
 maxwell = [
     "neo>=0.13.3",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 mcsraw = [
     "neo>=0.13.3",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 mearec = [
     "MEArec>=1.8.0",
     "neo>=0.13.3",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
     "setuptools; python_version >= '3.12'"
 ]
 neuralynx = [
     "natsort>=7.1.1",
     "neo>=0.13.3",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 neuroscope = [
     "lxml>=4.6.5",
     "neo>=0.13.3",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 openephys = [
     "lxml>=4.9.4",
     "neo>=0.14",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 phy = [
     "neo>=0.13.3",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 plexon = [
     "neo>=0.13.3",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
     "zugbruecke >= 0.2.1; platform_system != 'Windows'",
 ]
 spike2 = [
     "neo>=0.13.3",
     "sonpy>=1.7.1; python_version=='3.9' and platform_system != 'Darwin'",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 spikegadgets = [
     "neo>=0.13.3",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 spikeglx = [
     "neo>=0.14",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 tdt = [
     "neo>=0.13.3",
-    "spikeinterface>=0.102",
+    "spikeinterface>=0.102.2",
 ]
 ecephys = [  # Note that this the requirements of the extracts as they are on pipy
     "neuroconv[alphaomega]",

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
@@ -277,31 +277,13 @@ class SpikeGLXNIDQInterface(BaseDataInterface):
         # Prepare TimeSeries metadata
         time_series_name = "TimeSeriesNIDQ"
         description = f"Analog data from the NIDQ board. Channels are {channel_names} in that order."
-
-        # Ensure TimeSeries metadata exists
-        if "TimeSeries" not in metadata:
-            metadata["TimeSeries"] = {}
-
-        # Add or update the TimeSeriesNIDQ entry in metadata
-        if time_series_name not in metadata["TimeSeries"]:
-            metadata["TimeSeries"][time_series_name] = {}
-
-        # Set default values if not already in metadata
-        ts_metadata = metadata["TimeSeries"][time_series_name]
-        if "name" not in ts_metadata:
-            ts_metadata["name"] = time_series_name
-        if "description" not in ts_metadata:
-            ts_metadata["description"] = description
-        if "unit" not in ts_metadata:
-            ts_metadata["unit"] = "a.u."
-
+        metadata["TimeSeries"][time_series_name] = dict(description=description)
         # Use add_time_series_to_nwbfile to add the time series
         add_time_series_to_nwbfile(
             recording=analog_recorder,
             nwbfile=nwbfile,
             metadata=metadata,
             segment_index=segment_index,
-            write_as="raw",
             iterator_type=iterator_type,
             iterator_opts=iterator_opts,
             always_write_timestamps=always_write_timestamps,

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
@@ -268,7 +268,6 @@ class SpikeGLXNIDQInterface(BaseDataInterface):
 
         analog_recorder = recording.select_channels(channel_ids=self.analog_channel_ids)
         channel_names = analog_recorder.get_property(key="channel_names")
-        segment_index = 0
 
         # Create default metadata if not provided
         if metadata is None:
@@ -283,7 +282,6 @@ class SpikeGLXNIDQInterface(BaseDataInterface):
             recording=analog_recorder,
             nwbfile=nwbfile,
             metadata=metadata,
-            segment_index=segment_index,
             iterator_type=iterator_type,
             iterator_opts=iterator_opts,
             always_write_timestamps=always_write_timestamps,

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
@@ -5,14 +5,11 @@ from typing import Literal, Optional
 import numpy as np
 from pydantic import ConfigDict, DirectoryPath, FilePath, validate_call
 from pynwb import NWBFile
-from pynwb.base import TimeSeries
 
 from .spikeglx_utils import get_session_start_time
 from ....basedatainterface import BaseDataInterface
 from ....tools.signal_processing import get_rising_frames_from_ttl
-from ....tools.spikeinterface.spikeinterface import _recording_traces_to_hdmf_iterator
 from ....utils import (
-    calculate_regular_series_rate,
     get_json_schema_from_method_signature,
 )
 
@@ -234,6 +231,7 @@ class SpikeGLXNIDQInterface(BaseDataInterface):
                 iterator_type=iterator_type,
                 iterator_opts=iterator_opts,
                 always_write_timestamps=always_write_timestamps,
+                metadata=metadata,
             )
 
         if self.has_digital_channels:
@@ -246,6 +244,7 @@ class SpikeGLXNIDQInterface(BaseDataInterface):
         iterator_type: Optional[str],
         iterator_opts: Optional[dict],
         always_write_timestamps: bool,
+        metadata: Optional[dict] = None,
     ):
         """
         Add analog channels from the NIDQ board to the NWB file.
@@ -262,44 +261,52 @@ class SpikeGLXNIDQInterface(BaseDataInterface):
             Additional options for the iterator
         always_write_timestamps : bool
             If True, always writes timestamps instead of using sampling rate
+        metadata : Optional[dict], default: None
+            Metadata dictionary with TimeSeries information
         """
+        from ....tools.spikeinterface import add_time_series_to_nwbfile
+
         analog_recorder = recording.select_channels(channel_ids=self.analog_channel_ids)
         channel_names = analog_recorder.get_property(key="channel_names")
         segment_index = 0
-        analog_data_iterator = _recording_traces_to_hdmf_iterator(
+
+        # Create default metadata if not provided
+        if metadata is None:
+            metadata = {}
+
+        # Prepare TimeSeries metadata
+        time_series_name = "TimeSeriesNIDQ"
+        description = f"Analog data from the NIDQ board. Channels are {channel_names} in that order."
+
+        # Ensure TimeSeries metadata exists
+        if "TimeSeries" not in metadata:
+            metadata["TimeSeries"] = {}
+
+        # Add or update the TimeSeriesNIDQ entry in metadata
+        if time_series_name not in metadata["TimeSeries"]:
+            metadata["TimeSeries"][time_series_name] = {}
+
+        # Set default values if not already in metadata
+        ts_metadata = metadata["TimeSeries"][time_series_name]
+        if "name" not in ts_metadata:
+            ts_metadata["name"] = time_series_name
+        if "description" not in ts_metadata:
+            ts_metadata["description"] = description
+        if "unit" not in ts_metadata:
+            ts_metadata["unit"] = "a.u."
+
+        # Use add_time_series_to_nwbfile to add the time series
+        add_time_series_to_nwbfile(
             recording=analog_recorder,
+            nwbfile=nwbfile,
+            metadata=metadata,
             segment_index=segment_index,
+            write_as="raw",
             iterator_type=iterator_type,
             iterator_opts=iterator_opts,
+            always_write_timestamps=always_write_timestamps,
+            time_series_name=time_series_name,
         )
-
-        name = "TimeSeriesNIDQ"
-        description = f"Analog data from the NIDQ board. Channels are {channel_names} in that order."
-        time_series_kwargs = dict(name=name, data=analog_data_iterator, unit="a.u.", description=description)
-
-        if always_write_timestamps:
-            timestamps = recording.get_times(segment_index=segment_index)
-            shifted_timestamps = timestamps
-            time_series_kwargs.update(timestamps=shifted_timestamps)
-        else:
-            recording_has_timestamps = recording.has_time_vector(segment_index=segment_index)
-            if recording_has_timestamps:
-                timestamps = recording.get_times(segment_index=segment_index)
-                rate = calculate_regular_series_rate(series=timestamps)
-                recording_t_start = timestamps[0]
-            else:
-                rate = recording.get_sampling_frequency()
-                recording_t_start = recording._recording_segments[segment_index].t_start or 0
-
-            if rate:
-                starting_time = float(recording_t_start)
-                time_series_kwargs.update(starting_time=starting_time, rate=recording.get_sampling_frequency())
-            else:
-                shifted_timestamps = timestamps
-                time_series_kwargs.update(timestamps=shifted_timestamps)
-
-        time_series = TimeSeries(**time_series_kwargs)
-        nwbfile.add_acquisition(time_series)
 
     def _add_digital_channels(self, nwbfile: NWBFile):
         """

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
@@ -264,7 +264,7 @@ class SpikeGLXNIDQInterface(BaseDataInterface):
         metadata : Optional[dict], default: None
             Metadata dictionary with TimeSeries information
         """
-        from ....tools.spikeinterface import add_time_series_to_nwbfile
+        from ....tools.spikeinterface import add_recording_as_time_series_to_nwbfile
 
         analog_recorder = recording.select_channels(channel_ids=self.analog_channel_ids)
         channel_names = analog_recorder.get_property(key="channel_names")
@@ -277,8 +277,8 @@ class SpikeGLXNIDQInterface(BaseDataInterface):
         time_series_name = "TimeSeriesNIDQ"
         description = f"Analog data from the NIDQ board. Channels are {channel_names} in that order."
         metadata["TimeSeries"][time_series_name] = dict(description=description)
-        # Use add_time_series_to_nwbfile to add the time series
-        add_time_series_to_nwbfile(
+        # Use add_recording_as_time_series_to_nwbfile to add the time series
+        add_recording_as_time_series_to_nwbfile(
             recording=analog_recorder,
             nwbfile=nwbfile,
             metadata=metadata,

--- a/src/neuroconv/tools/spikeinterface/__init__.py
+++ b/src/neuroconv/tools/spikeinterface/__init__.py
@@ -5,7 +5,7 @@ from .spikeinterface import (
     add_electrodes_to_nwbfile,
     add_recording_to_nwbfile,
     add_sorting_to_nwbfile,
-    add_time_series_to_nwbfile,
+    add_recording_as_time_series_to_nwbfile,
     add_units_table_to_nwbfile,
     add_sorting_analyzer_to_nwbfile,
     write_recording_to_nwbfile,

--- a/src/neuroconv/tools/spikeinterface/__init__.py
+++ b/src/neuroconv/tools/spikeinterface/__init__.py
@@ -5,6 +5,7 @@ from .spikeinterface import (
     add_electrodes_to_nwbfile,
     add_recording_to_nwbfile,
     add_sorting_to_nwbfile,
+    add_time_series_to_nwbfile,
     add_units_table_to_nwbfile,
     add_sorting_analyzer_to_nwbfile,
     write_recording_to_nwbfile,

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -699,60 +699,6 @@ def _recording_traces_to_hdmf_iterator(
     return traces_as_iterator
 
 
-def _report_variable_gain(recording: BaseRecording) -> None:
-    """
-    Helper function to report variable gains per channel IDs.
-    Groups the different available gains per channel IDs and raises a ValueError.
-    """
-    channel_gains = recording.get_channel_gains()
-    channel_ids = recording.get_channel_ids()
-
-    # Group the different gains per channel IDs
-    gain_to_channel_ids = {}
-    for gain, channel_id in zip(channel_gains, channel_ids):
-        gain = gain.item() if isinstance(gain, np.generic) else gain
-        channel_id = channel_id.item() if isinstance(channel_id, np.generic) else channel_id
-        if gain not in gain_to_channel_ids:
-            gain_to_channel_ids[gain] = []
-        gain_to_channel_ids[gain].append(channel_id)
-
-    # Create a user-friendly message
-    message_lines = ["Recording extractors with heterogeneous gains are not supported."]
-    message_lines.append("Multiple gains were found per channel IDs:")
-    for gain, ids in gain_to_channel_ids.items():
-        message_lines.append(f"  Gain {gain}: Channel IDs {ids}")
-    message = "\n".join(message_lines)
-
-    raise ValueError(message)
-
-
-def _report_variable_units(recording: BaseRecording) -> None:
-    """
-    Helper function to report variable units per channel IDs.
-    Groups the different available units per channel IDs and raises a ValueError.
-    """
-    units = recording.get_property("physical_unit")
-    channel_ids = recording.get_channel_ids()
-
-    # Group the different units per channel IDs
-    unit_to_channel_ids = {}
-    for unit, channel_id in zip(units, channel_ids):
-        unit = unit.item() if isinstance(unit, np.generic) else unit
-        channel_id = channel_id.item() if isinstance(channel_id, np.generic) else channel_id
-        if unit not in unit_to_channel_ids:
-            unit_to_channel_ids[unit] = []
-        unit_to_channel_ids[unit].append(channel_id)
-
-    # Create a user-friendly message
-    message_lines = ["Recording extractors with heterogeneous units are not supported."]
-    message_lines.append("Multiple units were found per channel IDs:")
-    for unit, ids in unit_to_channel_ids.items():
-        message_lines.append(f"  Unit '{unit}': Channel IDs {ids}")
-    message = "\n".join(message_lines)
-
-    raise ValueError(message)
-
-
 def _report_variable_offset(recording: BaseRecording) -> None:
     """
     Helper function to report variable offsets per channel IDs.

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -726,7 +726,7 @@ def _report_variable_offset(recording: BaseRecording) -> None:
     raise ValueError(message)
 
 
-def add_time_series_to_nwbfile(
+def add_recording_as_time_series_to_nwbfile(
     recording: BaseRecording,
     nwbfile: pynwb.NWBFile,
     metadata: Optional[dict] = None,
@@ -802,7 +802,7 @@ def _add_time_series_segment_to_nwbfile(
     time_series_name: str = "TimeSeries",
 ):
     """
-    See `add_time_series_to_nwbfile` for details.
+    See `add_recording_as_time_series_to_nwbfile` for details.
     """
 
     tseries_kwargs = dict(name=time_series_name)

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -856,18 +856,13 @@ def add_time_series_to_nwbfile(
         gain_to_unit = recording.get_property("gain_to_physical_unit")
         offset_to_unit = recording.get_property("offset_to_physical_unit")
 
-        all_channels_have_same_unit = len(set(units)) == 1 if units is not None else False
-        scaling_is_available = gain_to_unit is not None and offset_to_unit is not None
-        if all_channels_have_same_unit and scaling_is_available:
+        channels_have_same_unit = len(set(units)) == 1 if units is not None else False
+        channels_have_same_gain = len(set(gain_to_unit)) == 1 if gain_to_unit is not None else False
+        channels_have_same_offest = len(set(offset_to_unit)) == 1 if offset_to_unit is not None else False
 
-            unique_gains = set(gain_to_unit)
-            if len(unique_gains) > 1:
-                _report_variable_gain(recording=recording)
+        save_scaling_info = channels_have_same_unit and channels_have_same_gain and channels_have_same_offest
 
-            unique_offset = set(offset_to_unit)
-            if len(unique_offset) > 1:
-                _report_variable_offset(recording=recording)
-
+        if save_scaling_info:
             tseries_kwargs.update(unit=units[0], conversion=gain_to_unit[0], offset=offset_to_unit[0])
         else:
             warning_msg = (
@@ -877,7 +872,7 @@ def add_time_series_to_nwbfile(
                 "1) Set the unit in the metadata['TimeSeries'][time_series_name]['unit'] field, or "
                 "2) Set the `physical_unit`, `gain_to_physical_unit`, and `offset_to_physical_unit` properties "
                 "on the recording object with consistent units across all channels. "
-                f"Current units: {units if units is not None else 'None'}, "
+                f"Channel units: {units if units is not None else 'None'}, "
                 f"gain available: {gain_to_unit is not None}, "
                 f"offset available: {offset_to_unit is not None}"
             )

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -698,11 +698,14 @@ def _recording_traces_to_hdmf_iterator(
     return traces_as_iterator
 
 
-def _report_variable_offset(channel_offsets, channel_ids):
+def _report_variable_offset(recording: BaseRecording) -> None:
     """
     Helper function to report variable offsets per channel IDs.
     Groups the different available offsets per channel IDs and raises a ValueError.
     """
+    channel_offsets = recording.get_channel_offsets()
+    channel_ids = recording.get_channel_ids()
+
     # Group the different offsets per channel IDs
     offset_to_channel_ids = {}
     for offset, channel_id in zip(channel_offsets, channel_ids):
@@ -786,6 +789,15 @@ def add_electrical_series_to_nwbfile(
     whenever possible.
     """
 
+    if write_scaled:
+        warnings.warn(
+            "The 'write_scaled' parameter is deprecated and will be removed in October 2025. "
+            "The function will automatically handle channel conversion and offsets using "
+            "'gain_to_physical_unit' and 'offset_to_physical_unit' properties.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if starting_time is not None:
         warnings.warn(
             "The 'starting_time' parameter is deprecated and will be removed in June 2025. "
@@ -842,30 +854,35 @@ def add_electrical_series_to_nwbfile(
     )
     eseries_kwargs.update(electrodes=electrode_table_region)
 
-    # Spikeinterface guarantees data in micro volts when return_scaled=True. This multiplies by gain and adds offsets
-    # In nwb to get traces in Volts we take data*channel_conversion*conversion + offset
-    channel_conversion = recording.get_channel_gains()
-    channel_offsets = recording.get_channel_offsets()
+    if recording.has_scaleable_traces():
+        # Spikeinterface gains and offsets are gains and offsets to micro volts.
+        # The units of the ElectricalSeries should be volts so we scale correspondingly.
+        micro_to_volts_conversion_factor = 1e-6
+        channel_gains_to_volts = recording.get_channel_gains() * micro_to_volts_conversion_factor
+        channel_offsets_to_volts = recording.get_channel_offsets() * micro_to_volts_conversion_factor
 
-    unique_channel_conversion = np.unique(channel_conversion)
-    unique_channel_conversion = unique_channel_conversion[0] if len(unique_channel_conversion) == 1 else None
+        unique_gains = set(channel_gains_to_volts)
+        if len(unique_gains) == 1:
+            conversion_to_volts = channel_gains_to_volts[0]
+            eseries_kwargs.update(conversion=conversion_to_volts)
+        else:
+            eseries_kwargs.update(channel_conversion=channel_gains_to_volts)
 
-    unique_offset = np.unique(channel_offsets)
-    if unique_offset.size > 1:
-        channel_ids = recording.get_channel_ids()
-        # This prints a user friendly error where the user is provided with a map from offset to channels
-        _report_variable_offset(channel_offsets, channel_ids)
-    unique_offset = unique_offset[0] if unique_offset[0] is not None else 0
+        unique_offset = set(channel_offsets_to_volts)
+        if len(unique_offset) > 1:
+            channel_ids = recording.get_channel_ids()
+            # This prints a user friendly error where the user is provided with a map from offset to channels
+            _report_variable_offset(recording=recording)
 
-    micro_to_volts_conversion_factor = 1e-6
-    if not write_scaled and unique_channel_conversion is None:
-        eseries_kwargs.update(conversion=micro_to_volts_conversion_factor)
-        eseries_kwargs.update(channel_conversion=channel_conversion)
-    elif not write_scaled and unique_channel_conversion is not None:
-        eseries_kwargs.update(conversion=unique_channel_conversion * micro_to_volts_conversion_factor)
-
-    if not write_scaled:
-        eseries_kwargs.update(offset=unique_offset * micro_to_volts_conversion_factor)
+        unique_offset = channel_offsets_to_volts[0]
+        eseries_kwargs.update(offset=unique_offset)
+    else:
+        warning_message = (
+            "The recording extractor does not have gains and offsets to convert to volts. "
+            "That means that correct units are not guaranteed.  \n"
+            "Set the correct gains and offsets to the recording extractor before writing to NWB."
+        )
+        warnings.warn(warning_message, UserWarning, stacklevel=2)
 
     # Iterator
     ephys_data_iterator = _recording_traces_to_hdmf_iterator(

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -784,7 +784,6 @@ def add_time_series_to_nwbfile(
     recording: BaseRecording,
     nwbfile: pynwb.NWBFile,
     metadata: Optional[dict] = None,
-    segment_index: int = 0,
     iterator_type: Optional[str] = "v2",
     iterator_opts: Optional[dict] = None,
     always_write_timestamps: bool = False,
@@ -807,13 +806,13 @@ def add_time_series_to_nwbfile(
                 'time_series_name': {
                     'description': 'my_description',
                     'unit': 'my_unit',
+                    "offset": offset_to_unit_value,
+                    "conversion": gain_to_unit_value,
                     'comments': 'comments',
                     ...
                 }
             }
         Where the time_seires_name is used to look up metadata in the metadata dictionary.
-    segment_index : int, default: 0
-        The recording segment to add to the NWBFile.
     iterator_type: {"v2",  None}, default: 'v2'
         The type of DataChunkIterator to use.
         'v2' is the locally developed SpikeInterfaceRecordingDataChunkIterator, which offers full control over chunking.
@@ -830,6 +829,34 @@ def add_time_series_to_nwbfile(
     time_series_name : str, optional
         Name of the TimeSeries to create. If not provided, a default name will be generated based on the write_as parameter.
         This parameter is used to look up metadata in the metadata dictionary if provided.
+    """
+
+    num_segments = recording.get_num_segments()
+    for segment_index in range(num_segments):
+        _add_time_series_segment_to_nwbfile(
+            recording=recording,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            segment_index=segment_index,
+            iterator_type=iterator_type,
+            iterator_opts=iterator_opts,
+            always_write_timestamps=always_write_timestamps,
+            time_series_name=time_series_name,
+        )
+
+
+def _add_time_series_segment_to_nwbfile(
+    recording: BaseRecording,
+    nwbfile: pynwb.NWBFile,
+    metadata: Optional[dict] = None,
+    segment_index: int = 0,
+    iterator_type: Optional[str] = "v2",
+    iterator_opts: Optional[dict] = None,
+    always_write_timestamps: bool = False,
+    time_series_name: str = "TimeSeries",
+):
+    """
+    See `add_time_series_to_nwbfile` for details.
     """
 
     tseries_kwargs = dict(name=time_series_name)

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -1,6 +1,7 @@
 import uuid
 import warnings
 from collections import defaultdict
+from copy import deepcopy
 from typing import Any, Literal, Optional, Union
 
 import numpy as np
@@ -778,7 +779,8 @@ def add_time_series_to_nwbfile(
     """
 
     tseries_kwargs = dict(name=time_series_name)
-    metadata = dict() if metadata is None else metadata.copy()
+    metadata = dict() if metadata is None else metadata
+    metadata = deepcopy(metadata)
 
     # Apply metadata if available
     if "TimeSeries" in metadata and time_series_name in metadata["TimeSeries"]:
@@ -803,6 +805,8 @@ def add_time_series_to_nwbfile(
         all_channels_have_same_unit = len(set(units)) == 1 if units is not None else False
         scaling_is_available = gain_to_unit is not None and offset_to_unit is not None
         if all_channels_have_same_unit and scaling_is_available:
+
+            tseries_kwargs.update(unit=units[0])
 
             unique_gains = set(gain_to_unit)
             if len(unique_gains) == 1:

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -27,6 +27,7 @@ from neuroconv.tools.spikeinterface import (
     add_electrodes_to_nwbfile,
     add_recording_to_nwbfile,
     add_sorting_to_nwbfile,
+    add_time_series_to_nwbfile,
     add_units_table_to_nwbfile,
     check_if_recording_traces_fit_into_memory,
     write_recording_to_nwbfile,
@@ -1022,6 +1023,140 @@ class TestAddElectrodes(TestCase):
 
         assert np.array_equal(extracted_complete_property, expected_complete_property)
         assert np.array_equal(extracted_incomplete_property, expected_incomplete_property)
+
+
+class TestAddTimeSeries:
+    def test_default_values(self):
+        """Test that default values are correctly set."""
+        # Create a recording object for testing
+        num_channels = 3
+        sampling_frequency = 1.0
+        durations = [3.0]  # 3 samples in the recorder
+        recording = generate_recording(
+            sampling_frequency=sampling_frequency, num_channels=num_channels, durations=durations
+        )
+
+        # Create a fresh NWBFile for testing
+        nwbfile = mock_NWBFile()
+
+        add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
+
+        acquisition_module = nwbfile.acquisition
+        assert "TimeSeries" in acquisition_module
+        time_series = acquisition_module["TimeSeries"]
+
+        extracted_data = time_series.data[:]
+        expected_data = recording.get_traces(segment_index=0)
+        np.testing.assert_array_almost_equal(expected_data, extracted_data)
+
+    def test_metadata_priority(self):
+        """Test that metadata takes priority over recording properties."""
+        # Create a recording object for testing
+        num_channels = 3
+        sampling_frequency = 1.0
+        durations = [3.0]
+        recording = generate_recording(
+            sampling_frequency=sampling_frequency, num_channels=num_channels, durations=durations
+        )
+        values = ["recording_unit"] * num_channels
+        recording.set_property("physical_unit", values=values)
+
+        # Create a fresh NWBFile for testing
+        nwbfile = mock_NWBFile()
+
+        metadata = {
+            "TimeSeries": {
+                "TimeSeriesRaw": {"name": "TimeSeriesRaw", "description": "Custom description", "unit": "metadata_unit"}
+            }
+        }
+
+        add_time_series_to_nwbfile(
+            recording=recording,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            time_series_name="TimeSeriesRaw",
+        )
+
+        time_series = nwbfile.acquisition["TimeSeriesRaw"]
+        assert time_series.unit == "metadata_unit"
+        assert time_series.description == "Custom description"
+
+    def test_time_series_name(self):
+        """Test that time_series_name is used to look up metadata."""
+        # Create a recording object for testing
+        num_channels = 3
+        sampling_frequency = 1.0
+        durations = [3.0]
+        recording = generate_recording(
+            sampling_frequency=sampling_frequency, num_channels=num_channels, durations=durations
+        )
+
+        # Create a fresh NWBFile for testing
+        nwbfile = mock_NWBFile()
+
+        metadata = {
+            "TimeSeries": {
+                "CustomTimeSeries": {
+                    "name": "CustomTimeSeries",
+                    "description": "Custom description",
+                    "unit": "custom_unit",
+                }
+            }
+        }
+
+        add_time_series_to_nwbfile(
+            recording=recording,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            time_series_name="CustomTimeSeries",
+            iterator_type=None,
+        )
+
+        assert "CustomTimeSeries" in nwbfile.acquisition
+        time_series = nwbfile.acquisition["CustomTimeSeries"]
+        assert time_series.unit == "custom_unit"
+        assert time_series.description == "Custom description"
+
+    def test_custom_metadata_with_time_series_name(self):
+        """Test that custom metadata is applied when time_series_name is provided."""
+        # Create a recording object for testing
+        num_channels = 3
+        sampling_frequency = 1.0
+        durations = [3.0]
+        recording = generate_recording(
+            sampling_frequency=sampling_frequency, num_channels=num_channels, durations=durations
+        )
+
+        # Create a fresh NWBFile for testing
+        nwbfile = mock_NWBFile()
+
+        # Create metadata with a custom time series entry
+        metadata = {
+            "TimeSeries": {
+                "MyCustomSeries": {
+                    "name": "MyCustomSeries",
+                    "description": "Very custom description",
+                    "unit": "custom_unit",
+                    "comments": "This is a custom time series",
+                }
+            }
+        }
+
+        add_time_series_to_nwbfile(
+            recording=recording,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            time_series_name="MyCustomSeries",
+            iterator_type=None,
+        )
+
+        # Verify the custom time series was created with the correct metadata
+        assert "MyCustomSeries" in nwbfile.acquisition
+        time_series = nwbfile.acquisition["MyCustomSeries"]
+        assert time_series.name == "MyCustomSeries"
+        assert time_series.description == "Very custom description"
+        assert time_series.unit == "custom_unit"
+        assert time_series.comments == "This is a custom time series"
 
 
 class TestAddElectrodeGroups:

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -25,9 +25,9 @@ from neuroconv.tools.spikeinterface import (
     add_electrical_series_to_nwbfile,
     add_electrode_groups_to_nwbfile,
     add_electrodes_to_nwbfile,
+    add_recording_as_time_series_to_nwbfile,
     add_recording_to_nwbfile,
     add_sorting_to_nwbfile,
-    add_time_series_to_nwbfile,
     add_units_table_to_nwbfile,
     check_if_recording_traces_fit_into_memory,
     write_recording_to_nwbfile,
@@ -1039,7 +1039,7 @@ class TestAddTimeSeries:
         # Create a fresh NWBFile for testing
         nwbfile = mock_NWBFile()
 
-        add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
+        add_recording_as_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
 
         acquisition_module = nwbfile.acquisition
         assert "TimeSeries" in acquisition_module
@@ -1072,7 +1072,7 @@ class TestAddTimeSeries:
             }
         }
 
-        add_time_series_to_nwbfile(
+        add_recording_as_time_series_to_nwbfile(
             recording=recording,
             nwbfile=nwbfile,
             metadata=metadata,
@@ -1110,7 +1110,7 @@ class TestAddTimeSeries:
             }
         }
 
-        add_time_series_to_nwbfile(
+        add_recording_as_time_series_to_nwbfile(
             recording=recording,
             nwbfile=nwbfile,
             metadata=metadata,
@@ -1148,7 +1148,7 @@ class TestAddTimeSeries:
         # Create a fresh NWBFile for testing
         nwbfile = mock_NWBFile()
 
-        add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
+        add_recording_as_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
 
         # Verify the time series has the correct unit and conversion
         time_series = nwbfile.acquisition["TimeSeries"]
@@ -1178,7 +1178,7 @@ class TestAddTimeSeries:
         nwbfile = mock_NWBFile()
 
         with pytest.warns(UserWarning, match="heterogeneous units"):
-            add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
+            add_recording_as_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
 
         # Verify the time series has the default unit
         time_series = nwbfile.acquisition["TimeSeries"]
@@ -1202,7 +1202,7 @@ class TestAddTimeSeries:
         nwbfile = mock_NWBFile()
 
         with pytest.warns(UserWarning, match="lacking scaling factors"):
-            add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
+            add_recording_as_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
 
         # Verify the time series has the default unit
         time_series = nwbfile.acquisition["TimeSeries"]
@@ -1229,7 +1229,7 @@ class TestAddTimeSeries:
             }
         }
 
-        add_time_series_to_nwbfile(
+        add_recording_as_time_series_to_nwbfile(
             recording=recording,
             nwbfile=nwbfile,
             metadata=metadata,
@@ -1265,7 +1265,9 @@ class TestAddTimeSeries:
         # Create a fresh NWBFile for testing
         nwbfile = mock_NWBFile()
 
-        add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata, iterator_type=None)
+        add_recording_as_time_series_to_nwbfile(
+            recording=recording, nwbfile=nwbfile, metadata=metadata, iterator_type=None
+        )
 
         # Verify the time series has the unit from metadata
         time_series = nwbfile.acquisition["TimeSeries"]
@@ -1296,7 +1298,9 @@ class TestAddTimeSeries:
         # Create a fresh NWBFile for testing
         nwbfile = mock_NWBFile()
 
-        add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata, iterator_type=None)
+        add_recording_as_time_series_to_nwbfile(
+            recording=recording, nwbfile=nwbfile, metadata=metadata, iterator_type=None
+        )
 
         # Verify the time series has the values from metadata
         time_series = nwbfile.acquisition["TimeSeries"]

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -1049,38 +1049,6 @@ class TestAddTimeSeries:
         expected_data = recording.get_traces(segment_index=0)
         np.testing.assert_array_almost_equal(expected_data, extracted_data)
 
-    def test_metadata_priority(self):
-        """Test that metadata takes priority over recording properties."""
-        # Create a recording object for testing
-        num_channels = 3
-        sampling_frequency = 1.0
-        durations = [3.0]
-        recording = generate_recording(
-            sampling_frequency=sampling_frequency, num_channels=num_channels, durations=durations
-        )
-        values = ["recording_unit"] * num_channels
-        recording.set_property("physical_unit", values=values)
-
-        # Create a fresh NWBFile for testing
-        nwbfile = mock_NWBFile()
-
-        metadata = {
-            "TimeSeries": {
-                "TimeSeriesRaw": {"name": "TimeSeriesRaw", "description": "Custom description", "unit": "metadata_unit"}
-            }
-        }
-
-        add_time_series_to_nwbfile(
-            recording=recording,
-            nwbfile=nwbfile,
-            metadata=metadata,
-            time_series_name="TimeSeriesRaw",
-        )
-
-        time_series = nwbfile.acquisition["TimeSeriesRaw"]
-        assert time_series.unit == "metadata_unit"
-        assert time_series.description == "Custom description"
-
     def test_time_series_name(self):
         """Test that time_series_name is used to look up metadata."""
         # Create a recording object for testing
@@ -1240,6 +1208,38 @@ class TestAddTimeSeries:
         time_series = nwbfile.acquisition["TimeSeries"]
         assert time_series.unit == "n.a."
 
+    def test_metadata_priority(self):
+        """Test that metadata takes priority over recording properties."""
+        # Create a recording object for testing
+        num_channels = 3
+        sampling_frequency = 1.0
+        durations = [3.0]
+        recording = generate_recording(
+            sampling_frequency=sampling_frequency, num_channels=num_channels, durations=durations
+        )
+        values = ["recording_unit"] * num_channels
+        recording.set_property("physical_unit", values=values)
+
+        # Create a fresh NWBFile for testing
+        nwbfile = mock_NWBFile()
+
+        metadata = {
+            "TimeSeries": {
+                "TimeSeriesRaw": {"name": "TimeSeriesRaw", "description": "Custom description", "unit": "metadata_unit"}
+            }
+        }
+
+        add_time_series_to_nwbfile(
+            recording=recording,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            time_series_name="TimeSeriesRaw",
+        )
+
+        time_series = nwbfile.acquisition["TimeSeriesRaw"]
+        assert time_series.unit == "metadata_unit"
+        assert time_series.description == "Custom description"
+
     def test_metadata_unit_priority(self):
         """Test that metadata unit takes priority over recording properties."""
         # Create a recording object for testing
@@ -1270,6 +1270,39 @@ class TestAddTimeSeries:
         # Verify the time series has the unit from metadata
         time_series = nwbfile.acquisition["TimeSeries"]
         assert time_series.unit == "custom_unit"
+
+    def test_metadata_conversion_offset_priority(self):
+        """Test that metadata unit, conversion, and offset take priority over recording properties."""
+        # Create a recording object for testing
+        num_channels = 3
+        sampling_frequency = 1.0
+        durations = [3.0]
+        recording = generate_recording(
+            sampling_frequency=sampling_frequency, num_channels=num_channels, durations=durations
+        )
+
+        # Set properties with homogeneous units and scaling factors
+        units = ["mV"] * num_channels
+        gains = [2.0] * num_channels
+        offsets = [0.5] * num_channels
+
+        recording.set_property("physical_unit", units)
+        recording.set_property("gain_to_physical_unit", gains)
+        recording.set_property("offset_to_physical_unit", offsets)
+
+        # Create metadata with custom unit, conversion, and offset
+        metadata = {"TimeSeries": {"TimeSeries": {"unit": "custom_unit", "conversion": 3.0, "offset": 1.5}}}
+
+        # Create a fresh NWBFile for testing
+        nwbfile = mock_NWBFile()
+
+        add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata, iterator_type=None)
+
+        # Verify the time series has the values from metadata
+        time_series = nwbfile.acquisition["TimeSeries"]
+        assert time_series.unit == "custom_unit"
+        assert time_series.conversion == 3.0
+        assert time_series.offset == 1.5
 
 
 class TestAddElectrodeGroups:

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -1049,6 +1049,76 @@ class TestAddTimeSeries:
         expected_data = recording.get_traces(segment_index=0)
         np.testing.assert_array_almost_equal(expected_data, extracted_data)
 
+    def test_error_with_multiple_gain(self):
+        """Test that an error is raised when a recording has variable gains."""
+        # Generate a mock recording with 5 channels and 1 second duration
+        recording = generate_recording(num_channels=5, durations=[1.0])
+        # Rename channels to specific identifiers for clarity in error messages
+        recording = recording.rename_channels(new_channel_ids=["a", "b", "c", "d", "e"])
+        # Set different gains for the channels
+        recording.set_channel_gains(gains=[1, 1, 2, 2, 3])
+        recording.set_channel_offsets(offsets=[0, 0, 0, 0, 0])
+        # Set homogeneous units
+        recording.set_property("physical_unit", ["mV"] * 5)
+        recording.set_property("gain_to_physical_unit", [1, 1, 2, 2, 3])
+        recording.set_property("offset_to_physical_unit", [0, 0, 0, 0, 0])
+
+        # Create a mock NWBFile object
+        nwbfile = mock_NWBFile()
+
+        # Expected error message
+        expected_message_lines = [
+            "Recording extractors with heterogeneous gains are not supported.",
+            "Multiple gains were found per channel IDs:",
+            "  Gain 1: Channel IDs ['a', 'b']",
+            "  Gain 2: Channel IDs ['c', 'd']",
+            "  Gain 3: Channel IDs ['e']",
+        ]
+        expected_message = "\n".join(expected_message_lines)
+
+        # Use re.escape to escape any special regex characters in the expected message
+        expected_message_regex = re.escape(expected_message)
+
+        # Attempt to add time series to the NWB file
+        # Expecting a ValueError due to multiple gains, matching the expected message
+        with pytest.raises(ValueError, match=expected_message_regex):
+            add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
+
+    def test_error_with_multiple_units(self):
+        """Test that an error is raised when a recording has heterogeneous units."""
+        # Generate a mock recording with 5 channels and 1 second duration
+        recording = generate_recording(num_channels=5, durations=[1.0])
+        # Rename channels to specific identifiers for clarity in error messages
+        recording = recording.rename_channels(new_channel_ids=["a", "b", "c", "d", "e"])
+        # Set homogeneous gains and offsets
+        recording.set_channel_gains(gains=[1, 1, 1, 1, 1])
+        recording.set_channel_offsets(offsets=[0, 0, 0, 0, 0])
+        # Set different units for the channels
+        recording.set_property("physical_unit", ["mV", "mV", "V", "V", "uV"])
+        recording.set_property("gain_to_physical_unit", [1, 1, 1, 1, 1])
+        recording.set_property("offset_to_physical_unit", [0, 0, 0, 0, 0])
+
+        # Create a mock NWBFile object
+        nwbfile = mock_NWBFile()
+
+        # Expected error message
+        expected_message_lines = [
+            "Recording extractors with heterogeneous units are not supported.",
+            "Multiple units were found per channel IDs:",
+            "  Unit 'mV': Channel IDs ['a', 'b']",
+            "  Unit 'V': Channel IDs ['c', 'd']",
+            "  Unit 'uV': Channel IDs ['e']",
+        ]
+        expected_message = "\n".join(expected_message_lines)
+
+        # Use re.escape to escape any special regex characters in the expected message
+        expected_message_regex = re.escape(expected_message)
+
+        # Attempt to add time series to the NWB file
+        # Expecting a ValueError due to multiple units, matching the expected message
+        with pytest.raises(ValueError, match=expected_message_regex):
+            add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
+
     def test_metadata_priority(self):
         """Test that metadata takes priority over recording properties."""
         # Create a recording object for testing
@@ -1157,6 +1227,149 @@ class TestAddTimeSeries:
         assert time_series.description == "Very custom description"
         assert time_series.unit == "custom_unit"
         assert time_series.comments == "This is a custom time series"
+
+    def test_homogeneous_units_with_scaling(self):
+        """Test when recording has homogeneous units and scaling factors."""
+        # Create a recording object for testing
+        num_channels = 3
+        sampling_frequency = 1.0
+        durations = [3.0]
+        recording = generate_recording(
+            sampling_frequency=sampling_frequency, num_channels=num_channels, durations=durations
+        )
+
+        # Set properties with homogeneous units and scaling factors
+        units = ["mV"] * num_channels
+        gains = [2.0] * num_channels
+        offsets = [0.5] * num_channels
+
+        recording.set_property("physical_unit", units)
+        recording.set_property("gain_to_physical_unit", gains)
+        recording.set_property("offset_to_physical_unit", offsets)
+
+        # Create a fresh NWBFile for testing
+        nwbfile = mock_NWBFile()
+
+        add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
+
+        # Verify the time series has the correct unit and conversion
+        time_series = nwbfile.acquisition["TimeSeries"]
+        assert time_series.unit == "mV"
+        assert time_series.conversion == 2.0
+
+    def test_heterogeneous_units_warning(self):
+        """Test warning when recording has heterogeneous units."""
+        # Create a recording object for testing
+        num_channels = 3
+        sampling_frequency = 1.0
+        durations = [3.0]
+        recording = generate_recording(
+            sampling_frequency=sampling_frequency, num_channels=num_channels, durations=durations
+        )
+
+        # Set properties with heterogeneous units
+        units = ["mV", "V", "uV"]
+        gains = [2.0] * num_channels
+        offsets = [0.5] * num_channels
+
+        recording.set_property("physical_unit", units)
+        recording.set_property("gain_to_physical_unit", gains)
+        recording.set_property("offset_to_physical_unit", offsets)
+
+        # Create a fresh NWBFile for testing
+        nwbfile = mock_NWBFile()
+
+        with pytest.warns(UserWarning, match="heterogeneous units"):
+            add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
+
+        # Verify the time series has the default unit
+        time_series = nwbfile.acquisition["TimeSeries"]
+        assert time_series.unit == "n.a."
+
+    def test_missing_scaling_factors_warning(self):
+        """Test warning when recording is missing scaling factors."""
+        # Create a recording object for testing
+        num_channels = 3
+        sampling_frequency = 1.0
+        durations = [3.0]
+        recording = generate_recording(
+            sampling_frequency=sampling_frequency, num_channels=num_channels, durations=durations
+        )
+
+        # Set only units but no scaling factors
+        units = ["mV"] * num_channels
+        recording.set_property("physical_unit", units)
+
+        # Create a fresh NWBFile for testing
+        nwbfile = mock_NWBFile()
+
+        with pytest.warns(UserWarning, match="lacking scaling factors"):
+            add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
+
+        # Verify the time series has the default unit
+        time_series = nwbfile.acquisition["TimeSeries"]
+        assert time_series.unit == "n.a."
+
+    def test_metadata_unit_priority(self):
+        """Test that metadata unit takes priority over recording properties."""
+        # Create a recording object for testing
+        num_channels = 3
+        sampling_frequency = 1.0
+        durations = [3.0]
+        recording = generate_recording(
+            sampling_frequency=sampling_frequency, num_channels=num_channels, durations=durations
+        )
+
+        # Set properties with homogeneous units and scaling factors
+        units = ["mV"] * num_channels
+        gains = [2.0] * num_channels
+        offsets = [0.5] * num_channels
+
+        recording.set_property("physical_unit", units)
+        recording.set_property("gain_to_physical_unit", gains)
+        recording.set_property("offset_to_physical_unit", offsets)
+
+        # Create metadata with a different unit
+        metadata = {"TimeSeries": {"TimeSeries": {"unit": "custom_unit"}}}
+
+        # Create a fresh NWBFile for testing
+        nwbfile = mock_NWBFile()
+
+        add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata, iterator_type=None)
+
+        # Verify the time series has the unit from metadata
+        time_series = nwbfile.acquisition["TimeSeries"]
+        assert time_series.unit == "custom_unit"
+
+    def test_variable_gains(self):
+        """Test when recording has variable gains."""
+        # Create a recording object for testing
+        num_channels = 3
+        sampling_frequency = 1.0
+        durations = [3.0]
+        recording = generate_recording(
+            sampling_frequency=sampling_frequency, num_channels=num_channels, durations=durations
+        )
+
+        # Set properties with homogeneous units but variable gains
+        units = ["mV"] * num_channels
+        gains = [1.0, 2.0, 3.0]
+        offsets = [0.5] * num_channels
+
+        recording.set_property("physical_unit", units)
+        recording.set_property("gain_to_physical_unit", gains)
+        recording.set_property("offset_to_physical_unit", offsets)
+
+        # Create a fresh NWBFile for testing
+        nwbfile = mock_NWBFile()
+
+        add_time_series_to_nwbfile(recording=recording, nwbfile=nwbfile, iterator_type=None)
+
+        # Verify the time series has channel_conversion instead of conversion
+        time_series = nwbfile.acquisition["TimeSeries"]
+        assert time_series.unit == "mV"
+        assert hasattr(time_series, "channel_conversion")
+        np.testing.assert_array_equal(time_series.channel_conversion, gains)
 
 
 class TestAddElectrodeGroups:

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -337,50 +337,19 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
 
-        # Test conversion factor
-        conversion_factor_scalar = electrical_series.conversion
-        assert conversion_factor_scalar == 1e-6
-
         # Test offset scalar
         offset_scalar = electrical_series.offset
         assert offset_scalar == offsets[0] * 1e-6
 
         # Test channel conversion vector
         channel_conversion_vector = electrical_series.channel_conversion
-        np.testing.assert_array_almost_equal(channel_conversion_vector, gains)
+        gains_to_V = np.array(gains) * 1e-6
+        np.testing.assert_array_almost_equal(channel_conversion_vector, gains_to_V)
 
         # Test equality of data in Volts. Data in spikeextractors is in microvolts when scaled
         extracted_data = electrical_series.data[:]
-        data_in_volts = extracted_data * channel_conversion_vector * conversion_factor_scalar + offset_scalar
+        data_in_volts = extracted_data * channel_conversion_vector + offset_scalar
         traces_data_in_volts = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=True) * 1e-6
-        np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
-
-    def test_null_offsets_in_recording_extractor(self):
-        gains = self.gains_default
-        self.test_recording_extractor.set_channel_gains(gains=gains)
-
-        add_electrical_series_to_nwbfile(
-            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None
-        )
-
-        acquisition_module = self.nwbfile.acquisition
-        electrical_series = acquisition_module["ElectricalSeriesRaw"]
-
-        # Test conversion factor
-        conversion_factor_scalar = electrical_series.conversion
-        assert conversion_factor_scalar == 1e-6
-
-        # Test offset scalar
-        offset_scalar = electrical_series.offset
-        assert offset_scalar == 0
-
-        # Test equality of data in Volts. Data in spikeextractors is in microvolts when scaled
-        extracted_data = electrical_series.data[:]
-        data_in_volts = extracted_data * conversion_factor_scalar + offset_scalar
-        traces_data = self.test_recording_extractor.get_traces(segment_index=0, return_scaled=False)
-        gains = self.test_recording_extractor.get_channel_gains()
-        traces_data_in_micro_volts = traces_data * gains
-        traces_data_in_volts = traces_data_in_micro_volts * 1e-6
         np.testing.assert_array_almost_equal(data_in_volts, traces_data_in_volts)
 
     def test_variable_offsets_assertion(self):
@@ -403,6 +372,7 @@ def test_error_with_multiple_offset():
     # Rename channels to specific identifiers for clarity in error messages
     recording = recording.rename_channels(new_channel_ids=["a", "b", "c", "d", "e"])
     # Set different offsets for the channels
+    recording.set_channel_gains(gains=[1, 1, 1, 1, 1])
     recording.set_channel_offsets(offsets=[0, 0, 1, 1, 2])
 
     # Create a mock NWBFile object


### PR DESCRIPTION
As part of the ongoing effort to write all available data (i.e. not only neural) from a format in an easy way, this PR introduces the `add_time_series_to_nwbfile` function.

This function enables users to add non-neural recording data to NWB as a `TimeSeries`. It performs metadata validation and, when available, adds unit information, gains, and offsets.

This update also simplifies the process of integrating analog interfaces such as the `SpikeGLXNIDQInterface` interface, which I’ve refactored in this PR to demonstrate the new functionality.

Additional context comes from a request by @bendichter in this comment: https://github.com/catalystneuro/neuroconv/pull/1237#discussion_r1985650901

This complies with https://github.com/catalystneuro/neuroconv/issues/269 and #1280