### PR TITLE
updated sleap version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ audio = [
 ]
 sleap = [
     "av>=10.0.0",
-    "sleap-io>=0.0.2",
+    "sleap-io>=0.0.2,<0.3.0",
 ]
 deeplabcut = [
     "ndx-pose>=0.2",


### PR DESCRIPTION
Until https://github.com/rly/ndx-pose/issues/40 gets fixed, sleap must be pinned to the older version.