### PR TITLE
Add compression and chunking to `InternalVideoInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Add metadata support for `DeepLabCutInterface` [PR #1319](https://github.com/catalystneuro/neuroconv/pull/1319)
 * Added a RecordingInterface for WhiteMatter ephys data [PR #1297](https://github.com/catalystneuro/neuroconv/pull/1297) [PR #1333](https://github.com/catalystneuro/neuroconv/pull/1333)
 * Improved `ScanImageInteface` to support both single and multi-file data [PR #1330](https://github.com/catalystneuro/neuroconv/pull/1330)
-* Enable chunking for `InternalVideoInterfacd` [PR #TBD](https://github.com/catalystneuro/neuroconv/pull/TBD)
+* Enable chunking for `InternalVideoInterfac` [PR #1338](https://github.com/catalystneuro/neuroconv/pull/1338)
 
 
 ## Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Added a RecordingInterface for WhiteMatter ephys data [PR #1297](https://github.com/catalystneuro/neuroconv/pull/1297) [PR #1333](https://github.com/catalystneuro/neuroconv/pull/1333)
 * Improved `ScanImageInteface` to support both single and multi-file data [PR #1330](https://github.com/catalystneuro/neuroconv/pull/1330)
 * Enable chunking for `InternalVideoInterfac` [PR #1338](https://github.com/catalystneuro/neuroconv/pull/1338)
+* `ImageSeries` and `TwoPhotonSeries` now are chunked by default even if the data is passed as a plain array [PR #1338](https://github.com/catalystneuro/neuroconv/pull/1338)
 
 
 ## Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add metadata support for `DeepLabCutInterface` [PR #1319](https://github.com/catalystneuro/neuroconv/pull/1319)
 * Added a RecordingInterface for WhiteMatter ephys data [PR #1297](https://github.com/catalystneuro/neuroconv/pull/1297) [PR #1333](https://github.com/catalystneuro/neuroconv/pull/1333)
 * Improved `ScanImageInteface` to support both single and multi-file data [PR #1330](https://github.com/catalystneuro/neuroconv/pull/1330)
+* Enable chunking for `InternalVideoInterfacd` [PR #TBD](https://github.com/catalystneuro/neuroconv/pull/TBD)
 
 ## Improvements
 * Make metadata optional in `NWBConverter.add_to_nwbfile` [PR #1309](https://github.com/catalystneuro/neuroconv/pull/1309)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Add metadata support for `DeepLabCutInterface` [PR #1319](https://github.com/catalystneuro/neuroconv/pull/1319)
 * Added a RecordingInterface for WhiteMatter ephys data [PR #1297](https://github.com/catalystneuro/neuroconv/pull/1297) [PR #1333](https://github.com/catalystneuro/neuroconv/pull/1333)
 * Improved `ScanImageInteface` to support both single and multi-file data [PR #1330](https://github.com/catalystneuro/neuroconv/pull/1330)
-* Enable chunking for `InternalVideoInterfac` [PR #1338](https://github.com/catalystneuro/neuroconv/pull/1338)
+* Enable chunking for `InternalVideoInterface` [PR #1338](https://github.com/catalystneuro/neuroconv/pull/1338)
 * `ImageSeries` and `TwoPhotonSeries` now are chunked by default even if the data is passed as a plain array [PR #1338](https://github.com/catalystneuro/neuroconv/pull/1338)
 
 

--- a/docs/api/tools.iterative_write.rst
+++ b/docs/api/tools.iterative_write.rst
@@ -1,0 +1,4 @@
+Iterative Write
+---------------
+
+.. automodule:: neuroconv.tools.iterative_write

--- a/docs/api/tools.rst
+++ b/docs/api/tools.rst
@@ -2,7 +2,7 @@ Tools
 =====
 
 .. toctree::
-    :maxdepth: 4
+    :maxdepth: 3
 
     tools.spikeinterface
     tools.roiextractors

--- a/docs/api/tools.rst
+++ b/docs/api/tools.rst
@@ -9,6 +9,7 @@ Tools
     tools.yaml_to_nwb_conversion
     tools.neo
     tools.testing
+    tools.iterative_write
     tools.path_expansion
     tools.signal_processing
     tools.data_transfers

--- a/docs/developer_guide/building_documentation.rst
+++ b/docs/developer_guide/building_documentation.rst
@@ -10,13 +10,13 @@ First, create a clean environment and type the following commands in your termin
 
   git clone https://github.com/catalystneuro/neuroconv
   cd neuroconv
-  pip install -e .[docs]
+  pip install --editable .[docs]
 
 These commands install both the latest version of the repo and the dependencies necessary to build the documentation.
 
 .. note::
 
-  The argument ``-e`` makes you install `editable <https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs>`_
+  The argument ``--editable`` makes you install `editable <https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs>`_
 
 Use the following command to build the documentation locally.
 

--- a/docs/developer_guide/contributing.rst
+++ b/docs/developer_guide/contributing.rst
@@ -66,7 +66,7 @@ If you have not already, you will need to clone the repo:
 
 .. code-block:: bash
 
-    $ git checkout -b <new_branch>
+    $ git switch --create <new_branch>
 
 2) Make your changes.
 

--- a/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
@@ -302,6 +302,8 @@ class InternalVideoInterface(BaseDataInterface):
                 video_file=file_path,
                 stub_test=stub_test,
             )
+            image_series_kwargs.update(data=data_iterator)
+
         else:
             # Load the video
             with VideoCaptureContext(file_path) as video_capture_ob:
@@ -312,7 +314,7 @@ class InternalVideoInterface(BaseDataInterface):
 
                 maxshape = (total_frames, *frame_shape)
                 tqdm_pos, tqdm_mininterval = (0, 10)
-                video = np.zeros(shape=maxshape, dtype=dtype)
+                video_array = np.zeros(shape=maxshape, dtype=dtype)
 
                 if stub_test:
                     stub_frames = 10
@@ -324,11 +326,10 @@ class InternalVideoInterface(BaseDataInterface):
                     mininterval=tqdm_mininterval,
                 ) as pbar:
                     for n, frame in enumerate(video_capture_ob):
-                        video[n, :, :, :] = frame
+                        video_array[n, :, :, :] = frame
                         pbar.update(1)
-                data_iterator = video
 
-        image_series_kwargs.update(data=data_iterator)
+                image_series_kwargs.update(data=video_array)
 
         from ....utils import calculate_regular_series_rate
 

--- a/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
@@ -298,7 +298,7 @@ class InternalVideoInterface(BaseDataInterface):
             buffer_data = True
 
         if buffer_data:
-            data_iterable = VideoDataChunkIterator(
+            data_iterator = VideoDataChunkIterator(
                 video_file=file_path,
                 stub_test=stub_test,
             )
@@ -326,9 +326,9 @@ class InternalVideoInterface(BaseDataInterface):
                     for n, frame in enumerate(video_capture_ob):
                         video[n, :, :, :] = frame
                         pbar.update(1)
-                data_iterable = video
+                data_iterator = video
 
-        image_series_kwargs.update(data=data_iterable)
+        image_series_kwargs.update(data=data_iterator)
 
         from ....utils import calculate_regular_series_rate
 

--- a/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
@@ -5,14 +5,13 @@ from typing import Literal
 
 import numpy as np
 import psutil
-from hdmf.data_utils import DataChunkIterator
 from pydantic import FilePath, validate_call
 from pynwb import NWBFile
 from pynwb.device import Device
 from pynwb.image import ImageSeries
 from tqdm import tqdm
 
-from .video_utils import VideoCaptureContext
+from .video_utils import VideoCaptureContext, VideoDataChunkIterator
 from ....basedatainterface import BaseDataInterface
 from ....tools import get_package
 from ....tools.nwb_helpers import get_module
@@ -288,8 +287,7 @@ class InternalVideoInterface(BaseDataInterface):
                 nwbfile.add_device(device)
             image_series_kwargs["device"] = device
 
-        stub_frames = 10
-
+        # The 70 size is an estimation of the total size of the video file in memory
         uncompressed_estimate = file_path.stat().st_size * 70
         available_memory = psutil.virtual_memory().available
         if not buffer_data and not stub_test and uncompressed_estimate >= available_memory:
@@ -298,38 +296,27 @@ class InternalVideoInterface(BaseDataInterface):
                 f"as array ({human_readable_size(available_memory)} available)! Forcing buffer_data to True."
             )
             buffer_data = True
-        with VideoCaptureContext(str(file_path)) as video_capture_ob:
-            if stub_test:
-                video_capture_ob.frame_count = stub_frames
-            total_frames = video_capture_ob.get_video_frame_count()
-            frame_shape = video_capture_ob.get_frame_shape()
-
-        maxshape = (total_frames, *frame_shape)
-        tqdm_pos, tqdm_mininterval = (0, 10)
 
         if buffer_data:
-            chunks = (1, frame_shape[0], frame_shape[1], 3)  # best_gzip_chunk
-            video_capture_ob = VideoCaptureContext(str(file_path))
-            if stub_test:
-                video_capture_ob.frame_count = stub_frames
-            iterable = DataChunkIterator(
-                data=tqdm(
-                    iterable=video_capture_ob,
-                    desc=f"Copying video data for {file_path.name}",
-                    position=tqdm_pos,
-                    total=total_frames,
-                    mininterval=tqdm_mininterval,
-                ),
-                iter_axis=0,  # nwb standard is time as zero axis
-                maxshape=maxshape,
+            # Use VideoDataChunkIterator with the calculated chunk shape
+            data_iterable = VideoDataChunkIterator(
+                video_file=file_path,
+                stub_test=stub_test,
             )
-
         else:
             # Load the video
-            chunks = None
-            video = np.zeros(shape=maxshape, dtype="uint8")
-            with VideoCaptureContext(str(file_path)) as video_capture_ob:
+            with VideoCaptureContext(file_path) as video_capture_ob:
+
+                total_frames = video_capture_ob.get_video_frame_count()
+                frame_shape = video_capture_ob.get_frame_shape()
+                dtype = video_capture_ob.get_video_frame_dtype()
+
+                maxshape = (total_frames, *frame_shape)
+                tqdm_pos, tqdm_mininterval = (0, 10)
+                video = np.zeros(shape=maxshape, dtype=dtype)
+
                 if stub_test:
+                    stub_frames = 10
                     video_capture_ob.frame_count = stub_frames
                 with tqdm(
                     desc=f"Reading video data for {Path(file_path).name}",
@@ -340,9 +327,9 @@ class InternalVideoInterface(BaseDataInterface):
                     for n, frame in enumerate(video_capture_ob):
                         video[n, :, :, :] = frame
                         pbar.update(1)
-            iterable = video
+                data_iterable = video
 
-        image_series_kwargs.update(data=iterable)
+        image_series_kwargs.update(data=data_iterable)
 
         from ....utils import calculate_regular_series_rate
 

--- a/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
@@ -302,7 +302,6 @@ class InternalVideoInterface(BaseDataInterface):
                 video_file=file_path,
                 stub_test=stub_test,
             )
-            # next(data_iterable)
         else:
             # Load the video
             with VideoCaptureContext(file_path) as video_capture_ob:

--- a/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
@@ -298,11 +298,11 @@ class InternalVideoInterface(BaseDataInterface):
             buffer_data = True
 
         if buffer_data:
-            # Use VideoDataChunkIterator with the calculated chunk shape
             data_iterable = VideoDataChunkIterator(
                 video_file=file_path,
                 stub_test=stub_test,
             )
+            # next(data_iterable)
         else:
             # Load the video
             with VideoCaptureContext(file_path) as video_capture_ob:

--- a/src/neuroconv/datainterfaces/behavior/video/video_utils.py
+++ b/src/neuroconv/datainterfaces/behavior/video/video_utils.py
@@ -266,7 +266,7 @@ class VideoDataChunkIterator(GenericDataChunkIterator):
             self.video_capture_ob.frame_count = 10
 
         self._dtype = self.video_capture_ob.get_video_frame_dtype()
-        self._num_frames = self.video_capture_ob.get_video_frame_count()
+        self._num_samples = self.video_capture_ob.get_video_frame_count()
         self._sample_shape = self.video_capture_ob.get_frame_shape()
 
         if chunk_mb is None and chunk_shape is None:
@@ -293,7 +293,7 @@ class VideoDataChunkIterator(GenericDataChunkIterator):
         """This is how the data is chunked for reading."""
 
         chunk_shape = get_image_series_chunk_shape(
-            num_frames=self._num_frames,
+            num_samples=self._num_samples,
             sample_shape=self._sample_shape,
             dtype=self._dtype,
             chunk_mb=chunk_mb,
@@ -333,4 +333,4 @@ class VideoDataChunkIterator(GenericDataChunkIterator):
         return self._dtype
 
     def _get_maxshape(self) -> tuple[int, int, int, int]:
-        return (self._num_frames, *self._sample_shape)
+        return (self._num_samples, *self._sample_shape)

--- a/src/neuroconv/datainterfaces/behavior/video/video_utils.py
+++ b/src/neuroconv/datainterfaces/behavior/video/video_utils.py
@@ -3,6 +3,10 @@ from pydantic import FilePath
 from tqdm import tqdm
 
 from neuroconv.tools.hdmf import GenericDataChunkIterator
+from neuroconv.tools.iterative_write import (
+    get_image_series_buffer_shape,
+    get_image_series_chunk_shape,
+)
 
 from ....tools import get_package
 
@@ -287,9 +291,6 @@ class VideoDataChunkIterator(GenericDataChunkIterator):
 
     def _get_default_chunk_shape(self, chunk_mb):
         """This is how the data is chunked for reading."""
-        from neuroconv.tools.roiextractors.imagingextractordatachunkiterator import (
-            get_image_series_chunk_shape,
-        )
 
         chunk_shape = get_image_series_chunk_shape(
             num_samples=self._num_samples,
@@ -301,9 +302,6 @@ class VideoDataChunkIterator(GenericDataChunkIterator):
 
     def _get_scaled_buffer_shape(self, buffer_gb: float, chunk_shape: tuple) -> tuple:
         """Select the buffer_shape less than the threshold of buffer_gb that is also a multiple of the chunk_shape."""
-        from neuroconv.tools.roiextractors.imagingextractordatachunkiterator import (
-            get_image_series_buffer_shape,
-        )
 
         assert buffer_gb > 0, f"buffer_gb ({buffer_gb}) must be greater than zero!"
         assert all(np.array(chunk_shape) > 0), f"Some dimensions of chunk_shape ({chunk_shape}) are less than zero!"

--- a/src/neuroconv/datainterfaces/behavior/video/video_utils.py
+++ b/src/neuroconv/datainterfaces/behavior/video/video_utils.py
@@ -3,10 +3,6 @@ from pydantic import FilePath
 from tqdm import tqdm
 
 from neuroconv.tools.hdmf import GenericDataChunkIterator
-from neuroconv.tools.roiextractors.imagingextractordatachunkiterator import (
-    get_image_series_buffer_shape,
-    get_image_series_chunk_shape,
-)
 
 from ....tools import get_package
 
@@ -291,6 +287,9 @@ class VideoDataChunkIterator(GenericDataChunkIterator):
 
     def _get_default_chunk_shape(self, chunk_mb):
         """This is how the data is chunked for reading."""
+        from neuroconv.tools.roiextractors.imagingextractordatachunkiterator import (
+            get_image_series_chunk_shape,
+        )
 
         chunk_shape = get_image_series_chunk_shape(
             num_samples=self._num_samples,
@@ -302,6 +301,10 @@ class VideoDataChunkIterator(GenericDataChunkIterator):
 
     def _get_scaled_buffer_shape(self, buffer_gb: float, chunk_shape: tuple) -> tuple:
         """Select the buffer_shape less than the threshold of buffer_gb that is also a multiple of the chunk_shape."""
+        from neuroconv.tools.roiextractors.imagingextractordatachunkiterator import (
+            get_image_series_buffer_shape,
+        )
+
         assert buffer_gb > 0, f"buffer_gb ({buffer_gb}) must be greater than zero!"
         assert all(np.array(chunk_shape) > 0), f"Some dimensions of chunk_shape ({chunk_shape}) are less than zero!"
 

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -54,7 +54,7 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):  # noqa: D101
     def estimate_default_buffer_shape(
         buffer_gb: float, chunk_shape: tuple[int, ...], maxshape: tuple[int, ...], dtype: np.dtype
     ) -> tuple[int, ...]:
-        # TODO: Ad ddocstring to this once someone understands it better
+        # TODO: Add ddocstring to this once someone understands it better
         # Elevate any overflow warnings to trigger error.
         # This is usually an indicator of something going terribly wrong with the estimation calculations and should be
         # avoided at all costs.

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -62,7 +62,7 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):  # noqa: D101
     def estimate_default_buffer_shape(
         buffer_gb: float, chunk_shape: tuple[int, ...], maxshape: tuple[int, ...], dtype: np.dtype
     ) -> tuple[int, ...]:
-        # TODO: Add ddocstring to this once someone understands it better
+        # TODO: Add docstring to this once someone understands it better
         # Elevate any overflow warnings to trigger error.
         # This is usually an indicator of something going terribly wrong with the estimation calculations and should be
         # avoided at all costs.

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -14,6 +14,14 @@ from hdmf.utils import get_data_shape
 
 class GenericDataChunkIterator(HDMFGenericDataChunkIterator):  # noqa: D101
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        # Add the sizes for easy access after all chunk sizes are calculated
+        # self.chunk_shape and self.buffer shape are attribute in HDMFGenericDataChunkIterator
+        self._chunk_size_mb = math.prod(self.chunk_shape) * self._get_dtype().itemsize / 1e6
+        self._buffer_size_gb = math.prod(self.buffer_shape) * self._get_dtype().itemsize / 1e9
+
     def _get_default_buffer_shape(self, buffer_gb: float = 1.0) -> tuple[int]:
         return self.estimate_default_buffer_shape(
             buffer_gb=buffer_gb, chunk_shape=self.chunk_shape, maxshape=self.maxshape, dtype=self.dtype

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -13,7 +13,6 @@ from hdmf.utils import get_data_shape
 
 
 class GenericDataChunkIterator(HDMFGenericDataChunkIterator):  # noqa: D101
-    # TODO Should this be added to the API?
 
     def _get_default_buffer_shape(self, buffer_gb: float = 1.0) -> tuple[int]:
         return self.estimate_default_buffer_shape(

--- a/src/neuroconv/tools/hdmf.py
+++ b/src/neuroconv/tools/hdmf.py
@@ -17,7 +17,7 @@ class GenericDataChunkIterator(HDMFGenericDataChunkIterator):  # noqa: D101
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        # Add the sizes for easy access after all chunk sizes are calculated
+        # Add the size in bytes of chunk and buffer for easy access
         # self.chunk_shape and self.buffer shape are attribute in HDMFGenericDataChunkIterator
         self._chunk_size_mb = math.prod(self.chunk_shape) * self._get_dtype().itemsize / 1e6
         self._buffer_size_gb = math.prod(self.buffer_shape) * self._get_dtype().itemsize / 1e9

--- a/src/neuroconv/tools/iterative_write.py
+++ b/src/neuroconv/tools/iterative_write.py
@@ -1,0 +1,163 @@
+import math
+
+import numpy as np
+
+
+def get_image_series_chunk_shape(
+    *,
+    num_samples: int,
+    sample_shape: tuple[int, int, int] | tuple[int, int, int, int],
+    dtype: np.dtype,
+    chunk_mb: float = 10.0,
+) -> tuple[int, int]:
+    """
+    Estimate good chunk shape for a ImageSeries dataset.
+
+    This function gives good estimates for cloud access patterns.
+
+    Parameters
+    ----------
+    num_samples : int
+        The number of frames in the ImageSeries dataset.
+    sample_shape : tuple[int, int, int] | tuple[int, int, int, int]
+        The shape of a single sample for the ImageSeries.
+        For TwoPhotonSeries, this might be (num_columns, num_rows) or (num_columns, num_rows, num_planes).
+        For ImageSeries, this might be (num_columns, num_rows, num_channels).
+    dtype : np.dtype
+        The data type of the ImageSeries dataset.
+    chunk_mb : float, optional
+        The upper bound on size in megabytes (MB) of the internal chunk for the HDF5 dataset.
+        The default is 10MB, as recommended by the HDF5 group.
+
+    Returns
+    -------
+    tuple[int, int, int] | tuple[int, int, int, int]
+        The chunk shape for the TwoPhotonSeries dataset.
+    """
+    assert chunk_mb > 0, f"chunk_mb ({chunk_mb}) must be greater than zero!"
+
+    num_rows, num_columns = sample_shape[0], sample_shape[1]
+    frame_size_bytes = num_rows * num_columns * dtype.itemsize
+
+    chunk_size_bytes = chunk_mb * 1e6
+    num_samples_per_chunk = int(chunk_size_bytes / frame_size_bytes)
+
+    # Clip the number of frames between 1 and num_samples
+    num_samples_per_chunk = min(num_samples_per_chunk, num_samples)
+    num_samples_per_chunk = max(num_samples_per_chunk, 1)
+
+    chunk_shape = (num_samples_per_chunk, num_rows, num_columns)
+
+    if len(sample_shape) == 3:
+        chunk_shape = chunk_shape + (1,)
+
+    return chunk_shape
+
+
+def get_image_series_buffer_shape(
+    *,
+    chunk_shape: tuple[int, int, int] | tuple[int, int, int, int],
+    sample_shape: tuple[int, int, int] | tuple[int, int, int, int],
+    series_shape: tuple[int, int, int] | tuple[int, int, int, int],
+    dtype: np.dtype,
+    buffer_gb: float = 1.0,
+) -> tuple[int, int, int] | tuple[int, int, int, int]:
+    """
+    Estimate good buffer shape for a ImageSeries dataset.
+
+    This function gives good estimates for cloud access patterns.
+
+    Parameters
+    ----------
+    chunk_shape : tuple[int, int, int] | tuple[int, int, int, int]
+        The shape of the chunk for the ImageSeries dataset.
+    sample_shape : tuple[int, int, int] | tuple[int, int, int, int]
+        The shape of a single sample for the ImageSeries.
+        For TwoPhotonSeries, this might be (num_columns, num_rows) or (num_columns, num_rows, num_planes).
+        For ImageSeries, this might be (num_columns, num_rows, num_channels).
+    series_shape : tuple[int, int, int] | tuple[int, int, int, int]
+        The shape of the full ImageSeries dataset.
+    dtype : np.dtype
+        The data type of the ImageSeries dataset.
+    buffer_gb : float
+        The upper bound on size in gigabytes (GB) of the internal chunk for the HDF5 dataset.
+
+    Returns
+    -------
+    tuple[int, int] | tuple[int, int, int]
+        The buffer shape for the TwoPhotonSeries dataset.
+    """
+    assert buffer_gb > 0, f"buffer_gb ({buffer_gb}) must be greater than zero!"
+
+    # First we determined a minimal buffer shape, this is a chunk shape but we included
+    # the full last dimension (note that chunk_shape last dimension is 1 or omitted)
+    num_frames_in_chunk = chunk_shape[0]
+    min_buffer_shape = (num_frames_in_chunk,) + sample_shape
+
+    # The smallest the buffer could be is the size of a chunk
+    bytes_per_element = dtype.itemsize
+    minimal_buffer_size_in_bytes = math.prod(min_buffer_shape) * bytes_per_element
+
+    desired_buffer_size_in_bytes = buffer_gb * 1e9
+    scaling_factor = desired_buffer_size_in_bytes // minimal_buffer_size_in_bytes
+    num_frames_in_buffer = num_frames_in_chunk * scaling_factor
+
+    # This is the largest buffer that still fits within the buffer_gb
+    max_buffer_shape = tuple([num_frames_in_buffer]) + sample_shape
+
+    corrected_buffer_shape = []
+
+    # We need to clip every element to be between the minimal and maximal values
+    minimal_values = min_buffer_shape
+    maximal_values = series_shape
+    for dimension_index, dimension_length in enumerate(max_buffer_shape):
+        min_size = minimal_values[dimension_index]
+        max_size = maximal_values[dimension_index]
+        scaled_size = max(int(dimension_length), min_size)
+        scaled_size = min(scaled_size, max_size)
+        corrected_buffer_shape.append(scaled_size)
+
+    return tuple(corrected_buffer_shape)
+
+
+def get_electrical_series_chunk_shape(
+    number_of_channels: int, number_of_frames: int, dtype: np.dtype, chunk_mb: float = 10.0
+) -> tuple[int, int]:
+    """
+    Estimate good chunk shape for an ElectricalSeries dataset.
+
+    This function gives good estimates for cloud access patterns.
+
+    Parameters
+    ----------
+    number_of_channels : int
+        The number of channels in the ElectricalSeries dataset.
+    number_of_frames : int
+        The number of frames in the ElectricalSeries dataset.
+    dtype : np.dtype
+        The data type of the ElectricalSeries dataset.
+    chunk_mb : float, optional
+        The upper bound on size in megabytes (MB) of the internal chunk for the HDF5 dataset.
+        The chunk_shape will be set implicitly by this argument.
+
+    Returns
+    -------
+    tuple[int, int]
+        The chunk shape for the ElectricalSeries dataset.
+    """
+    assert chunk_mb > 0, f"chunk_mb ({chunk_mb}) must be greater than zero!"
+
+    # We use 64 channels as that gives enough time for common sampling rates when chunk_mb == 10.0
+    # See # from https://github.com/flatironinstitute/neurosift/issues/52#issuecomment-1671405249
+    chunk_channels = min(64, number_of_channels)
+
+    size_of_chunk_channels_bytes = chunk_channels * dtype.itemsize
+    total_chunk_space_bytes = chunk_mb * 1e6
+
+    # We allocate as many frames as possible with the remaining space of the chunk
+    chunk_frames = total_chunk_space_bytes // size_of_chunk_channels_bytes
+
+    # We clip by the number of frames if the samples are too small
+    chunk_frames = min(chunk_frames, number_of_frames)
+
+    return (chunk_frames, chunk_channels)

--- a/src/neuroconv/tools/iterative_write.py
+++ b/src/neuroconv/tools/iterative_write.py
@@ -121,7 +121,11 @@ def get_image_series_buffer_shape(
 
 
 def get_electrical_series_chunk_shape(
-    number_of_channels: int, number_of_frames: int, dtype: np.dtype, chunk_mb: float = 10.0
+    *,
+    number_of_channels: int,
+    number_of_frames: int,
+    dtype: np.dtype,
+    chunk_mb: float = 10.0,
 ) -> tuple[int, int]:
     """
     Estimate good chunk shape for an ElectricalSeries dataset.

--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
@@ -27,6 +27,7 @@ from pynwb.image import ImageSeries
 from typing_extensions import Self
 
 from neuroconv.tools.hdmf import get_full_data_shape
+from neuroconv.tools.iterative_write import get_electrical_series_chunk_shape
 from neuroconv.utils.str_utils import human_readable_size
 
 from ._pydantic_pure_json_schema_generator import PureJSONSchemaGenerator
@@ -287,7 +288,6 @@ class DatasetIOConfiguration(BaseModel, ABC):
             compression_method = "gzip"
 
         elif isinstance(neurodata_object, ElectricalSeries) and dataset_name == "data":
-            from ....tools.spikeinterface import get_electrical_series_chunk_shape
 
             number_of_frames = candidate_dataset.shape[0]
             number_of_channels = candidate_dataset.shape[1]

--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
@@ -12,6 +12,7 @@ from hdmf import Container
 from hdmf.build.builders import (
     BaseBuilder,
 )
+from hdmf.data_utils import GenericDataChunkIterator as HDMFGenericDataChunkIterator
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -28,7 +29,7 @@ from neuroconv.tools.hdmf import get_full_data_shape
 from neuroconv.utils.str_utils import human_readable_size
 
 from ._pydantic_pure_json_schema_generator import PureJSONSchemaGenerator
-from ...hdmf import GenericDataChunkIterator, SliceableDataChunkIterator
+from ...hdmf import SliceableDataChunkIterator
 
 
 def _recursively_find_location_in_memory_nwbfile(current_location: str, neurodata_object: Container) -> str:
@@ -274,7 +275,7 @@ class DatasetIOConfiguration(BaseModel, ABC):
         full_shape = get_full_data_shape(dataset=candidate_dataset, location_in_file=location_in_file, builder=builder)
         dtype = _infer_dtype(dataset=candidate_dataset)
 
-        if isinstance(candidate_dataset, GenericDataChunkIterator):
+        if isinstance(candidate_dataset, HDMFGenericDataChunkIterator):
             chunk_shape = candidate_dataset.chunk_shape
             buffer_shape = candidate_dataset.buffer_shape
             compression_method = "gzip"

--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
@@ -209,15 +209,21 @@ class DatasetIOConfiguration(BaseModel, ABC):
             raise ValueError(
                 f"{len(buffer_shape)=} does not match {len(full_shape)=} for dataset at location '{location_in_file}'!"
             )
+        if any(buffer_axis <= 0 for buffer_axis in buffer_shape):
+            raise ValueError(
+                f"Some dimensions of the {buffer_shape=} are less than or equal to zero for dataset at "
+                f"location '{location_in_file}'!"
+            )
+
         if any(chunk_axis > buffer_axis for chunk_axis, buffer_axis in zip(chunk_shape, buffer_shape)):
             raise ValueError(
                 f"Some dimensions of the {chunk_shape=} exceed the {buffer_shape=} for dataset at "
                 f"location '{location_in_file}'!"
             )
 
-        if any(buffer_axis <= 0 for buffer_axis in buffer_shape):
+        if any(buffer_axis > full_axis for buffer_axis, full_axis in zip(buffer_shape, full_shape)):
             raise ValueError(
-                f"Some dimensions of the {buffer_shape=} are less than or equal to zero for dataset at "
+                f"Some dimensions of the {buffer_shape=} exceed the {full_shape=} for dataset at "
                 f"location '{location_in_file}'!"
             )
 
@@ -228,12 +234,6 @@ class DatasetIOConfiguration(BaseModel, ABC):
         ):
             raise ValueError(
                 f"Some dimensions of the {chunk_shape=} do not evenly divide the {buffer_shape=} for dataset at "
-                f"location '{location_in_file}'!"
-            )
-
-        if any(buffer_axis > full_axis for buffer_axis, full_axis in zip(buffer_shape, full_shape)):
-            raise ValueError(
-                f"Some dimensions of the {buffer_shape=} exceed the {full_shape=} for dataset at "
                 f"location '{location_in_file}'!"
             )
 

--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
@@ -198,7 +198,7 @@ class DatasetIOConfiguration(BaseModel, ABC):
                 f"location '{location_in_file}'!"
             )
 
-        # We only do the buffer checks for datasets with iterative writing.
+        # If the buffer shape is None skip the rest of the checks
         if buffer_shape is None:
             return values
 
@@ -206,6 +206,7 @@ class DatasetIOConfiguration(BaseModel, ABC):
             raise ValueError(
                 f"{len(chunk_shape)=} does not match {len(buffer_shape)=} for dataset at location '{location_in_file}'!"
             )
+
         if len(buffer_shape) != len(full_shape):
             raise ValueError(
                 f"{len(buffer_shape)=} does not match {len(full_shape)=} for dataset at location '{location_in_file}'!"

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -1,12 +1,14 @@
 """General purpose iterator for all ImagingExtractor data."""
 
-import math
-
 import numpy as np
 from roiextractors import ImagingExtractor
 from tqdm import tqdm
 
 from neuroconv.tools.hdmf import GenericDataChunkIterator
+from neuroconv.tools.iterative_write import (
+    get_image_series_buffer_shape,
+    get_image_series_chunk_shape,
+)
 
 
 class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
@@ -158,120 +160,3 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
         sliced_selection = (slice(0, self.buffer_shape[0]),) + selection[1:]
 
         return data.transpose(tranpose_axes)[sliced_selection]
-
-
-def get_image_series_chunk_shape(
-    *,
-    num_samples: int,
-    sample_shape: tuple[int, int, int] | tuple[int, int, int, int],
-    dtype: np.dtype,
-    chunk_mb: float = 10.0,
-) -> tuple[int, int]:
-    """
-    Estimate good chunk shape for a ImageSeries dataset.
-
-    This function gives good estimates for cloud access patterns.
-
-    Parameters
-    ----------
-    num_samples : int
-        The number of frames in the ImageSeries dataset.
-    sample_shape : tuple[int, int, int] | tuple[int, int, int, int]
-        The shape of a single sample for the ImageSeries.
-        For TwoPhotonSeries, this might be (num_columns, num_rows) or (num_columns, num_rows, num_planes).
-        For ImageSeries, this might be (num_columns, num_rows, num_channels).
-    dtype : np.dtype
-        The data type of the ImageSeries dataset.
-    chunk_mb : float, optional
-        The upper bound on size in megabytes (MB) of the internal chunk for the HDF5 dataset.
-        The default is 10MB, as recommended by the HDF5 group.
-
-    Returns
-    -------
-    tuple[int, int, int] | tuple[int, int, int, int]
-        The chunk shape for the TwoPhotonSeries dataset.
-    """
-    assert chunk_mb > 0, f"chunk_mb ({chunk_mb}) must be greater than zero!"
-
-    num_rows, num_columns = sample_shape[0], sample_shape[1]
-    frame_size_bytes = num_rows * num_columns * dtype.itemsize
-
-    chunk_size_bytes = chunk_mb * 1e6
-    num_samples_per_chunk = int(chunk_size_bytes / frame_size_bytes)
-
-    # Clip the number of frames between 1 and num_samples
-    num_samples_per_chunk = min(num_samples_per_chunk, num_samples)
-    num_samples_per_chunk = max(num_samples_per_chunk, 1)
-
-    chunk_shape = (num_samples_per_chunk, num_rows, num_columns)
-
-    if len(sample_shape) == 3:
-        chunk_shape = chunk_shape + (1,)
-
-    return chunk_shape
-
-
-def get_image_series_buffer_shape(
-    *,
-    chunk_shape: tuple[int, int, int] | tuple[int, int, int, int],
-    sample_shape: tuple[int, int, int] | tuple[int, int, int, int],
-    series_shape: tuple[int, int, int] | tuple[int, int, int, int],
-    dtype: np.dtype,
-    buffer_gb: float = 1.0,
-) -> tuple[int, int, int] | tuple[int, int, int, int]:
-    """
-    Estimate good buffer shape for a ImageSeries dataset.
-
-    This function gives good estimates for cloud access patterns.
-
-    Parameters
-    ----------
-    chunk_shape : tuple[int, int, int] | tuple[int, int, int, int]
-        The shape of the chunk for the ImageSeries dataset.
-    sample_shape : tuple[int, int, int] | tuple[int, int, int, int]
-        The shape of a single sample for the ImageSeries.
-        For TwoPhotonSeries, this might be (num_columns, num_rows) or (num_columns, num_rows, num_planes).
-        For ImageSeries, this might be (num_columns, num_rows, num_channels).
-    series_shape : tuple[int, int, int] | tuple[int, int, int, int]
-        The shape of the full ImageSeries dataset.
-    dtype : np.dtype
-        The data type of the ImageSeries dataset.
-    buffer_gb : float
-        The upper bound on size in gigabytes (GB) of the internal chunk for the HDF5 dataset.
-
-    Returns
-    -------
-    tuple[int, int] | tuple[int, int, int]
-        The buffer shape for the TwoPhotonSeries dataset.
-    """
-    assert buffer_gb > 0, f"buffer_gb ({buffer_gb}) must be greater than zero!"
-
-    # First we determined a minimal buffer shape, this is a chunk shape but we included
-    # the full last dimension (note that chunk_shape last dimension is 1 or omitted)
-    num_frames_in_chunk = chunk_shape[0]
-    min_buffer_shape = (num_frames_in_chunk,) + sample_shape
-
-    # The smallest the buffer could be is the size of a chunk
-    bytes_per_element = dtype.itemsize
-    minimal_buffer_size_in_bytes = math.prod(min_buffer_shape) * bytes_per_element
-
-    desired_buffer_size_in_bytes = buffer_gb * 1e9
-    scaling_factor = desired_buffer_size_in_bytes // minimal_buffer_size_in_bytes
-    num_frames_in_buffer = num_frames_in_chunk * scaling_factor
-
-    # This is the largest buffer that still fits within the buffer_gb
-    max_buffer_shape = tuple([num_frames_in_buffer]) + sample_shape
-
-    corrected_buffer_shape = []
-
-    # We need to clip every element to be between the minimal and maximal values
-    minimal_values = min_buffer_shape
-    maximal_values = series_shape
-    for dimension_index, dimension_length in enumerate(max_buffer_shape):
-        min_size = minimal_values[dimension_index]
-        max_size = maximal_values[dimension_index]
-        scaled_size = max(int(dimension_length), min_size)
-        scaled_size = min(scaled_size, max_size)
-        corrected_buffer_shape.append(scaled_size)
-
-    return tuple(corrected_buffer_shape)

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -94,7 +94,7 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
         height, width = roi_extractors_frame_shape[0], roi_extractors_frame_shape[1]
         nwb_frame_shape = (width, height)
 
-        if self.imaging_extractor.is_volumetric():
+        if self.imaging_extractor.is_volumetric:
             num_planes = self.imaging_extractor.get_num_planes()
             sample_shape = nwb_frame_shape + (num_planes,)
         else:

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -106,12 +106,12 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
         """Select the chunk_shape less than the threshold of chunk_mb while keeping the original image size."""
         assert chunk_mb > 0, f"chunk_mb ({chunk_mb}) must be greater than zero!"
 
-        num_frames = self.imaging_extractor.get_num_samples()
+        num_samples = self.imaging_extractor.get_num_samples()
         sample_shape = self._get_sample_shape()
         dtype = self.imaging_extractor.get_dtype()
 
         chunk_shape = get_image_series_chunk_shape(
-            num_frames=num_frames,
+            num_samples=num_samples,
             sample_shape=sample_shape,
             dtype=dtype,
             chunk_mb=chunk_mb,
@@ -162,7 +162,7 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
 
 def get_image_series_chunk_shape(
     *,
-    num_frames: int,
+    num_samples: int,
     sample_shape: tuple[int, int, int] | tuple[int, int, int, int],
     dtype: np.dtype,
     chunk_mb: float = 10.0,
@@ -174,7 +174,7 @@ def get_image_series_chunk_shape(
 
     Parameters
     ----------
-    num_frames : int
+    num_samples : int
         The number of frames in the ImageSeries dataset.
     sample_shape : tuple[int, int, int] | tuple[int, int, int, int]
         The shape of a single sample for the ImageSeries.
@@ -197,13 +197,13 @@ def get_image_series_chunk_shape(
     frame_size_bytes = num_rows * num_columns * dtype.itemsize
 
     chunk_size_bytes = chunk_mb * 1e6
-    num_frames_per_chunk = int(chunk_size_bytes / frame_size_bytes)
+    num_samples_per_chunk = int(chunk_size_bytes / frame_size_bytes)
 
-    # Clip the number of frames between 1 and num_frames
-    num_frames_per_chunk = min(num_frames_per_chunk, num_frames)
-    num_frames_per_chunk = max(num_frames_per_chunk, 1)
+    # Clip the number of frames between 1 and num_samples
+    num_samples_per_chunk = min(num_samples_per_chunk, num_samples)
+    num_samples_per_chunk = max(num_samples_per_chunk, 1)
 
-    chunk_shape = (num_frames_per_chunk, num_rows, num_columns)
+    chunk_shape = (num_samples_per_chunk, num_rows, num_columns)
 
     if len(sample_shape) == 3:
         chunk_shape = chunk_shape + (1,)

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -90,7 +90,7 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
         )
 
     def _get_sample_shape(self) -> tuple:
-        """We are using this translate the sample shape in roiextractors to the nwb convention"""
+        """This translate the sample shape in roiextractors to the nwb convention by transposing the frame shape."""
 
         roi_extractors_frame_shape = self.imaging_extractor.get_frame_shape()
         height, width = roi_extractors_frame_shape[0], roi_extractors_frame_shape[1]

--- a/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
+++ b/src/neuroconv/tools/roiextractors/imagingextractordatachunkiterator.py
@@ -128,7 +128,6 @@ class ImagingExtractorDataChunkIterator(GenericDataChunkIterator):
         # Determine maximum buffer shape with scaling factor
         max_buffer_shape = tuple([int(scaling_factor * min_buffer_shape[0])]) + series_max_shape
 
-        # Build the scaled buffer shape element by element instead of using list comprehension
         scaled_buffer_shape = []
         maxshape = self._get_maxshape()
 

--- a/tests/imports.py
+++ b/tests/imports.py
@@ -62,6 +62,7 @@ class TestImportStructure(TestCase):
             "nwb_helpers",  # Attached to namespace by top __init__ call of NWBConverter
             "path_expansion",
             "processes",
+            "iterative_write",
             # Functions and classes imported on the __init__
             "get_format_summaries",
             "get_package",

--- a/tests/test_behavior/conftest.py
+++ b/tests/test_behavior/conftest.py
@@ -13,7 +13,8 @@ test_video_parameters = {
     "number_of_frames": 30,
     "number_of_rows": 64,
     "number_of_columns": 48,
-    "frameSize": (48, 64),  # This is give in x,y images coordinates (x is columns)
+    "frame_shape": (48, 64),  # This is give in x,y images coordinates (x is columns)
+    "number_of_channels": 3,
     "fps": 25,
 }
 
@@ -28,7 +29,8 @@ def video_files(tmp_path_session):
     number_of_frames = test_video_parameters["number_of_frames"]
     number_of_rows = test_video_parameters["number_of_rows"]
     number_of_columns = test_video_parameters["number_of_columns"]
-    frameSize = test_video_parameters["frameSize"]
+    frame_shape = test_video_parameters["frame_shape"]
+    number_of_channels = test_video_parameters["number_of_channels"]
     fps = test_video_parameters["fps"]
     # Standard code for specifying image formats
     fourcc_specification = ("M", "J", "P", "G")
@@ -39,25 +41,26 @@ def video_files(tmp_path_session):
         filename=video_file1,
         fourcc=fourcc,
         fps=fps,
-        frameSize=frameSize,
+        frameSize=frame_shape,
     )
     writer2 = cv2.VideoWriter(
         filename=video_file2,
         fourcc=fourcc,
         fps=fps,
-        frameSize=frameSize,
+        frameSize=frame_shape,
     )
     writer3 = cv2.VideoWriter(
         filename=video_file3,
         fourcc=fourcc,
         fps=fps,
-        frameSize=frameSize,
+        frameSize=frame_shape,
     )
 
+    sample_shape = (number_of_rows, number_of_columns, number_of_channels)
     for frame in range(number_of_frames):
-        writer1.write(np.random.randint(0, 255, (number_of_rows, number_of_columns, 3)).astype("uint8"))
-        writer2.write(np.random.randint(0, 255, (number_of_rows, number_of_columns, 3)).astype("uint8"))
-        writer3.write(np.random.randint(0, 255, (number_of_rows, number_of_columns, 3)).astype("uint8"))
+        writer1.write(np.random.randint(0, 255, sample_shape).astype("uint8"))
+        writer2.write(np.random.randint(0, 255, sample_shape).astype("uint8"))
+        writer3.write(np.random.randint(0, 255, sample_shape).astype("uint8"))
 
     writer1.release()
     writer2.release()

--- a/tests/test_behavior/conftest.py
+++ b/tests/test_behavior/conftest.py
@@ -9,6 +9,15 @@ def tmp_path_session(tmp_path_factory):
     return tmp_path_factory.mktemp("session")
 
 
+test_video_parameters = {
+    "number_of_frames": 30,
+    "number_of_rows": 64,
+    "number_of_columns": 48,
+    "frameSize": (48, 64),  # This is give in x,y images coordinates (x is columns)
+    "fps": 25,
+}
+
+
 @pytest.fixture(scope="session")
 def video_files(tmp_path_session):
     """Create test video files and return their paths."""
@@ -16,11 +25,11 @@ def video_files(tmp_path_session):
     video_file1 = str(tmp_path_session / "test1.avi")
     video_file2 = str(tmp_path_session / "test2.avi")
     video_file3 = str(tmp_path_session / "test3.avi")
-    number_of_frames = 30
-    number_of_rows = 64
-    number_of_columns = 48
-    frameSize = (number_of_columns, number_of_rows)  # This is give in x,y images coordinates (x is columns)
-    fps = 25
+    number_of_frames = test_video_parameters["number_of_frames"]
+    number_of_rows = test_video_parameters["number_of_rows"]
+    number_of_columns = test_video_parameters["number_of_columns"]
+    frameSize = test_video_parameters["frameSize"]
+    fps = test_video_parameters["fps"]
     # Standard code for specifying image formats
     fourcc_specification = ("M", "J", "P", "G")
     # Utility to transform the four code specification to OpenCV specification

--- a/tests/test_behavior/test_internal_video_interface.py
+++ b/tests/test_behavior/test_internal_video_interface.py
@@ -131,7 +131,8 @@ def test_video_chunking(nwb_converter, nwbfile_path, metadata):
     num_frames = test_video_parameters["number_of_frames"]
     num_rows = test_video_parameters["number_of_rows"]
     num_columns = test_video_parameters["number_of_columns"]
-    expected_video_shape = (num_frames, num_rows, num_columns, 3)
+    num_channels = test_video_parameters["number_of_channels"]
+    expected_video_shape = (num_frames, num_rows, num_columns, num_channels)
 
     with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
         nwbfile = io.read()
@@ -140,11 +141,11 @@ def test_video_chunking(nwb_converter, nwbfile_path, metadata):
         # Verify that chunking is applied
         video_written_with_iterator = mod["Video test1"]
         assert video_written_with_iterator.data.shape == expected_video_shape  # Chunked data
-        assert video_written_with_iterator.data.chunks == (10, 64, 48, 3)  # Chunked data
+        assert video_written_with_iterator.data.chunks == (num_frames, num_rows, num_columns, 1)  # Chunked data
 
         video_written_without_iterator = mod["Video test2"]
         assert video_written_without_iterator.data.shape == expected_video_shape
-        assert video_written_without_iterator.data.chunks == (30, 64, 48, 3)
+        assert video_written_without_iterator.data.chunks == (30, num_rows, num_columns, num_channels)
 
 
 def test_video_stub(nwb_converter, nwbfile_path, metadata):

--- a/tests/test_behavior/test_internal_video_interface.py
+++ b/tests/test_behavior/test_internal_video_interface.py
@@ -133,6 +133,7 @@ def test_video_chunking(nwb_converter, nwbfile_path, metadata):
     num_columns = test_video_parameters["number_of_columns"]
     num_channels = test_video_parameters["number_of_channels"]
     expected_video_shape = (num_frames, num_rows, num_columns, num_channels)
+    expected_chunking = (num_frames, num_rows, num_columns, 1)  # We chunk each channel separately
 
     with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
         nwbfile = io.read()
@@ -141,11 +142,11 @@ def test_video_chunking(nwb_converter, nwbfile_path, metadata):
         # Verify that chunking is applied
         video_written_with_iterator = mod["Video test1"]
         assert video_written_with_iterator.data.shape == expected_video_shape  # Chunked data
-        assert video_written_with_iterator.data.chunks == (num_frames, num_rows, num_columns, 1)  # Chunked data
+        assert video_written_with_iterator.data.chunks == expected_chunking  # Chunked data
 
         video_written_without_iterator = mod["Video test2"]
         assert video_written_without_iterator.data.shape == expected_video_shape
-        assert video_written_without_iterator.data.chunks == (30, num_rows, num_columns, num_channels)
+        assert video_written_without_iterator.data.chunks == expected_chunking
 
 
 def test_video_stub(nwb_converter, nwbfile_path, metadata):

--- a/tests/test_behavior/test_internal_video_interface.py
+++ b/tests/test_behavior/test_internal_video_interface.py
@@ -133,7 +133,9 @@ def test_video_chunking(nwb_converter, nwbfile_path, metadata):
     num_columns = test_video_parameters["number_of_columns"]
     num_channels = test_video_parameters["number_of_channels"]
     expected_video_shape = (num_frames, num_rows, num_columns, num_channels)
-    expected_chunking = (num_frames, num_rows, num_columns, 1)  # We chunk each channel separately
+    # We chunk each channel separately  and this dataset is small enough that each
+    # chunk covers all the frames
+    expected_chunking = (num_frames, num_rows, num_columns, 1)
 
     with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
         nwbfile = io.read()

--- a/tests/test_behavior/test_internal_video_interface.py
+++ b/tests/test_behavior/test_internal_video_interface.py
@@ -14,6 +14,8 @@ from neuroconv.datainterfaces.behavior.video.internalvideointerface import (
 )
 from neuroconv.utils import dict_deep_update
 
+from .conftest import test_video_parameters
+
 
 def test_initialization_without_metadata(video_files):
 
@@ -114,9 +116,10 @@ def test_save_video_to_custom_module(nwb_converter, nwbfile_path, metadata):
 
 def test_video_chunking(nwb_converter, nwbfile_path, metadata):
     """Test that video chunking works correctly."""
+
     conversion_options = dict(
-        Video1=dict(stub_test=True, buffer_data=True),
-        Video2=dict(stub_test=True, buffer_data=False),
+        Video1=dict(buffer_data=True),
+        Video2=dict(buffer_data=False),
     )
     nwb_converter.run_conversion(
         nwbfile_path=nwbfile_path,
@@ -125,15 +128,23 @@ def test_video_chunking(nwb_converter, nwbfile_path, metadata):
         metadata=metadata,
     )
 
+    num_frames = test_video_parameters["number_of_frames"]
+    num_rows = test_video_parameters["number_of_rows"]
+    num_columns = test_video_parameters["number_of_columns"]
+    expected_video_shape = (num_frames, num_rows, num_columns, 3)
+
     with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
         nwbfile = io.read()
         mod = nwbfile.acquisition
+
         # Verify that chunking is applied
         video_written_with_iterator = mod["Video test1"]
+        assert video_written_with_iterator.data.shape == expected_video_shape  # Chunked data
+        assert video_written_with_iterator.data.chunks == (10, 64, 48, 3)  # Chunked data
+
         video_written_without_iterator = mod["Video test2"]
-        assert video_written_with_iterator.data.chunks is not None
-        # Verify that non-chunking option works
-        assert video_written_without_iterator.data.chunks is not None  # Still chunked due to HDF5 storage
+        assert video_written_without_iterator.data.shape == expected_video_shape
+        assert video_written_without_iterator.data.chunks == (30, 64, 48, 3)
 
 
 def test_video_stub(nwb_converter, nwbfile_path, metadata):

--- a/tests/test_behavior/test_internal_video_interface.py
+++ b/tests/test_behavior/test_internal_video_interface.py
@@ -129,9 +129,11 @@ def test_video_chunking(nwb_converter, nwbfile_path, metadata):
         nwbfile = io.read()
         mod = nwbfile.acquisition
         # Verify that chunking is applied
-        assert mod["Video test1"].data.chunks is not None
+        video_written_with_iterator = mod["Video test1"]
+        video_written_without_iterator = mod["Video test2"]
+        assert video_written_with_iterator.data.chunks is not None
         # Verify that non-chunking option works
-        assert mod["Video test2"].data.chunks is not None  # Still chunked due to HDF5 storage
+        assert video_written_without_iterator.data.chunks is not None  # Still chunked due to HDF5 storage
 
 
 def test_video_stub(nwb_converter, nwbfile_path, metadata):

--- a/tests/test_behavior/test_video_utils.py
+++ b/tests/test_behavior/test_video_utils.py
@@ -211,7 +211,7 @@ class TestVideoInterface(unittest.TestCase):
 
 # To Discuss in review: This does not raise an error anymore because our implementation has a safety mechanism
 # that clips the buffer size between the size of the chunk and the max size of the data. In other words.
-# The previous erro was:
+# The previous error was:
 # # Traceback (most recent call last):
 #   File "/home/heberto/development/neuroconv/src/neuroconv/datainterfaces/behavior/video/video_utils.py", line 273, in _get_default_buffer_shape
 #     assert buffer_gb >= self._full_frame_size_mb / 1e3, f"provide buffer size >= {self._full_frame_size_mb/1e3} GB"

--- a/tests/test_behavior/test_video_utils.py
+++ b/tests/test_behavior/test_video_utils.py
@@ -209,8 +209,9 @@ class TestVideoInterface(unittest.TestCase):
     #         it = VideoDataChunkIterator(video_file, buffer_gb=buffer_size)
 
 
-# TO Discuss: This does not raise an error anymore because our implementation as a safety mechanism
-# That causes too small of a buffer to be equal to the size of the chunk so this test does not fail.
+# To Discuss in review: This does not raise an error anymore because our implementation has a safety mechanism
+# that clips the buffer size between the size of the chunk and the max size of the data. In other words.
+# The previous erro was:
 # # Traceback (most recent call last):
 #   File "/home/heberto/development/neuroconv/src/neuroconv/datainterfaces/behavior/video/video_utils.py", line 273, in _get_default_buffer_shape
 #     assert buffer_gb >= self._full_frame_size_mb / 1e3, f"provide buffer size >= {self._full_frame_size_mb/1e3} GB"

--- a/tests/test_behavior/test_video_utils.py
+++ b/tests/test_behavior/test_video_utils.py
@@ -200,20 +200,3 @@ class TestVideoInterface(unittest.TestCase):
             assert all(
                 [nwbfile.acquisition["imageseries"].data.chunks[i] == j for i, j in enumerate(custom_frame_shape)]
             )
-
-    # def test_small_buffer_size(self):
-    #     frame_size_mb = math.prod(self.frame_shape) / 1e6
-    #     buffer_size = frame_size_mb / 1e3 / 2
-    #     video_file = self.create_video(self.fps, self.frame_shape, self.number_of_frames)
-    #     with self.assertRaises(AssertionError):
-    #         it = VideoDataChunkIterator(video_file, buffer_gb=buffer_size)
-
-
-# To Discuss in review: This does not raise an error anymore because our implementation has a safety mechanism
-# that clips the buffer size between the size of the chunk and the max size of the data. In other words.
-# The previous error was:
-# # Traceback (most recent call last):
-#   File "/home/heberto/development/neuroconv/src/neuroconv/datainterfaces/behavior/video/video_utils.py", line 273, in _get_default_buffer_shape
-#     assert buffer_gb >= self._full_frame_size_mb / 1e3, f"provide buffer size >= {self._full_frame_size_mb/1e3} GB"
-#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# AssertionError: provide buffer size >= 0.0014399999999999999 GB

--- a/tests/test_behavior/test_video_utils.py
+++ b/tests/test_behavior/test_video_utils.py
@@ -1,4 +1,3 @@
-import math
 import os
 import tempfile
 import unittest
@@ -202,9 +201,18 @@ class TestVideoInterface(unittest.TestCase):
                 [nwbfile.acquisition["imageseries"].data.chunks[i] == j for i, j in enumerate(custom_frame_shape)]
             )
 
-    def test_small_buffer_size(self):
-        frame_size_mb = math.prod(self.frame_shape) / 1e6
-        buffer_size = frame_size_mb / 1e3 / 2
-        video_file = self.create_video(self.fps, self.frame_shape, self.number_of_frames)
-        with self.assertRaises(AssertionError):
-            it = VideoDataChunkIterator(video_file, buffer_gb=buffer_size)
+    # def test_small_buffer_size(self):
+    #     frame_size_mb = math.prod(self.frame_shape) / 1e6
+    #     buffer_size = frame_size_mb / 1e3 / 2
+    #     video_file = self.create_video(self.fps, self.frame_shape, self.number_of_frames)
+    #     with self.assertRaises(AssertionError):
+    #         it = VideoDataChunkIterator(video_file, buffer_gb=buffer_size)
+
+
+# TO Discuss: This does not raise an error anymore because our implementation as a safety mechanism
+# That causes too small of a buffer to be equal to the size of the chunk so this test does not fail.
+# # Traceback (most recent call last):
+#   File "/home/heberto/development/neuroconv/src/neuroconv/datainterfaces/behavior/video/video_utils.py", line 273, in _get_default_buffer_shape
+#     assert buffer_gb >= self._full_frame_size_mb / 1e3, f"provide buffer size >= {self._full_frame_size_mb/1e3} GB"
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# AssertionError: provide buffer size >= 0.0014399999999999999 GB


### PR DESCRIPTION
Should fix #1315

So we already had a `VideoDataChunkIterator` that we were not using. Most of this PR work was to align this iterator with the iterator for roiextractors so they match in the planar case. 