### PR TITLE
Expose iterative write parameters on `BaseImagingExtractor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## Features
 * Added a new `add_recording_as_time_series_to_nwbfile` function to add recording extractors from SpikeInterface as recording extractors to an nwbfile as time series [PR #1296](https://github.com/catalystneuro/neuroconv/pull/1296)
 * Added `OpenEphysBinaryAnalogInterface` for converting OpenEphys analog channels data similar to the SpikeGLX NIDQ interface [PR #1237](https://github.com/catalystneuro/neuroconv/pull/1237)
+* Expose iterative write options on `BaseImagingExtractorInterface` [PR #TBD](https://github.com/catalystneuro/neuroconv/pull/TBD)
 
 ## Improvements
 * Add documentation for conversion options with `NWBConverter` [PR #1301](https://github.com/catalystneuro/neuroconv/pull/1301)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ## Features
 * Added a new `add_recording_as_time_series_to_nwbfile` function to add recording extractors from SpikeInterface as recording extractors to an nwbfile as time series [PR #1296](https://github.com/catalystneuro/neuroconv/pull/1296)
 * Added `OpenEphysBinaryAnalogInterface` for converting OpenEphys analog channels data similar to the SpikeGLX NIDQ interface [PR #1237](https://github.com/catalystneuro/neuroconv/pull/1237)
-* Expose iterative write options on `BaseImagingExtractorInterface` [PR #TBD](https://github.com/catalystneuro/neuroconv/pull/TBD)
+* Expose iterative write options on `BaseImagingExtractorInterface` [PR #1307](https://github.com/catalystneuro/neuroconv/pull/1307)
 
 ## Improvements
 * Add documentation for conversion options with `NWBConverter` [PR #1301](https://github.com/catalystneuro/neuroconv/pull/1301)

--- a/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
@@ -147,6 +147,8 @@ class BaseImagingExtractorInterface(BaseExtractorInterface):
         stub_test: bool = False,
         stub_frames: int = 100,
         always_write_timestamps: bool = False,
+        iterator_type: Optional[str] = "v2",
+        iterator_options: Optional[dict] = None,
     ):
         """
         Add imaging data to the NWB file
@@ -169,6 +171,10 @@ class BaseImagingExtractorInterface(BaseExtractorInterface):
         stub_frames : int, optional
             The number of frames to write when stub_test is True. Will use min(stub_frames, total_frames) to avoid
             exceeding available frames, by default 100.
+        iterator_type : str, optional
+            The type of iterator to use for adding the data. Commonly used to manage large datasets, by default "v2".
+        iterator_options : dict, optional
+            Additional options for controlling the iteration process, by default None.
         """
 
         from ...tools.roiextractors import add_imaging_to_nwbfile
@@ -189,4 +195,6 @@ class BaseImagingExtractorInterface(BaseExtractorInterface):
             photon_series_index=photon_series_index,
             parent_container=parent_container,
             always_write_timestamps=always_write_timestamps,
+            iterator_type=iterator_type,
+            iterator_options=iterator_options,
         )

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -114,10 +114,10 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
         assert buffer_gb > 0, f"buffer_gb ({buffer_gb}) must be greater than zero!"
         assert all(np.array(chunk_shape) > 0), f"Some dimensions of chunk_shape ({chunk_shape}) are less than zero!"
 
-        sample_shape = self._get_maxshape()[1:]
-        min_buffer_shape = tuple([chunk_shape[0]]) + sample_shape
+        series_max_shape = self._get_maxshape()[1:]
+        min_buffer_shape = tuple([chunk_shape[0]]) + series_max_shape
         scaling_factor = math.floor((buffer_gb * 1e9 / (math.prod(min_buffer_shape) * self._get_dtype().itemsize)))
-        max_buffer_shape = tuple([int(scaling_factor * min_buffer_shape[0])]) + sample_shape
+        max_buffer_shape = tuple([int(scaling_factor * min_buffer_shape[0])]) + series_max_shape
         scaled_buffer_shape = tuple(
             [
                 min(max(int(dimension_length), chunk_shape[dimension_index]), self._get_maxshape()[dimension_index])
@@ -140,10 +140,10 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
         width = max_series_shape.shape[2]
 
         if len(max_series_shape.shape) == 3:
-            sample_shape = (num_samples, height, width)
+            sample_shape = (num_samples, width, height)
         else:
             num_planes = max_series_shape.shape[3]
-            sample_shape = (num_samples, height, width, num_planes)
+            sample_shape = (num_samples, width, height, num_planes)
 
         return sample_shape
 
@@ -154,4 +154,5 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
         )
         tranpose_axes = (0, 2, 1) if len(data.shape) == 3 else (0, 2, 1, 3)
         sliced_selection = (slice(0, self.buffer_shape[0]),) + selection[1:]
+
         return data.transpose(tranpose_axes)[sliced_selection]

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -136,8 +136,9 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
         else:
             num_planes = 1
 
-        image_shape = self.imaging_extractor.get_image_shape()
-        sample_shape = (self.imaging_extractor.get_num_frames(), image_shape[0], image_shape[1], num_planes)
+        height, width = self.imaging_extractor.get_image_shape()
+        num_samples = self.imaging_extractor.get_num_samples()
+        sample_shape = (num_samples, width, height, num_planes)
 
         # if the last dimension is 1, remove it
         sample_shape = sample_shape[:-1] if sample_shape[-1] == 1 else sample_shape

--- a/tests/test_ophys/test_imagingextractordatachunkiterator.py
+++ b/tests/test_ophys/test_imagingextractordatachunkiterator.py
@@ -150,7 +150,7 @@ class TestImagingExtractorDataChunkIterator(TestCase):
                 num_rows=max_data_shape[2],
             )
 
-        dci = ImagingExtractorDataChunkIterator(
+        data_chunk_iterator = ImagingExtractorDataChunkIterator(
             imaging_extractor=imaging_extractor,
             buffer_gb=buffer_gb,
             buffer_shape=buffer_shape,
@@ -159,10 +159,12 @@ class TestImagingExtractorDataChunkIterator(TestCase):
         )
 
         if buffer_gb is not None:
-            assert ((math.prod(dci.buffer_shape) * self.imaging_extractor.get_dtype().itemsize) / 1e9) <= buffer_gb
+            assert (
+                (math.prod(data_chunk_iterator.buffer_shape) * self.imaging_extractor.get_dtype().itemsize) / 1e9
+            ) <= buffer_gb
 
-        data_chunks = np.zeros(dci.maxshape)
-        for data_chunk in dci:
+        data_chunks = np.zeros(data_chunk_iterator.maxshape)
+        for data_chunk in data_chunk_iterator:
             data_chunks[data_chunk.selection] = data_chunk.data
 
         expected_frames = imaging_extractor.get_video().transpose((0, 2, 1))


### PR DESCRIPTION
Two things:
1) Those parameters were previously not exposed, now they are.
2) Also, now that we are adjusting the semantics of frame-shape-sample I fixed the calculation of the max shape which is buggy at the moment because the previously `get_image_size` did return the size of the volume sometimes.