### PR TITLE
Make DeepDict behave as normal dict when evaluated in notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Add metadata support for `DeepLabCutInterface` [PR #1319](https://github.com/catalystneuro/neuroconv/pull/1319)
 * Added a RecordingInterface for WhiteMatter ephys data [PR #1297](https://github.com/catalystneuro/neuroconv/pull/1297) [PR #1333](https://github.com/catalystneuro/neuroconv/pull/1333)
 * Improved `ScanImageInteface` to support both single and multi-file data [PR #1330](https://github.com/catalystneuro/neuroconv/pull/1330)
-
+* `DeepDict` now behaves as a python dict when printed in notebooks [PR #1351](https://github.com/catalystneuro/neuroconv/pull/1351)
 
 ## Improvements
 * Make metadata optional in `NWBConverter.add_to_nwbfile` [PR #1309](https://github.com/catalystneuro/neuroconv/pull/1309)

--- a/src/neuroconv/utils/dict.py
+++ b/src/neuroconv/utils/dict.py
@@ -255,4 +255,9 @@ class DeepDict(defaultdict):
         return DeepDict(deepcopy(self.to_dict()))
 
     def __repr__(self) -> str:
-        return "DeepDict: " + dict.__repr__(self.to_dict())
+        return f"DeepDict({repr(self.to_dict())})"
+
+    def _repr_pretty_(self, p, cycle):
+        p.text("DeepDict(\n")
+        p.pretty(self.to_dict())
+        p.text("\n)")

--- a/src/neuroconv/utils/dict.py
+++ b/src/neuroconv/utils/dict.py
@@ -258,6 +258,7 @@ class DeepDict(defaultdict):
         return f"DeepDict({repr(self.to_dict())})"
 
     def _repr_pretty_(self, p, cycle):
+        "This is used by IPython to pretty-print the object and used here to achieve printing parity with dicts."
         p.text("DeepDict(\n")
         p.pretty(self.to_dict())
         p.text("\n)")

--- a/tests/test_minimal/test_utils/test_dict.py
+++ b/tests/test_minimal/test_utils/test_dict.py
@@ -36,7 +36,7 @@ class TestDeepDict(unittest.TestCase):
         self.assertIsInstance(dd["a"]["b"], DeepDict)
 
     def test_repr(self):
-        expected_repr = "DeepDict: {'a': {'b': {'c': 42}}}"
+        expected_repr = "DeepDict({'a': {'b': {'c': 42}}})"
         self.assertEqual(repr(self.dd), expected_repr)
 
     def test_deep_update(self):


### PR DESCRIPTION
Should fix #1350

After this PR the metadata (a deep dict) prints like this:

![image](https://github.com/user-attachments/assets/a53e0114-ed84-47b1-ae8c-f02fc554f418)


Whereas before this PR it printed like this:

![image](https://github.com/user-attachments/assets/9f98fe87-bdc3-459c-a54f-9a09430663a6)

(no nesting)
