### PR TITLE
Improve public methods to add objects from spikeinterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Deprecations and Changes
 * `write_scaled` behavior on `add_electrical_series_to_nwbfile` is deprecated and will be removed in or after October 2025 [PR #1292](https://github.com/catalystneuro/neuroconv/pull/1292)
 * `add_electrical_series_to_nwbfile` now requires both gain and offsets to write scaling factor for voltage conversion when writing to NWB [PR #1292](https://github.com/catalystneuro/neuroconv/pull/1292)
+* `add_electrical_series_to_nwbfile`, `add_units_table_to_nwbfile` and `add_electrodes_to_nwbfile` and `add_electrode_groups_to_nwbfile` are becoming private methods. Use `add_recording_to_nwbfile`, `add_sorting_to_nwbfile` and `add_recording_metadata_to_nwbfile` instead [# TBD](https://github.com/catalystneuro/neuroconv/pull/TBD)
 
 ## Bug Fixes
 

--- a/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
@@ -293,18 +293,11 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
         -----
         This function adds metadata to the `nwbfile` in-place, meaning the `nwbfile` object is modified directly.
         """
-        from ...tools.spikeinterface import (
-            add_devices_to_nwbfile,
-            add_electrode_groups_to_nwbfile,
-            add_electrodes_to_nwbfile,
-        )
+        from ...tools.spikeinterface import add_recording_metadata_to_nwbfile
 
         if hasattr(self, "generate_recording_with_channel_metadata"):
             recording = self.generate_recording_with_channel_metadata()
-
-            add_devices_to_nwbfile(nwbfile=nwbfile, metadata=metadata)
-            add_electrode_groups_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata)
-            add_electrodes_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata)
+            add_recording_metadata_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata)
 
     def add_to_nwbfile(
         self,

--- a/src/neuroconv/tools/spikeinterface/__init__.py
+++ b/src/neuroconv/tools/spikeinterface/__init__.py
@@ -2,16 +2,20 @@ from .spikeinterface import (
     add_devices_to_nwbfile,
     add_electrical_series_to_nwbfile,
     add_electrode_groups_to_nwbfile,
+    _add_electrode_groups_to_nwbfile,
     add_electrodes_to_nwbfile,
     add_recording_to_nwbfile,
     add_sorting_to_nwbfile,
     add_recording_as_time_series_to_nwbfile,
     add_units_table_to_nwbfile,
+    _add_units_table_to_nwbfile,
     add_sorting_analyzer_to_nwbfile,
     write_recording_to_nwbfile,
     write_sorting_to_nwbfile,
     write_sorting_analyzer_to_nwbfile,
     check_if_recording_traces_fit_into_memory,
+    _check_if_recording_traces_fit_into_memory,
+    add_recording_metadata_to_nwbfile,
 )
 
 from .spikeinterfacerecordingdatachunkiterator import get_electrical_series_chunk_shape

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -18,9 +18,285 @@ from ..nwb_helpers import get_module, make_or_load_nwbfile
 from ...utils import (
     DeepDict,
     calculate_regular_series_rate,
-    dict_deep_update,
 )
 from ...utils.str_utils import human_readable_size
+
+
+def add_recording_to_nwbfile(
+    recording: BaseRecording,
+    nwbfile: pynwb.NWBFile,
+    metadata: Optional[dict] = None,
+    starting_time: Optional[float] = None,
+    write_as: Literal["raw", "processed", "lfp"] = "raw",
+    es_key: Optional[str] = None,
+    write_electrical_series: bool = True,
+    write_scaled: bool = False,
+    iterator_type: str = "v2",
+    iterator_opts: Optional[dict] = None,
+    always_write_timestamps: bool = False,
+):
+    """
+    Adds traces from recording object as ElectricalSeries to an NWBFile object.
+
+    Parameters
+    ----------
+    recording : SpikeInterfaceRecording
+        A recording extractor from spikeinterface
+    nwbfile : NWBFile
+        nwb file to which the recording information is to be added
+    metadata : dict, optional
+        metadata info for constructing the nwb file.
+        Should be of the format::
+
+            metadata['Ecephys']['ElectricalSeries'] = dict(
+                name=my_name,
+                description=my_description
+            )
+    write_as : {'raw', 'processed', 'lfp'}
+        How to save the traces data in the nwb file. Options:
+        - 'raw': save it in acquisition
+        - 'processed': save it as FilteredEphys, in a processing module
+        - 'lfp': save it as LFP, in a processing module
+    es_key : str, optional
+        Key in metadata dictionary containing metadata info for the specific electrical series
+    iterator_type: {"v2",  None}, default: 'v2'
+        The type of DataChunkIterator to use.
+        'v2' is the locally developed SpikeInterfaceRecordingDataChunkIterator, which offers full control over chunking.
+        None: write the TimeSeries with no memory chunking.
+    iterator_opts: dict, optional
+        Dictionary of options for the iterator.
+        See https://hdmf.readthedocs.io/en/stable/hdmf.data_utils.html#hdmf.data_utils.GenericDataChunkIterator
+        for the full list of options.
+    always_write_timestamps : bool, default: False
+        Set to True to always write timestamps.
+        By default (False), the function checks if the timestamps are uniformly sampled, and if so, stores the data
+        using a regular sampling rate instead of explicit timestamps. If set to True, timestamps will be written
+        explicitly, regardless of whether the sampling rate is uniform.
+
+    Notes
+    -----
+    Missing keys in an element of metadata['Ecephys']['ElectrodeGroup'] will be auto-populated with defaults
+    whenever possible.
+    """
+
+    if metadata is None:
+        metadata = _get_nwb_metadata(recording=recording)
+
+    add_recording_metadata_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata)
+    # Early termination just adds the metadata
+    if not write_electrical_series:
+        warning_message = (
+            "`write_electrical_series` is deprecated and will be removed in or after October 2025."
+            "If only metadata addition is desired, use `add_recording_metadata_to_nwbfile` instead."
+        )
+
+        warnings.warn(warning_message, stacklevel=2)
+        return None
+
+    number_of_segments = recording.get_num_segments()
+    for segment_index in range(number_of_segments):
+        _add_recording_segment_to_nwbfile(
+            recording=recording,
+            nwbfile=nwbfile,
+            segment_index=segment_index,
+            starting_time=starting_time,
+            metadata=metadata,
+            write_as=write_as,
+            es_key=es_key,
+            write_scaled=write_scaled,
+            iterator_type=iterator_type,
+            iterator_opts=iterator_opts,
+            always_write_timestamps=always_write_timestamps,
+        )
+
+
+def add_electrical_series_to_nwbfile(
+    recording: BaseRecording,
+    nwbfile: pynwb.NWBFile,
+    metadata: dict = None,
+    segment_index: int = 0,
+    starting_time: Optional[float] = None,
+    write_as: Literal["raw", "processed", "lfp"] = "raw",
+    es_key: str = None,
+    write_scaled: bool = False,
+    iterator_type: Optional[str] = "v2",
+    iterator_opts: Optional[dict] = None,
+    always_write_timestamps: bool = False,
+):
+    """
+    Deprecated. Call `add_recording_to_nwbfile` instead.
+    """
+
+    _add_recording_segment_to_nwbfile(
+        recording=recording,
+        nwbfile=nwbfile,
+        segment_index=segment_index,
+        starting_time=starting_time,
+        metadata=metadata,
+        write_as=write_as,
+        es_key=es_key,
+        write_scaled=write_scaled,
+        iterator_type=iterator_type,
+        iterator_opts=iterator_opts,
+        always_write_timestamps=always_write_timestamps,
+    )
+
+
+def _add_recording_segment_to_nwbfile(
+    recording: BaseRecording,
+    nwbfile: pynwb.NWBFile,
+    metadata: dict = None,
+    segment_index: int = 0,
+    starting_time: Optional[float] = None,
+    write_as: Literal["raw", "processed", "lfp"] = "raw",
+    es_key: str = None,
+    write_scaled: bool = False,
+    iterator_type: Optional[str] = "v2",
+    iterator_opts: Optional[dict] = None,
+    always_write_timestamps: bool = False,
+):
+    """
+    See add_recordingto_nwbfile for details.
+    """
+
+    if write_scaled:
+        warnings.warn(
+            "The 'write_scaled' parameter is deprecated and will be removed in October 2025. "
+            "The function will automatically handle channel conversion and offsets using "
+            "'gain_to_physical_unit' and 'offset_to_physical_unit' properties.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    if starting_time is not None:
+        warnings.warn(
+            "The 'starting_time' parameter is deprecated and will be removed in June 2025. "
+            "Use the time alignment methods or set the recording times directlyfor modifying the starting time or timestamps "
+            "of the data if needed: "
+            "https://neuroconv.readthedocs.io/en/main/user_guide/temporal_alignment.html",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    assert write_as in [
+        "raw",
+        "processed",
+        "lfp",
+    ], f"'write_as' should be 'raw', 'processed' or 'lfp', but instead received value {write_as}"
+
+    modality_signature = write_as.upper() if write_as == "lfp" else write_as.capitalize()
+    default_name = f"ElectricalSeries{modality_signature}"
+    default_description = dict(raw="Raw acquired data", lfp="Processed data - LFP", processed="Processed data")
+
+    eseries_kwargs = dict(name=default_name, description=default_description[write_as])
+
+    # Select and/or create module if lfp or processed data is to be stored.
+    if write_as in ["lfp", "processed"]:
+        ecephys_mod = get_module(
+            nwbfile=nwbfile,
+            name="ecephys",
+            description="Intermediate data from extracellular electrophysiology recordings, e.g., LFP.",
+        )
+        if write_as == "lfp" and "LFP" not in ecephys_mod.data_interfaces:
+            ecephys_mod.add(pynwb.ecephys.LFP(name="LFP"))
+        if write_as == "processed" and "Processed" not in ecephys_mod.data_interfaces:
+            ecephys_mod.add(pynwb.ecephys.FilteredEphys(name="Processed"))
+
+    if metadata is not None and "Ecephys" in metadata and es_key is not None:
+        assert es_key in metadata["Ecephys"], f"metadata['Ecephys'] dictionary does not contain key '{es_key}'"
+        eseries_kwargs.update(metadata["Ecephys"][es_key])
+
+    # If the recording extractor has more than 1 segment, append numbers to the names so that the names are unique.
+    # 0-pad these names based on the number of segments.
+    # If there are 10 segments use 2 digits, if there are 100 segments use 3 digits, etc.
+    if recording.get_num_segments() > 1:
+        width = int(np.ceil(np.log10((recording.get_num_segments()))))
+        eseries_kwargs["name"] += f"{segment_index:0{width}}"
+
+    # The add_electrodes adds a column with channel name to the electrode table.
+    add_electrodes_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata)
+
+    # Create a region for the electrodes table
+    electrode_table_indices = _get_electrode_table_indices_for_recording(recording=recording, nwbfile=nwbfile)
+    electrode_table_region = nwbfile.create_electrode_table_region(
+        region=electrode_table_indices,
+        description="electrode_table_region",
+    )
+    eseries_kwargs.update(electrodes=electrode_table_region)
+
+    if recording.has_scaleable_traces():
+        # Spikeinterface gains and offsets are gains and offsets to micro volts.
+        # The units of the ElectricalSeries should be volts so we scale correspondingly.
+        micro_to_volts_conversion_factor = 1e-6
+        channel_gains_to_volts = recording.get_channel_gains() * micro_to_volts_conversion_factor
+        channel_offsets_to_volts = recording.get_channel_offsets() * micro_to_volts_conversion_factor
+
+        unique_gains = set(channel_gains_to_volts)
+        if len(unique_gains) == 1:
+            conversion_to_volts = channel_gains_to_volts[0]
+            eseries_kwargs.update(conversion=conversion_to_volts)
+        else:
+            eseries_kwargs.update(channel_conversion=channel_gains_to_volts)
+
+        unique_offset = set(channel_offsets_to_volts)
+        if len(unique_offset) > 1:
+            channel_ids = recording.get_channel_ids()
+            # This prints a user friendly error where the user is provided with a map from offset to channels
+            _report_variable_offset(recording=recording)
+
+        unique_offset = channel_offsets_to_volts[0]
+        eseries_kwargs.update(offset=unique_offset)
+    else:
+        warning_message = (
+            "The recording extractor does not have gains and offsets to convert to volts. "
+            "That means that correct units are not guaranteed.  \n"
+            "Set the correct gains and offsets to the recording extractor before writing to NWB."
+        )
+        warnings.warn(warning_message, UserWarning, stacklevel=2)
+
+    # Iterator
+    ephys_data_iterator = _recording_traces_to_hdmf_iterator(
+        recording=recording,
+        segment_index=segment_index,
+        iterator_type=iterator_type,
+        iterator_opts=iterator_opts,
+    )
+    eseries_kwargs.update(data=ephys_data_iterator)
+
+    starting_time = starting_time if starting_time is not None else 0
+    if always_write_timestamps:
+        timestamps = recording.get_times(segment_index=segment_index)
+        shifted_timestamps = starting_time + timestamps
+        eseries_kwargs.update(timestamps=shifted_timestamps)
+    else:
+        # By default we write the rate if the timestamps are regular
+        recording_has_timestamps = recording.has_time_vector(segment_index=segment_index)
+        if recording_has_timestamps:
+            timestamps = recording.get_times(segment_index=segment_index)
+            rate = calculate_regular_series_rate(series=timestamps)  # Returns None if it is not regular
+            recording_t_start = timestamps[0]
+        else:
+            rate = recording.get_sampling_frequency()
+            recording_t_start = recording._recording_segments[segment_index].t_start or 0
+
+        # Shift timestamps if starting_time is set
+        if rate:
+            starting_time = float(starting_time + recording_t_start)
+            # Note that we call the sampling frequency again because the estimated rate might be different from the
+            # sampling frequency of the recording extractor by some epsilon.
+            eseries_kwargs.update(starting_time=starting_time, rate=recording.get_sampling_frequency())
+        else:
+            shifted_timestamps = starting_time + timestamps
+            eseries_kwargs.update(timestamps=shifted_timestamps)
+
+    # Create ElectricalSeries object and add it to nwbfile
+    es = pynwb.ecephys.ElectricalSeries(**eseries_kwargs)
+    if write_as == "raw":
+        nwbfile.add_acquisition(es)
+    elif write_as == "processed":
+        ecephys_mod.data_interfaces["Processed"].add_electrical_series(es)
+    elif write_as == "lfp":
+        ecephys_mod.data_interfaces["LFP"].add_electrical_series(es)
 
 
 def _get_nwb_metadata(recording: BaseRecording, metadata: dict = None):
@@ -92,6 +368,15 @@ def add_devices_to_nwbfile(nwbfile: pynwb.NWBFile, metadata: Optional[DeepDict] 
 
 
 def add_electrode_groups_to_nwbfile(recording: BaseRecording, nwbfile: pynwb.NWBFile, metadata: Optional[dict] = None):
+    """
+    Deprecated. This will become a private method.
+    """
+    warnings.warn("This function is deprecated and will be removed in future versions.", DeprecationWarning)
+
+    _add_electrode_groups_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata)
+
+
+def _add_electrode_groups_to_nwbfile(recording: BaseRecording, nwbfile: pynwb.NWBFile, metadata: Optional[dict] = None):
     """
     Add electrode group information to nwbfile object.
 
@@ -511,7 +796,7 @@ def add_electrodes_to_nwbfile(
     if len(groupless_names) > 0:
         electrode_group_list = [dict(name=group_name) for group_name in groupless_names]
         missing_group_metadata = dict(Ecephys=dict(ElectrodeGroup=electrode_group_list))
-        add_electrode_groups_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=missing_group_metadata)
+        _add_electrode_groups_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=missing_group_metadata)
 
     group_list = [nwbfile.electrode_groups[group_name] for group_name in group_names]
     data_to_add["group"] = dict(description="the ElectrodeGroup object", data=group_list, index=False)
@@ -610,6 +895,19 @@ def add_electrodes_to_nwbfile(
 
 
 def check_if_recording_traces_fit_into_memory(recording: BaseRecording, segment_index: int = 0) -> None:
+    """
+    Deprecated. This function will no longer be exposed in the public API
+    """
+
+    warnings.warn(
+        "This function is deprecated and will be removed in or October 2025. "
+        "Use the 'iterator_type' argument in the add_recording_as_time_series_to_nwbfile function instead.",
+        DeprecationWarning,
+    )
+    _check_if_recording_traces_fit_into_memory(recording=recording, segment_index=segment_index)
+
+
+def _check_if_recording_traces_fit_into_memory(recording: BaseRecording, segment_index: int = 0) -> None:
     """
     Raises an error if the full traces of a recording extractor are larger than psutil.virtual_memory().available.
 
@@ -890,211 +1188,7 @@ def _add_time_series_segment_to_nwbfile(
     nwbfile.add_acquisition(time_series)
 
 
-def add_electrical_series_to_nwbfile(
-    recording: BaseRecording,
-    nwbfile: pynwb.NWBFile,
-    metadata: dict = None,
-    segment_index: int = 0,
-    starting_time: Optional[float] = None,
-    write_as: Literal["raw", "processed", "lfp"] = "raw",
-    es_key: str = None,
-    write_scaled: bool = False,
-    iterator_type: Optional[str] = "v2",
-    iterator_opts: Optional[dict] = None,
-    always_write_timestamps: bool = False,
-):
-    """
-    Adds traces from recording object as ElectricalSeries to an NWBFile object.
-
-    Parameters
-    ----------
-    recording : SpikeInterfaceRecording
-        A recording extractor from spikeinterface
-    nwbfile : NWBFile
-        nwb file to which the recording information is to be added
-    metadata : dict, optional
-        metadata info for constructing the nwb file.
-        Should be of the format::
-
-            metadata['Ecephys']['ElectricalSeries'] = dict(
-                name=my_name,
-                description=my_description
-            )
-    segment_index : int, default: 0
-        The recording segment to add to the NWBFile.
-    starting_time : float, optional
-        Sets the starting time of the ElectricalSeries to a manually set value.
-    write_as : {'raw', 'processed', 'lfp'}
-        How to save the traces data in the nwb file. Options:
-        - 'raw': save it in acquisition
-        - 'processed': save it as FilteredEphys, in a processing module
-        - 'lfp': save it as LFP, in a processing module
-    es_key : str, optional
-        Key in metadata dictionary containing metadata info for the specific electrical series
-    write_scaled : bool, default: False
-        If True, writes the traces in uV with the right conversion.
-        If False , the data is stored as it is and the right conversions factors are added to the nwbfile.
-    iterator_type: {"v2",  None}, default: 'v2'
-        The type of DataChunkIterator to use.
-        'v2' is the locally developed SpikeInterfaceRecordingDataChunkIterator, which offers full control over chunking.
-        None: write the TimeSeries with no memory chunking.
-    iterator_opts: dict, optional
-        Dictionary of options for the iterator.
-        See https://hdmf.readthedocs.io/en/stable/hdmf.data_utils.html#hdmf.data_utils.GenericDataChunkIterator
-        for the full list of options.
-    always_write_timestamps : bool, default: False
-        Set to True to always write timestamps.
-        By default (False), the function checks if the timestamps are uniformly sampled, and if so, stores the data
-        using a regular sampling rate instead of explicit timestamps. If set to True, timestamps will be written
-        explicitly, regardless of whether the sampling rate is uniform.
-
-    Notes
-    -----
-    Missing keys in an element of metadata['Ecephys']['ElectrodeGroup'] will be auto-populated with defaults
-    whenever possible.
-    """
-
-    if write_scaled:
-        warnings.warn(
-            "The 'write_scaled' parameter is deprecated and will be removed in October 2025. "
-            "The function will automatically handle channel conversion and offsets using "
-            "'gain_to_physical_unit' and 'offset_to_physical_unit' properties.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-    if starting_time is not None:
-        warnings.warn(
-            "The 'starting_time' parameter is deprecated and will be removed in June 2025. "
-            "Use the time alignment methods or set the recording times directlyfor modifying the starting time or timestamps "
-            "of the data if needed: "
-            "https://neuroconv.readthedocs.io/en/main/user_guide/temporal_alignment.html",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-    assert write_as in [
-        "raw",
-        "processed",
-        "lfp",
-    ], f"'write_as' should be 'raw', 'processed' or 'lfp', but instead received value {write_as}"
-
-    modality_signature = write_as.upper() if write_as == "lfp" else write_as.capitalize()
-    default_name = f"ElectricalSeries{modality_signature}"
-    default_description = dict(raw="Raw acquired data", lfp="Processed data - LFP", processed="Processed data")
-
-    eseries_kwargs = dict(name=default_name, description=default_description[write_as])
-
-    # Select and/or create module if lfp or processed data is to be stored.
-    if write_as in ["lfp", "processed"]:
-        ecephys_mod = get_module(
-            nwbfile=nwbfile,
-            name="ecephys",
-            description="Intermediate data from extracellular electrophysiology recordings, e.g., LFP.",
-        )
-        if write_as == "lfp" and "LFP" not in ecephys_mod.data_interfaces:
-            ecephys_mod.add(pynwb.ecephys.LFP(name="LFP"))
-        if write_as == "processed" and "Processed" not in ecephys_mod.data_interfaces:
-            ecephys_mod.add(pynwb.ecephys.FilteredEphys(name="Processed"))
-
-    if metadata is not None and "Ecephys" in metadata and es_key is not None:
-        assert es_key in metadata["Ecephys"], f"metadata['Ecephys'] dictionary does not contain key '{es_key}'"
-        eseries_kwargs.update(metadata["Ecephys"][es_key])
-
-    # If the recording extractor has more than 1 segment, append numbers to the names so that the names are unique.
-    # 0-pad these names based on the number of segments.
-    # If there are 10 segments use 2 digits, if there are 100 segments use 3 digits, etc.
-    if recording.get_num_segments() > 1:
-        width = int(np.ceil(np.log10((recording.get_num_segments()))))
-        eseries_kwargs["name"] += f"{segment_index:0{width}}"
-
-    # The add_electrodes adds a column with channel name to the electrode table.
-    add_electrodes_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata)
-
-    # Create a region for the electrodes table
-    electrode_table_indices = _get_electrode_table_indices_for_recording(recording=recording, nwbfile=nwbfile)
-    electrode_table_region = nwbfile.create_electrode_table_region(
-        region=electrode_table_indices,
-        description="electrode_table_region",
-    )
-    eseries_kwargs.update(electrodes=electrode_table_region)
-
-    if recording.has_scaleable_traces():
-        # Spikeinterface gains and offsets are gains and offsets to micro volts.
-        # The units of the ElectricalSeries should be volts so we scale correspondingly.
-        micro_to_volts_conversion_factor = 1e-6
-        channel_gains_to_volts = recording.get_channel_gains() * micro_to_volts_conversion_factor
-        channel_offsets_to_volts = recording.get_channel_offsets() * micro_to_volts_conversion_factor
-
-        unique_gains = set(channel_gains_to_volts)
-        if len(unique_gains) == 1:
-            conversion_to_volts = channel_gains_to_volts[0]
-            eseries_kwargs.update(conversion=conversion_to_volts)
-        else:
-            eseries_kwargs.update(channel_conversion=channel_gains_to_volts)
-
-        unique_offset = set(channel_offsets_to_volts)
-        if len(unique_offset) > 1:
-            channel_ids = recording.get_channel_ids()
-            # This prints a user friendly error where the user is provided with a map from offset to channels
-            _report_variable_offset(recording=recording)
-
-        unique_offset = channel_offsets_to_volts[0]
-        eseries_kwargs.update(offset=unique_offset)
-    else:
-        warning_message = (
-            "The recording extractor does not have gains and offsets to convert to volts. "
-            "That means that correct units are not guaranteed.  \n"
-            "Set the correct gains and offsets to the recording extractor before writing to NWB."
-        )
-        warnings.warn(warning_message, UserWarning, stacklevel=2)
-
-    # Iterator
-    ephys_data_iterator = _recording_traces_to_hdmf_iterator(
-        recording=recording,
-        segment_index=segment_index,
-        iterator_type=iterator_type,
-        iterator_opts=iterator_opts,
-    )
-    eseries_kwargs.update(data=ephys_data_iterator)
-
-    starting_time = starting_time if starting_time is not None else 0
-    if always_write_timestamps:
-        timestamps = recording.get_times(segment_index=segment_index)
-        shifted_timestamps = starting_time + timestamps
-        eseries_kwargs.update(timestamps=shifted_timestamps)
-    else:
-        # By default we write the rate if the timestamps are regular
-        recording_has_timestamps = recording.has_time_vector(segment_index=segment_index)
-        if recording_has_timestamps:
-            timestamps = recording.get_times(segment_index=segment_index)
-            rate = calculate_regular_series_rate(series=timestamps)  # Returns None if it is not regular
-            recording_t_start = timestamps[0]
-        else:
-            rate = recording.get_sampling_frequency()
-            recording_t_start = recording._recording_segments[segment_index].t_start or 0
-
-        # Shift timestamps if starting_time is set
-        if rate:
-            starting_time = float(starting_time + recording_t_start)
-            # Note that we call the sampling frequency again because the estimated rate might be different from the
-            # sampling frequency of the recording extractor by some epsilon.
-            eseries_kwargs.update(starting_time=starting_time, rate=recording.get_sampling_frequency())
-        else:
-            shifted_timestamps = starting_time + timestamps
-            eseries_kwargs.update(timestamps=shifted_timestamps)
-
-    # Create ElectricalSeries object and add it to nwbfile
-    es = pynwb.ecephys.ElectricalSeries(**eseries_kwargs)
-    if write_as == "raw":
-        nwbfile.add_acquisition(es)
-    elif write_as == "processed":
-        ecephys_mod.data_interfaces["Processed"].add_electrical_series(es)
-    elif write_as == "lfp":
-        ecephys_mod.data_interfaces["LFP"].add_electrical_series(es)
-
-
-def add_electrodes_info_to_nwbfile(recording: BaseRecording, nwbfile: pynwb.NWBFile, metadata: dict = None):
+def add_recording_metadata_to_nwbfile(recording: BaseRecording, nwbfile: pynwb.NWBFile, metadata: dict = None):
     """
     Add device, electrode_groups, and electrodes info to the nwbfile.
 
@@ -1128,103 +1222,20 @@ def add_electrodes_info_to_nwbfile(recording: BaseRecording, nwbfile: pynwb.NWBF
         possibly including the default, will occur.
     """
     add_devices_to_nwbfile(nwbfile=nwbfile, metadata=metadata)
-    add_electrode_groups_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata)
+    _add_electrode_groups_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata)
     add_electrodes_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata)
 
 
-def add_recording_to_nwbfile(
-    recording: BaseRecording,
-    nwbfile: pynwb.NWBFile,
-    metadata: Optional[dict] = None,
-    starting_time: Optional[float] = None,
-    write_as: Literal["raw", "processed", "lfp"] = "raw",
-    es_key: Optional[str] = None,
-    write_electrical_series: bool = True,
-    write_scaled: bool = False,
-    iterator_type: str = "v2",
-    iterator_opts: Optional[dict] = None,
-    always_write_timestamps: bool = False,
-):
+def add_electrodes_info_to_nwbfile(recording: BaseRecording, nwbfile: pynwb.NWBFile, metadata: dict = None):
     """
-    Add traces from a recording object as an ElectricalSeries to an NWBFile object.
-    Also adds device, electrode_groups, and electrodes to the NWBFile.
-
-    Parameters
-    ----------
-    recording : BaseRecording
-        A recording extractor from SpikeInterface.
-    nwbfile : pynwb.NWBFile
-        The NWBFile object to which the recording information is to be added.
-    metadata : dict, optional
-        Metadata information for constructing the NWBFile. This should include:
-
-        - metadata['Ecephys']['ElectricalSeries'] : dict
-            Dictionary with metadata for the ElectricalSeries, such as:
-
-            - name : str
-                Name of the ElectricalSeries.
-            - description : str
-                Description of the ElectricalSeries.
-    starting_time : float, optional
-        Manually set the starting time of the ElectricalSeries. If not provided,
-        the starting time is taken from the recording extractor.
-    write_as : {'raw', 'processed', 'lfp'}, default='raw'
-        Specifies how to save the trace data in the NWB file. Options are:
-        - 'raw': Save the data in the acquisition group.
-        - 'processed': Save the data as FilteredEphys in a processing module.
-        - 'lfp': Save the data as LFP in a processing module.
-    es_key : str, optional
-        Key in the metadata dictionary containing metadata information for the specific ElectricalSeries.
-    write_electrical_series : bool, default=True
-        If True, writes the ElectricalSeries to the NWBFile. If False, no ElectricalSeries is written.
-    write_scaled : bool, default=False
-        If True, writes the traces in microvolts (uV) with the appropriate conversion.
-        If False, the data is stored as-is, and the correct conversion factors are added to the NWBFile.
-    iterator_type : {'v2', None}, default='v2'
-        The type of DataChunkIterator to use when writing data in chunks. Options are:
-
-        - 'v2': The SpikeInterfaceRecordingDataChunkIterator, which offers full control over chunking.
-        - None: Write the TimeSeries with no memory chunking.
-    iterator_opts : dict, optional
-        Dictionary of options for the iterator. Refer to the documentation at
-        https://hdmf.readthedocs.io/en/stable/hdmf.data_utils.html#hdmf.data_utils.GenericDataChunkIterator
-        for a full list of available options.
-    always_write_timestamps : bool, default: False
-        Set to True to always write timestamps.
-        By default (False), the function checks if the timestamps are uniformly sampled, and if so, stores the data
-        using a regular sampling rate instead of explicit timestamps. If set to True, timestamps will be written
-        explicitly, regardless of whether the sampling rate is uniform.
-
-    Notes
-    -----
-    Missing keys in an element of `metadata['Ecephys']['ElectrodeGroup']` will be auto-populated with defaults
-    whenever possible. Ensure that the provided metadata dictionary is correctly structured to avoid
-    unintended behavior.
+    Dreprecated use `add_recording_metadata_to_nwbfile` instead.
     """
-
-    if hasattr(recording, "nwb_metadata"):
-        metadata = dict_deep_update(recording.nwb_metadata, metadata)
-    elif metadata is None:
-        metadata = _get_nwb_metadata(recording=recording)
-
-    add_electrodes_info_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata)
-
-    if write_electrical_series:
-        number_of_segments = recording.get_num_segments()
-        for segment_index in range(number_of_segments):
-            add_electrical_series_to_nwbfile(
-                recording=recording,
-                nwbfile=nwbfile,
-                segment_index=segment_index,
-                starting_time=starting_time,
-                metadata=metadata,
-                write_as=write_as,
-                es_key=es_key,
-                write_scaled=write_scaled,
-                iterator_type=iterator_type,
-                iterator_opts=iterator_opts,
-                always_write_timestamps=always_write_timestamps,
-            )
+    warnings.warn(
+        "This function is deprecated and will be removed in or October 2025. "
+        "Use the 'add_recording_metadata_to_nwbfile' function instead.",
+        DeprecationWarning,
+    )
+    add_recording_metadata_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=metadata)
 
 
 def write_recording_to_nwbfile(
@@ -1358,6 +1369,45 @@ def write_recording_to_nwbfile(
 
 
 def add_units_table_to_nwbfile(
+    sorting: BaseSorting,
+    nwbfile: pynwb.NWBFile,
+    unit_ids: Optional[list[Union[str, int]]] = None,
+    property_descriptions: Optional[dict] = None,
+    skip_properties: Optional[list[str]] = None,
+    units_table_name: str = "units",
+    unit_table_description: Optional[str] = None,
+    write_in_processing_module: bool = False,
+    waveform_means: Optional[np.ndarray] = None,
+    waveform_sds: Optional[np.ndarray] = None,
+    unit_electrode_indices: Optional[list[list[int]]] = None,
+    null_values_for_properties: Optional[dict] = None,
+):
+    """
+    add unist table will become a private method, use `add_sorting_to_nwbfile` instead.
+    """
+
+    warnings.warn(
+        "This function is deprecated and will be removed in or after October 2025. "
+        "Use the 'add_sorting_to_nwbfile' function instead.",
+        DeprecationWarning,
+    )
+    _add_units_table_to_nwbfile(
+        sorting=sorting,
+        nwbfile=nwbfile,
+        unit_ids=unit_ids,
+        property_descriptions=property_descriptions,
+        skip_properties=skip_properties,
+        units_table_name=units_table_name,
+        unit_table_description=unit_table_description,
+        write_in_processing_module=write_in_processing_module,
+        waveform_means=waveform_means,
+        waveform_sds=waveform_sds,
+        unit_electrode_indices=unit_electrode_indices,
+        null_values_for_properties=null_values_for_properties,
+    )
+
+
+def _add_units_table_to_nwbfile(
     sorting: BaseSorting,
     nwbfile: pynwb.NWBFile,
     unit_ids: Optional[list[Union[str, int]]] = None,
@@ -1637,6 +1687,7 @@ def add_sorting_to_nwbfile(
     waveform_means: Optional[np.ndarray] = None,
     waveform_sds: Optional[np.ndarray] = None,
     unit_electrode_indices: Optional[list[list[int]]] = None,
+    null_values_for_properties: Optional[dict] = None,
 ):
     """Add sorting data (units and their properties) to an NWBFile.
 
@@ -1680,7 +1731,7 @@ def add_sorting_to_nwbfile(
     ], f"Argument write_as ({write_as}) should be one of 'units' or 'processing'!"
     write_in_processing_module = False if write_as == "units" else True
 
-    add_units_table_to_nwbfile(
+    _add_units_table_to_nwbfile(
         sorting=sorting,
         unit_ids=unit_ids,
         nwbfile=nwbfile,
@@ -1692,6 +1743,7 @@ def add_sorting_to_nwbfile(
         waveform_means=waveform_means,
         waveform_sds=waveform_sds,
         unit_electrode_indices=unit_electrode_indices,
+        null_values_for_properties=null_values_for_properties,
     )
 
 
@@ -1871,11 +1923,11 @@ def add_sorting_analyzer_to_nwbfile(
             if prop not in sorting_copy.get_property_keys():
                 sorting_copy.set_property(prop, tm[prop])
 
-    add_electrodes_info_to_nwbfile(recording, nwbfile=nwbfile, metadata=metadata)
+    add_recording_metadata_to_nwbfile(recording, nwbfile=nwbfile, metadata=metadata)
     electrode_group_indices = _get_electrode_group_indices(recording, nwbfile=nwbfile)
     unit_electrode_indices = [electrode_group_indices] * len(sorting.unit_ids)
 
-    add_units_table_to_nwbfile(
+    _add_units_table_to_nwbfile(
         sorting=sorting_copy,
         nwbfile=nwbfile,
         unit_ids=unit_ids,
@@ -1978,7 +2030,7 @@ def write_sorting_analyzer_to_nwbfile(
 
         if write_electrical_series:
             add_electrical_series_kwargs = add_electrical_series_kwargs or dict()
-            add_electrical_series_to_nwbfile(
+            add_recording_to_nwbfile(
                 recording=recording, nwbfile=nwbfile_out, metadata=metadata, **add_electrical_series_kwargs
             )
 

--- a/tests/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_ecephys/test_tools_spikeinterface.py
@@ -22,14 +22,12 @@ from spikeinterface.extractors import NumpyRecording
 
 from neuroconv.tools.nwb_helpers import get_module
 from neuroconv.tools.spikeinterface import (
-    add_electrical_series_to_nwbfile,
-    add_electrode_groups_to_nwbfile,
+    _add_electrode_groups_to_nwbfile,
+    _check_if_recording_traces_fit_into_memory,
     add_electrodes_to_nwbfile,
     add_recording_as_time_series_to_nwbfile,
     add_recording_to_nwbfile,
     add_sorting_to_nwbfile,
-    add_units_table_to_nwbfile,
-    check_if_recording_traces_fit_into_memory,
     write_recording_to_nwbfile,
     write_sorting_analyzer_to_nwbfile,
 )
@@ -58,9 +56,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         )
 
     def test_default_values(self):
-        add_electrical_series_to_nwbfile(
-            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None
-        )
+        add_recording_to_nwbfile(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         assert "ElectricalSeriesRaw" in acquisition_module
@@ -72,7 +68,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
 
     def test_write_as_lfp(self):
         write_as = "lfp"
-        add_electrical_series_to_nwbfile(
+        add_recording_to_nwbfile(
             recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None, write_as=write_as
         )
 
@@ -93,7 +89,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
 
     def test_write_as_processing(self):
         write_as = "processed"
-        add_electrical_series_to_nwbfile(
+        add_recording_to_nwbfile(
             recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None, write_as=write_as
         )
 
@@ -119,7 +115,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
                 ElectricalSeriesLFP=dict(name="ElectricalSeriesLFP", description="lfp series"),
             )
         )
-        add_electrical_series_to_nwbfile(
+        add_recording_to_nwbfile(
             recording=self.test_recording_extractor,
             nwbfile=self.nwbfile,
             metadata=metadata,
@@ -129,7 +125,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         self.assertEqual(len(self.nwbfile.electrodes), len(self.test_recording_extractor.channel_ids))
         self.assertIn("ElectricalSeriesRaw", self.nwbfile.acquisition)
 
-        add_electrical_series_to_nwbfile(
+        add_recording_to_nwbfile(
             recording=self.test_recording_extractor,
             nwbfile=self.nwbfile,
             metadata=metadata,
@@ -149,7 +145,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         )
         original_groups = self.test_recording_extractor.get_channel_groups()
         self.test_recording_extractor.set_channel_groups(["group0"] * len(self.test_recording_extractor.channel_ids))
-        add_electrical_series_to_nwbfile(
+        add_recording_to_nwbfile(
             recording=self.test_recording_extractor,
             nwbfile=self.nwbfile,
             metadata=metadata,
@@ -166,7 +162,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         )
         # set new channel groups to create a new  electrode_group
         self.test_recording_extractor.set_channel_groups(["group1"] * len(self.test_recording_extractor.channel_ids))
-        add_electrical_series_to_nwbfile(
+        add_recording_to_nwbfile(
             recording=self.test_recording_extractor,
             nwbfile=self.nwbfile,
             metadata=metadata,
@@ -191,7 +187,7 @@ class TestAddElectricalSeriesWriting(unittest.TestCase):
         reg_expression = f"'write_as' should be 'raw', 'processed' or 'lfp', but instead received value {write_as}"
 
         with self.assertRaisesRegex(AssertionError, reg_expression):
-            add_electrical_series_to_nwbfile(
+            add_recording_to_nwbfile(
                 recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None, write_as=write_as
             )
 
@@ -214,9 +210,7 @@ class TestAddElectricalSeriesSavingTimestampsVsRates(unittest.TestCase):
         )
 
     def test_uniform_timestamps(self):
-        add_electrical_series_to_nwbfile(
-            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None
-        )
+        add_recording_to_nwbfile(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -229,9 +223,7 @@ class TestAddElectricalSeriesSavingTimestampsVsRates(unittest.TestCase):
     def test_non_uniform_timestamps(self):
         expected_timestamps = np.array([0.0, 2.0, 10.0])
         self.test_recording_extractor.set_times(times=expected_timestamps, with_warning=False)
-        add_electrical_series_to_nwbfile(
-            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None
-        )
+        add_recording_to_nwbfile(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -277,9 +269,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         self.test_recording_extractor.set_channel_gains(gains=gains)
         self.test_recording_extractor.set_channel_offsets(offsets=offsets)
 
-        add_electrical_series_to_nwbfile(
-            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None
-        )
+        add_recording_to_nwbfile(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -304,9 +294,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         self.test_recording_extractor.set_channel_gains(gains=gains)
         self.test_recording_extractor.set_channel_offsets(offsets=offsets)
 
-        add_electrical_series_to_nwbfile(
-            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None
-        )
+        add_recording_to_nwbfile(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -331,9 +319,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         self.test_recording_extractor.set_channel_gains(gains=gains)
         self.test_recording_extractor.set_channel_offsets(offsets=offsets)
 
-        add_electrical_series_to_nwbfile(
-            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None
-        )
+        add_recording_to_nwbfile(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -362,9 +348,7 @@ class TestAddElectricalSeriesVoltsScaling(unittest.TestCase):
         reg_expression = "Recording extractors with heterogeneous offsets are not supported"
 
         with self.assertRaisesRegex(ValueError, reg_expression):
-            add_electrical_series_to_nwbfile(
-                recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None
-            )
+            add_recording_to_nwbfile(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
 
 def test_error_with_multiple_offset():
@@ -395,7 +379,7 @@ def test_error_with_multiple_offset():
     # Attempt to add electrical series to the NWB file
     # Expecting a ValueError due to multiple offsets, matching the expected message
     with pytest.raises(ValueError, match=expected_message_regex):
-        add_electrical_series_to_nwbfile(recording=recording, nwbfile=nwbfile)
+        add_recording_to_nwbfile(recording=recording, nwbfile=nwbfile)
 
 
 class TestAddElectricalSeriesChunking(unittest.TestCase):
@@ -427,7 +411,7 @@ class TestAddElectricalSeriesChunking(unittest.TestCase):
         )
 
     def test_default_iterative_writer(self):
-        add_electrical_series_to_nwbfile(recording=self.test_recording_extractor, nwbfile=self.nwbfile)
+        add_recording_to_nwbfile(recording=self.test_recording_extractor, nwbfile=self.nwbfile)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -441,7 +425,7 @@ class TestAddElectricalSeriesChunking(unittest.TestCase):
 
     def test_iterator_opts_propagation(self):
         iterator_opts = dict(chunk_shape=(10, 3))
-        add_electrical_series_to_nwbfile(
+        add_recording_to_nwbfile(
             recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_opts=iterator_opts
         )
 
@@ -452,9 +436,7 @@ class TestAddElectricalSeriesChunking(unittest.TestCase):
         assert electrical_series_data_iterator.chunk_shape == iterator_opts["chunk_shape"]
 
     def test_non_iterative_write(self):
-        add_electrical_series_to_nwbfile(
-            recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None
-        )
+        add_recording_to_nwbfile(recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=None)
 
         acquisition_module = self.nwbfile.acquisition
         electrical_series = acquisition_module["ElectricalSeriesRaw"]
@@ -480,14 +462,14 @@ class TestAddElectricalSeriesChunking(unittest.TestCase):
         reg_expression = "Memory error, full electrical series is (.*?) GiB are available. Use iterator_type='V2'"
 
         with self.assertRaisesRegex(MemoryError, reg_expression):
-            check_if_recording_traces_fit_into_memory(recording=mock_recorder)
+            _check_if_recording_traces_fit_into_memory(recording=mock_recorder)
 
     def test_invalid_iterator_type_assertion(self):
         iterator_type = "invalid_iterator_type"
 
         reg_expression = "iterator_type (.*?)"
         with self.assertRaisesRegex(ValueError, reg_expression):
-            add_electrical_series_to_nwbfile(
+            add_recording_to_nwbfile(
                 recording=self.test_recording_extractor, nwbfile=self.nwbfile, iterator_type=iterator_type
             )
 
@@ -1317,7 +1299,7 @@ class TestAddElectrodeGroups:
 
         nwbfile = mock_NWBFile()
         with pytest.raises(ValueError, match="The number of group names must match the number of groups"):
-            add_electrode_groups_to_nwbfile(nwbfile=nwbfile, recording=recording)
+            _add_electrode_groups_to_nwbfile(nwbfile=nwbfile, recording=recording)
 
     def test_inconsistent_group_name_mapping(self):
         recording = generate_recording(num_channels=3)
@@ -1329,7 +1311,7 @@ class TestAddElectrodeGroups:
 
         nwbfile = mock_NWBFile()
         with pytest.raises(ValueError, match="Inconsistent mapping between group numbers and group names"):
-            add_electrode_groups_to_nwbfile(nwbfile=nwbfile, recording=recording)
+            _add_electrode_groups_to_nwbfile(nwbfile=nwbfile, recording=recording)
 
 
 class TestAddUnitsTable(TestCase):
@@ -1355,25 +1337,25 @@ class TestAddUnitsTable(TestCase):
 
     def test_integer_unit_names(self):
         """Ensure add units_table gets the right units name for integer units ids."""
-        add_units_table_to_nwbfile(sorting=self.base_sorting, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.base_sorting, nwbfile=self.nwbfile)
 
         expected_unit_names_in_units_table = ["0", "1", "2", "3"]
         unit_names_in_units_table = list(self.nwbfile.units["unit_name"].data)
         self.assertListEqual(unit_names_in_units_table, expected_unit_names_in_units_table)
 
     def test_string_unit_names(self):
-        """Ensure add_units_table_to_nwbfile gets the right units name for string units ids"""
-        add_units_table_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
+        """Ensure add_sorting_to_nwbfile gets the right units name for string units ids"""
+        add_sorting_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
 
         expected_unit_names_in_units_table = ["a", "b", "c", "d"]
         unit_names_in_units_table = list(self.nwbfile.units["unit_name"].data)
         self.assertListEqual(unit_names_in_units_table, expected_unit_names_in_units_table)
 
     def test_non_overwriting_unit_names_sorting_property(self):
-        "add_units_table_to_nwbfile function should not overwrite the sorting object unit_name property"
+        "add_sorting_to_nwbfile function should not overwrite the sorting object unit_name property"
         unit_names = ["name a", "name b", "name c", "name d"]
         self.sorting_1.set_property(key="unit_name", values=unit_names)
-        add_units_table_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
 
         expected_unit_names_in_units_table = unit_names
         unit_names_in_units_table = list(self.nwbfile.units["unit_name"].data)
@@ -1385,8 +1367,8 @@ class TestAddUnitsTable(TestCase):
         offset_unit_ids = [int(unit_id) + 2 for unit_id in unit_ids]
         sorting_with_offset_unit_ids = self.base_sorting.rename_units(new_unit_ids=offset_unit_ids)
 
-        add_units_table_to_nwbfile(sorting=self.base_sorting, nwbfile=self.nwbfile)
-        add_units_table_to_nwbfile(sorting=sorting_with_offset_unit_ids, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.base_sorting, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=sorting_with_offset_unit_ids, nwbfile=self.nwbfile)
 
         expected_unit_names_in_units_table = ["0", "1", "2", "3", "4", "5"]
         unit_names_in_units_table = list(self.nwbfile.units["unit_name"].data)
@@ -1394,8 +1376,8 @@ class TestAddUnitsTable(TestCase):
 
     def test_string_unit_names_overwrite(self):
         """Ensure unit names merge correctly after appending when channel names are strings."""
-        add_units_table_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
-        add_units_table_to_nwbfile(sorting=self.sorting_2, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.sorting_2, nwbfile=self.nwbfile)
 
         expected_unit_names_in_units_table = ["a", "b", "c", "d", "e", "f"]
         unit_names_in_units_table = list(self.nwbfile.units["unit_name"].data)
@@ -1406,8 +1388,8 @@ class TestAddUnitsTable(TestCase):
         self.sorting_1.set_property(key="common_property", values=["value_1"] * self.num_units)
         self.sorting_2.set_property(key="common_property", values=["value_2"] * self.num_units)
 
-        add_units_table_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
-        add_units_table_to_nwbfile(sorting=self.sorting_2, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.sorting_2, nwbfile=self.nwbfile)
 
         properties_in_units_table = list(self.nwbfile.units["common_property"].data)
         expected_properties_in_units_table = ["value_1", "value_1", "value_1", "value_1", "value_2", "value_2"]
@@ -1417,15 +1399,15 @@ class TestAddUnitsTable(TestCase):
         """Add a property only available in a second sorting."""
         self.sorting_2.set_property(key="added_property", values=["added_value"] * self.num_units)
 
-        add_units_table_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
-        add_units_table_to_nwbfile(sorting=self.sorting_2, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.sorting_2, nwbfile=self.nwbfile)
 
         properties_in_units_table = list(self.nwbfile.units["added_property"].data)
         expected_properties_in_units_table = ["", "", "added_value", "added_value", "added_value", "added_value"]
         self.assertListEqual(properties_in_units_table, expected_properties_in_units_table)
 
     def test_units_table_extension_after_manual_unit_addition(self):
-        """Add some rows to the units tables before using the add_units_table_to_nwbfile function"""
+        """Add some rows to the units tables before using the add_sorting_to_nwbfile function"""
         values_dic = self.defaults
 
         values_dic.update(id=123, spike_times=[0, 1, 2])
@@ -1434,17 +1416,17 @@ class TestAddUnitsTable(TestCase):
         values_dic.update(id=124, spike_times=[2, 3, 4])
         self.nwbfile.add_unit(**values_dic)
 
-        add_units_table_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
 
         expected_units_ids = [123, 124, 2, 3, 4, 5]
         expected_unit_names = ["123", "124", "a", "b", "c", "d"]
         self.assertListEqual(list(self.nwbfile.units.id.data), expected_units_ids)
         self.assertListEqual(list(self.nwbfile.units["unit_name"].data), expected_unit_names)
 
-    def test_manual_extension_after_add_units_table_to_nwbfile(self):
-        """Add some units to the units table after using the add_units_table_to_nwbfile function"""
+    def test_manual_extension_after_add_sorting_to_nwbfile(self):
+        """Add some units to the units table after using the add_sorting_to_nwbfile function"""
 
-        add_units_table_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
 
         values_dic = self.defaults
 
@@ -1465,7 +1447,7 @@ class TestAddUnitsTable(TestCase):
 
     def test_property_matching_by_unit_name_with_existing_property(self):
         """
-        Add some units to the units tables before using the add_units_table_to_nwbfile function.
+        Add some units to the units tables before using the add_sorting_to_nwbfile function.
         Previous properties that are also available in the sorting are matched with unit_name
         """
 
@@ -1486,7 +1468,7 @@ class TestAddUnitsTable(TestCase):
         property_values = ["value_a", "value_b", "x", "y"]
         self.sorting_1.set_property(key="property", values=property_values)
 
-        add_units_table_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
 
         # Properties correspond with unit names, ids are filled positionally
         expected_units_ids = [20, 21, 22, 3, 4]
@@ -1499,13 +1481,13 @@ class TestAddUnitsTable(TestCase):
 
     def test_add_existing_units(self):
         # test that additional units are not added if already in the nwbfile.units table
-        add_units_table_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
-        add_units_table_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
         self.assertEqual(len(self.nwbfile.units), len(self.sorting_1.unit_ids))
 
     def test_property_matching_by_unit_name_with_new_property(self):
         """
-        Add some units to the units tables before using the add_units_table_to_nwbfile function.
+        Add some units to the units tables before using the add_sorting_to_nwbfile function.
         New properties in the sorter are matched by unit name
         """
 
@@ -1525,7 +1507,7 @@ class TestAddUnitsTable(TestCase):
         property_values = ["value_a", "value_b", "value_c", "value_d"]
         self.sorting_1.set_property(key="property", values=property_values)
 
-        add_units_table_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=self.sorting_1, nwbfile=self.nwbfile)
 
         # Properties correspond with unit names, ids are filled positionally
         expected_units_ids = [20, 21, 22, 3, 4]
@@ -1541,18 +1523,18 @@ class TestAddUnitsTable(TestCase):
 
         units_table_name = "testing_processing"
         unit_table_description = "testing_description"
-        add_units_table_to_nwbfile(
+        add_sorting_to_nwbfile(
             sorting=self.base_sorting,
             nwbfile=self.nwbfile,
-            units_table_name=units_table_name,
-            unit_table_description=unit_table_description,
-            write_in_processing_module=True,
+            units_name=units_table_name,
+            units_description=unit_table_description,
+            write_as="processing",
         )
 
         ecephys_mod = get_module(
             nwbfile=self.nwbfile,
             name="ecephys",
-            description="Intermediate data from extracellular electrophysiology recordings, e.g., LFP.",
+            description="Intermed`iate data from extracellular electrophysiology recordings, e.g., LFP.",
         )
         self.assertIn(units_table_name, ecephys_mod.data_interfaces)
         units_table = ecephys_mod[units_table_name]
@@ -1562,7 +1544,7 @@ class TestAddUnitsTable(TestCase):
     def test_write_subset_units(self):
         """ """
         subset_unit_ids = self.base_sorting.unit_ids[::2]
-        add_units_table_to_nwbfile(
+        add_sorting_to_nwbfile(
             sorting=self.base_sorting,
             nwbfile=self.nwbfile,
             unit_ids=subset_unit_ids,
@@ -1576,7 +1558,7 @@ class TestAddUnitsTable(TestCase):
         bool_property = np.array([False] * len(self.base_sorting.unit_ids))
         bool_property[::2] = True
         self.base_sorting.set_property("test_bool", bool_property)
-        add_units_table_to_nwbfile(
+        add_sorting_to_nwbfile(
             sorting=self.base_sorting,
             nwbfile=self.nwbfile,
         )
@@ -1592,7 +1574,7 @@ class TestAddUnitsTable(TestCase):
 
         ragged_array_values1 = [[1, 2], [3, 4], [5, 6], [7, 8]]
         sorting1.set_property(key="ragged_property", values=ragged_array_values1)
-        add_units_table_to_nwbfile(sorting=sorting1, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=sorting1, nwbfile=self.nwbfile)
 
         written_values = self.nwbfile.units.to_dataframe()["ragged_property"].to_list()
         np.testing.assert_array_equal(written_values, ragged_array_values1)
@@ -1602,7 +1584,7 @@ class TestAddUnitsTable(TestCase):
         sorting2.set_property(key="ragged_property", values=ragged_array_values2)
         second_ragged_array_values = [["a", "b", "c"], ["d", "e", "f"], ["g", "h", "i"], ["j", "k", "l"]]
         sorting2.set_property(key="ragged_property2", values=second_ragged_array_values)
-        add_units_table_to_nwbfile(sorting=sorting2, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=sorting2, nwbfile=self.nwbfile)
 
         written_values = self.nwbfile.units.to_dataframe()["ragged_property"].to_list()
         expected_values = ragged_array_values1 + ragged_array_values2
@@ -1626,7 +1608,7 @@ class TestAddUnitsTable(TestCase):
 
         doubled_nested_array = [[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]], [[13, 14], [15, 16]]]
         sorting1.set_property(key="double_ragged_property", values=doubled_nested_array)
-        add_units_table_to_nwbfile(sorting=sorting1, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=sorting1, nwbfile=self.nwbfile)
 
         written_values = self.nwbfile.units.to_dataframe()["double_ragged_property"].to_list()
         np.testing.assert_array_equal(written_values, doubled_nested_array)
@@ -1641,7 +1623,7 @@ class TestAddUnitsTable(TestCase):
             [["s", "t", "u"], ["v", "w", "x"]],
         ]
         sorting2.set_property(key="double_ragged_property2", values=second_doubled_nested_array)
-        add_units_table_to_nwbfile(sorting=sorting2, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=sorting2, nwbfile=self.nwbfile)
 
         written_values = self.nwbfile.units.to_dataframe()["double_ragged_property"].to_list()
         expected_values = doubled_nested_array + doubled_nested_array2
@@ -1661,7 +1643,7 @@ class TestAddUnitsTable(TestCase):
         sorting1 = generate_sorting(num_units=2, durations=[1.0])
         sorting1 = sorting1.rename_units(new_unit_ids=["a", "b"])
         sorting1.set_property(key="complete_int_property", values=[1, 2])
-        add_units_table_to_nwbfile(sorting=sorting1, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=sorting1, nwbfile=self.nwbfile)
 
         expected_property = np.asarray([1, 2])
         extracted_property = self.nwbfile.units["complete_int_property"].data
@@ -1672,10 +1654,10 @@ class TestAddUnitsTable(TestCase):
 
         sorting2.set_property(key="incomplete_int_property", values=[10, 11])
         with self.assertRaises(ValueError):
-            add_units_table_to_nwbfile(sorting=sorting2, nwbfile=self.nwbfile)
+            add_sorting_to_nwbfile(sorting=sorting2, nwbfile=self.nwbfile)
 
         null_values_for_properties = {"complete_int_property": -1, "incomplete_int_property": -3}
-        add_units_table_to_nwbfile(
+        add_sorting_to_nwbfile(
             sorting=sorting2, nwbfile=self.nwbfile, null_values_for_properties=null_values_for_properties
         )
 
@@ -1692,7 +1674,7 @@ class TestAddUnitsTable(TestCase):
         sorting1 = generate_sorting(num_units=2, durations=[1.0])
         sorting1 = sorting1.rename_units(new_unit_ids=["a", "b"])
         sorting1.set_property(key="complete_bool_property", values=[True, False])
-        add_units_table_to_nwbfile(sorting=sorting1, nwbfile=self.nwbfile)
+        add_sorting_to_nwbfile(sorting=sorting1, nwbfile=self.nwbfile)
 
         expected_property = np.asarray([True, False])
         extracted_property = self.nwbfile.units["complete_bool_property"].data.astype(bool)
@@ -1703,10 +1685,10 @@ class TestAddUnitsTable(TestCase):
 
         sorting2.set_property(key="incomplete_bool_property", values=[True, False])
         with self.assertRaises(ValueError):
-            add_units_table_to_nwbfile(sorting=sorting2, nwbfile=self.nwbfile)
+            add_sorting_to_nwbfile(sorting=sorting2, nwbfile=self.nwbfile)
 
         null_values_for_properties = {"complete_bool_property": False, "incomplete_bool_property": False}
-        add_units_table_to_nwbfile(
+        add_sorting_to_nwbfile(
             sorting=sorting2, nwbfile=self.nwbfile, null_values_for_properties=null_values_for_properties
         )
 
@@ -1976,13 +1958,13 @@ class TestWriteSortingAnalyzer(TestCase):
 
         # now we set new channel groups to mimic a different probe and call the function again
         self.single_segment_analyzer.recording.set_channel_groups([1] * len(recording.channel_ids))
-        add_electrical_series_kwargs2_to_add_electrical_series_to_nwbfile = dict(es_key="ElectricalSeriesRaw2")
+        add_electrical_series_kwargs2_to_add_recording_to_nwbfile = dict(es_key="ElectricalSeriesRaw2")
         write_sorting_analyzer_to_nwbfile(
             sorting_analyzer=self.single_segment_analyzer,
             nwbfile=self.nwbfile,
             write_electrical_series=True,
             metadata=metadata,
-            add_electrical_series_kwargs=add_electrical_series_kwargs2_to_add_electrical_series_to_nwbfile,
+            add_electrical_series_kwargs=add_electrical_series_kwargs2_to_add_recording_to_nwbfile,
         )
         # check that we have 2 groups
         self.assertEqual(len(self.nwbfile.electrode_groups), 2)


### PR DESCRIPTION
This comes from a discussion here https://github.com/catalystneuro/neuroconv/pull/1296#issuecomment-2789884737 with @luiztauffer and @weiglszonja.

Some of the current methods are superfluos and it would be better to have a smaller API. See the changelog for the detailed description