### PR TITLE
Add support for `I;16` mode in `ImageInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * `DeepDict` now behaves as a python dict when printed in notebooks [PR #1351](https://github.com/catalystneuro/neuroconv/pull/1351)
 * Enable chunking for `InternalVideoInterface` [PR #1338](https://github.com/catalystneuro/neuroconv/pull/1338)
 * `ImageSeries` and `TwoPhotonSeries` now are chunked by default even if the data is passed as a plain array [PR #1338](https://github.com/catalystneuro/neuroconv/pull/1338)
-* Added support for 'I;16' mode in `ImageInterface`. This mode is mapped to `GrayscaleImage` in NWB [PR #TBD](https://github.com/catalystneuro/neuroconv/pull/TBD)
+* Added support for 'I;16' mode in `ImageInterface`. This mode is mapped to `GrayscaleImage` in NWB [PR #1365](https://github.com/catalystneuro/neuroconv/pull/1365)
 
 ## Improvements
 * Make metadata optional in `NWBConverter.add_to_nwbfile` [PR #1309](https://github.com/catalystneuro/neuroconv/pull/1309)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * `DeepDict` now behaves as a python dict when printed in notebooks [PR #1351](https://github.com/catalystneuro/neuroconv/pull/1351)
 * Enable chunking for `InternalVideoInterface` [PR #1338](https://github.com/catalystneuro/neuroconv/pull/1338)
 * `ImageSeries` and `TwoPhotonSeries` now are chunked by default even if the data is passed as a plain array [PR #1338](https://github.com/catalystneuro/neuroconv/pull/1338)
+* Added support for 'I;16' mode in `ImageInterface`. This mode is mapped to `GrayscaleImage` in NWB [PR #TBD](https://github.com/catalystneuro/neuroconv/pull/TBD)
 
 ## Improvements
 * Make metadata optional in `NWBConverter.add_to_nwbfile` [PR #1309](https://github.com/catalystneuro/neuroconv/pull/1309)

--- a/src/neuroconv/datainterfaces/image/imageinterface.py
+++ b/src/neuroconv/datainterfaces/image/imageinterface.py
@@ -132,6 +132,7 @@ class ImageInterface(BaseDataInterface):
         "RGB": RGBImage,
         "RGBA": RGBAImage,
         "LA": RGBAImage,  # LA will be converted to RGBA
+        "I;16": GrayscaleImage,  # 16-bit grayscale image
     }
 
     @classmethod

--- a/src/neuroconv/datainterfaces/image/imageinterface.py
+++ b/src/neuroconv/datainterfaces/image/imageinterface.py
@@ -128,7 +128,7 @@ class ImageInterface(BaseDataInterface):
 
     # Mapping from PIL mode to NWB image class
     IMAGE_MODE_TO_NWB_TYPE_MAP = {
-        "L": GrayscaleImage,
+        "L": GrayscaleImage,  # 8 bit grayscale image
         "RGB": RGBImage,
         "RGBA": RGBAImage,
         "LA": RGBAImage,  # LA will be converted to RGBA


### PR DESCRIPTION
This comes from the Surmeier conversion where a stack of image is stored in this format.

This PR adds support for images with mode 'I;16' to the `ImageInterface` class. The 'I;16' mode is now mapped to `GrayscaleImage` in the NWB format.

'I;16' indicates 16-bit unsigned integer grayscale images. This is used in applications where higher bit depth is required for better dynamic range and precision compared to standard 8-bit grayscale images (mode 'L').

