### PR TITLE
Test that top level modules can be imported with minimal installation

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Install NeuroConv with minimal requirements
         run: pip install .
       - name: Test initial import of all non-lazy dependencies
-        run: python -c "import neuroconv"
+        run: |
+          python -c "import neuroconv"
+          python -c "import neuroconv.datainterfaces"
       - name: Install Wine (For Plexon2 Tests)
         uses: ./.github/actions/install-wine
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -49,9 +49,12 @@ jobs:
       - name: Install NeuroConv with minimal requirements
         run: pip install .
       - name: Test initial import of all non-lazy dependencies
-        run: |
+        run: |  # Minimal installation should allow for lazy imports on main modules
           python -c "import neuroconv"
           python -c "import neuroconv.datainterfaces"
+          python -c "import neuroconv.tools"
+          python -c "import neuroconv.utils"
+          python -c "import neuroconv.converters"
       - name: Install Wine (For Plexon2 Tests)
         uses: ./.github/actions/install-wine
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,22 @@
 # v0.7.3 (Upcoming)
 
 ## Deprecations and Changes
-* Release pydantic ceiling [#1273](https://github.com/catalystneuro/neuroconv/pull/1273)
+* Release pydantic ceiling [PR #1273](https://github.com/catalystneuro/neuroconv/pull/1273)
 * `write_scaled` behavior on `add_electrical_series_to_nwbfile` is deprecated and will be removed in or after October 2025 [PR #1292](https://github.com/catalystneuro/neuroconv/pull/1292)
 * `add_electrical_series_to_nwbfile` now requires both gain and offsets to write scaling factor for voltage conversion when writing to NWB [PR #1292](https://github.com/catalystneuro/neuroconv/pull/1292)
 * `add_electrical_series_to_nwbfile`, `add_units_table_to_nwbfile` and `add_electrodes_to_nwbfile` and `add_electrode_groups_to_nwbfile` are becoming private methods. Use `add_recording_to_nwbfile`, `add_sorting_to_nwbfile` and `add_recording_metadata_to_nwbfile` instead [PR #1298](https://github.com/catalystneuro/neuroconv/pull/1298)
 
 ## Bug Fixes
+* Fixed import bugs when importing main modules where non-lazy dependencies were causing imported errors. Added tests to avoid this in the future. [PR #1305](https://github.com/catalystneuro/neuroconv/pull/1305)
 
 ## Features
-* Added a new `add_recording_as_time_series_to_nwbfile` function to add recording extractors from SpikeInterface as recording extractors to an nwbfile as time series [#1296](https://github.com/catalystneuro/neuroconv/pull/1296)
+* Added a new `add_recording_as_time_series_to_nwbfile` function to add recording extractors from SpikeInterface as recording extractors to an nwbfile as time series [PR #1296](https://github.com/catalystneuro/neuroconv/pull/1296)
 
 ## Improvements
 * Add documentation for conversion options with `NWBConverter` [#1301](https://github.com/catalystneuro/neuroconv/pull/1301)
-* `configure_backend` is now exposed to be imported as `from neuroconv.tools import configure_and_write_nwbfile` [#1287](https://github.com/catalystneuro/neuroconv/pull/1287)
+* `configure_backend` is now exposed to be imported as `from neuroconv.tools import configure_and_write_nwbfile` [PR #1287](https://github.com/catalystneuro/neuroconv/pull/1287)
 * Added metadata section to video conversion gallery [PR #1276](https://github.com/catalystneuro/neuroconv/pull/1276)
-* `DeepLabCutInterface` now calculates whether the timestamps come from a constant sampling rate and adds that instead if detected [#1293](https://github.com/catalystneuro/neuroconv/pull/1293)
+* `DeepLabCutInterface` now calculates whether the timestamps come from a constant sampling rate and adds that instead if detected [PR #1293](https://github.com/catalystneuro/neuroconv/pull/1293)
 * Fixed a bug in the extractor interfaces where segmentation and sorting interfaces were initialized twice [PR #1288](https://github.com/catalystneuro/neuroconv/pull/1288)
 * Support python 3.13 [PR #1117](https://github.com/catalystneuro/neuroconv/pull/1117)
 * Added *how to* documentation on how to set a probe to a recording interfaces [PR #1300](https://github.com/catalystneuro/neuroconv/pull/1300)
@@ -29,7 +30,7 @@
 
 ## Bug Fixes
 * Fixed a check in `_configure_backend` on neurodata_object ndx_events.Events to work only when ndx-events==0.2.0 is used. [PR #998](https://github.com/catalystneuro/neuroconv/pull/998)
-* Added an `append_on_disk_nwbfile` argumento to `run_conversion`. This changes the semantics of the overwrite parameter from assuming append mode when a file exists to a more conventional `safe writing` mode where confirmation is required to overwrite an existing file. Append mode now is controlled with the `append_on_disk_nwbfile`. [#1256](https://github.com/catalystneuro/neuroconv/pull/1256)
+* Added an `append_on_disk_nwbfile` argumento to `run_conversion`. This changes the semantics of the overwrite parameter from assuming append mode when a file exists to a more conventional `safe writing` mode where confirmation is required to overwrite an existing file. Append mode now is controlled with the `append_on_disk_nwbfile`. [PR #1256](https://github.com/catalystneuro/neuroconv/pull/1256)
 
 ## Features
 * Added `SortedRecordingConverter` to convert sorted recordings to NWB with correct metadata mapping between units and electrodes [PR #1132](https://github.com/catalystneuro/neuroconv/pull/1132)
@@ -42,13 +43,13 @@
 * Filter out warnings for missing timezone information in continuous integration [PR #1240](https://github.com/catalystneuro/neuroconv/pull/1240)
 * `FilePathType` is deprecated, use `FilePath` from pydantic instead [PR #1239](https://github.com/catalystneuro/neuroconv/pull/1239)
 * Change `np.NAN` to `np.nan` to support numpy 2.0 [PR #1245](https://github.com/catalystneuro/neuroconv/pull/1245)
-* Re activate Plexon tests on Mac. Testing this for a while as they are unreliable tests [#1195](https://github.com/catalystneuro/neuroconv/pull/1195)
-* Testing: only run tests for oldest and newest versions of python [#1249](https://github.com/catalystneuro/neuroconv/pull/1249)
+* Re activate Plexon tests on Mac. Testing this for a while as they are unreliable tests [PR #1195](https://github.com/catalystneuro/neuroconv/pull/1195)
+* Testing: only run tests for oldest and newest versions of python [PR #1249](https://github.com/catalystneuro/neuroconv/pull/1249)
 * Improve error display on scan image interfaces [PR #1246](https://github.com/catalystneuro/neuroconv/pull/1246)
-* Added concurrency to live-service-testing GitHub Actions workflow to prevent simultaneous write to the dandiset. [#1252](https://github.com/catalystneuro/neuroconv/pull/1252)
-* Updated GitHub Actions workflows to use Environment Files instead of the deprecated `set-output` command [#1259](https://github.com/catalystneuro/neuroconv/pull/1259)
-* Propagate `verbose` parameter from Converters to Interfaces [#1253](https://github.com/catalystneuro/neuroconv/issues/1253)
-* Replace uses of scipy load_mat and h5storage loadmat with pymat_reader read_mat in `CellExplorerSortingInterface` [#1254](https://github.com/catalystneuro/neuroconv/pull/1254)
+* Added concurrency to live-service-testing GitHub Actions workflow to prevent simultaneous write to the dandiset. [PR #1252](https://github.com/catalystneuro/neuroconv/pull/1252)
+* Updated GitHub Actions workflows to use Environment Files instead of the deprecated `set-output` command [PR #1259](https://github.com/catalystneuro/neuroconv/pull/1259)
+* Propagate `verbose` parameter from Converters to Interfaces [PR #1253](https://github.com/catalystneuro/neuroconv/issues/1253)
+* Replace uses of scipy load_mat and h5storage loadmat with pymat_reader read_mat in `CellExplorerSortingInterface` [PR #1254](https://github.com/catalystneuro/neuroconv/pull/1254)
 * Added camera device support for ExternalVideoInterface and InternalVideoInterface: [PR #1282](https://github.com/catalystneuro/neuroconv/pull/1282)
 
 
@@ -70,7 +71,7 @@
 * Interfaces and converters now have `verbose=False` by default [PR #1153](https://github.com/catalystneuro/neuroconv/pull/1153)
 * Added `metadata` and `conversion_options` as arguments to `NWBConverter.temporally_align_data_interfaces` [PR #1162](https://github.com/catalystneuro/neuroconv/pull/1162)
 * Deprecations in the ecephys pipeline: compression options, old iterator options, methods that did not end up in *to_nwbfile and the `get_schema_from_method_signature` function [PR #1207](https://github.com/catalystneuro/neuroconv/pull/1207)
-* Removed all deprecated functions from the roiextractors module: `add_fluorescence_traces`, `add_background_fluorescence_traces`, `add_summary_images`, `add_segmentation`, and `write_segmentation` [#1233](https://github.com/catalystneuro/neuroconv/pull/1233)
+* Removed all deprecated functions from the roiextractors module: `add_fluorescence_traces`, `add_background_fluorescence_traces`, `add_summary_images`, `add_segmentation`, and `write_segmentation` [PR #1233](https://github.com/catalystneuro/neuroconv/pull/1233)
 
 ## Bug Fixes
 * `run_conversion` does not longer trigger append mode when `nwbfile_path` points to a faulty file [PR #1180](https://github.com/catalystneuro/neuroconv/pull/1180)

--- a/src/neuroconv/datainterfaces/ecephys/sortedrecordinginterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/sortedrecordinginterface.py
@@ -7,9 +7,6 @@ from neuroconv.datainterfaces.ecephys.baserecordingextractorinterface import (
 from neuroconv.datainterfaces.ecephys.basesortingextractorinterface import (
     BaseSortingExtractorInterface,
 )
-from neuroconv.tools.spikeinterface.spikeinterface import (
-    _get_electrode_table_indices_for_recording,
-)
 
 
 class SortedRecordingConverter(ConverterPipe):
@@ -90,6 +87,10 @@ class SortedRecordingConverter(ConverterPipe):
             nwbfile=nwbfile,
             metadata=metadata,
             **conversion_options_recording,
+        )
+
+        from ...tools.spikeinterface.spikeinterface import (
+            _get_electrode_table_indices_for_recording,
         )
 
         # This returns the indices in the electrode table that corresponds to the channel ids of the recording

--- a/src/neuroconv/tools/spikeinterface/__init__.py
+++ b/src/neuroconv/tools/spikeinterface/__init__.py
@@ -18,4 +18,5 @@ from .spikeinterface import (
     add_recording_metadata_to_nwbfile,
 )
 
+
 from .spikeinterfacerecordingdatachunkiterator import get_electrical_series_chunk_shape


### PR DESCRIPTION
This should fix #1304. The specific error that trigger the user is now fixed on main but we should have a test for this (which I just added).
