### PR TITLE
Fix sync stream bug in `SpikeGLXConverterPipe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Removals, Deprecations and Changes
 
 ## Bug Fixes
+* Fix a bug for avoiding loading the sync stream in `SpikeGLXConverterPipe` [PR #TBD](https://github.com/catalystneuro/neuroconv/pull/TBD)
 
 ## Features
 * Extra optional kwargs to `BlackrockRecordingInterface` and `BlackrockSortingInterface` for finer control of the neo reader [PR #12](https://github.com/catalystneuro/neuroconv/pull/1290)

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxconverter.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxconverter.py
@@ -88,8 +88,11 @@ class SpikeGLXConverterPipe(ConverterPipe):
         data_interfaces = dict()
 
         nidq_streams = [stream_id for stream_id in streams_ids if stream_id == "nidq"]
-        electrical_streams = [stream_id for stream_id in streams_ids if stream_id not in nidq_streams]
-        for stream_id in electrical_streams:
+        sync_streams = [stream_id for stream_id in streams_ids if "SYNC" in stream_id]
+        neural_streams = [
+            stream_id for stream_id in streams_ids if stream_id not in nidq_streams and stream_id not in sync_streams
+        ]
+        for stream_id in neural_streams:
             data_interfaces[stream_id] = SpikeGLXRecordingInterface(folder_path=folder_path, stream_id=stream_id)
 
         for stream_id in nidq_streams:

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
@@ -71,6 +71,11 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
                 "SpikeGLXRecordingInterface is not designed to handle nidq files. Use SpikeGLXNIDQInterface instead"
             )
 
+        if "SYNC" in stream_id:
+            raise ValueError(
+                "SpikeGLXRecordingInterface is not designed to handle the SYNC stream. Open an issue if you need this functionality."
+            )
+
         if file_path is not None:
             warnings.warn(
                 "file_path is deprecated and will be removed by the end of 2025. "


### PR DESCRIPTION
Now that the sync stream is separated on neo we need this safeguard:

https://github.com/NeuralEnsemble/python-neo/pull/1683

