### PR TITLE
Fix bruker `BrukerTiffSinglePlaneImagingInterface` frame identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Bug Fixes
 * Fix a bug for avoiding loading the sync stream in `SpikeGLXConverterPipe` [PR #1373](https://github.com/catalystneuro/neuroconv/pull/1373)
-
+* Fixed a bug in the `BrukerTiffSinglePlaneImagingInterface` where the criteria to identify frames belonging to a specific stream relied on the file name instead of the stream name. [PR #1375](https://github.com/catalystneuro/neuroconv/pull/1375)
 ## Features
 * Extra optional kwargs to `BlackrockRecordingInterface` and `BlackrockSortingInterface` for finer control of the neo reader [PR #12](https://github.com/catalystneuro/neuroconv/pull/1290)
 

--- a/src/neuroconv/datainterfaces/ophys/brukertiff/brukertiffdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/brukertiff/brukertiffdatainterface.py
@@ -285,7 +285,7 @@ class BrukerTiffSinglePlaneImagingInterface(BaseImagingExtractorInterface):
             frame
             for frame in self.imaging_extractor._xml_root.findall(".//Frame")
             for file in frame.findall("File")
-            if stream_name in file.attrib["filename"]
+            if stream_name == file.attrib["channelName"]
         ]
 
         # general positionCurrent


### PR DESCRIPTION
Check the specific section of the xml:

```xml
    <Frame relativeTime="0.5989212" absoluteTime="0.672921200000524" parameterSet="CurrentSettings" index="4">
      <File channel="2" channelName="Ch2" filename="BOT_04022024_slice3ROI2_sul_burst-001_Cycle00001_Ch2_000004.ome.tif" />
      <File channel="3" channelName="Dodt" filename="BOT_04022024_slice3ROI2_sul_burst-001_Cycle00001_Ch3_000004.ome.tif" />
      <ExtraParameters lastGoodFrame="0" />
      <PVStateShard />
    </Frame>
```

The streams ar fetch from the channel names:
https://github.com/catalystneuro/roiextractors/blob/43534adc2cbaebe8b62d47eddfacea5bfdffe2a5/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py#L167-L177

But then to select the frames we are fetching from the filename instead of from the channelName again. 

See in the example above that this will fail because the name contains the channel not the channelName.

This PR fixes this.