### PR TITLE
Make metadata optional in `converter.add_to_nwbfile`

### DIFF
--- a/src/neuroconv/nwbconverter.py
+++ b/src/neuroconv/nwbconverter.py
@@ -229,7 +229,9 @@ class NWBConverter:
         self.add_to_nwbfile(nwbfile=nwbfile, metadata=metadata, conversion_options=conversion_options)
         return nwbfile
 
-    def add_to_nwbfile(self, nwbfile: NWBFile, metadata, conversion_options: Optional[dict] = None):
+    def add_to_nwbfile(
+        self, nwbfile: NWBFile, metadata: Optional[dict] = None, conversion_options: Optional[dict] = None
+    ):
         """
         Add data from the instantiated data interfaces to the given NWBFile.
 
@@ -244,6 +246,9 @@ class NWBConverter:
             Each key corresponds to a data interface name, and the values are dictionaries with options for that interface.
             By default, None.
         """
+
+        metadata = metadata or self.get_metadata()
+
         conversion_options = conversion_options or dict()
         for interface_name, data_interface in self.data_interface_objects.items():
             data_interface.add_to_nwbfile(


### PR DESCRIPTION
It is this way for run conversion in both the converters and interfaces. This will unify the behavior and make using `add_to_nwbfile` more streamlined. 