### PR TITLE
Enable cross-os cache

### DIFF
--- a/.github/actions/load-data/action.yml
+++ b/.github/actions/load-data/action.yml
@@ -10,9 +10,6 @@ inputs:
   s3-gin-bucket:
     description: 'S3 GIN Bucket URL'
     required: true
-  os:
-    description: 'Operating system'
-    required: true
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/load-data/action.yml
+++ b/.github/actions/load-data/action.yml
@@ -28,7 +28,8 @@ runs:
       id: cache-ephys-datasets
       with:
         path: ./ephy_testing_data
-        key: ephys-datasets-${{ inputs.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
+        key: ephys-datasets-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
+        enableCrossOsArchive: true
 
     - name: Get ophys_testing_data current head hash
       id: ophys
@@ -42,7 +43,8 @@ runs:
       id: cache-ophys-datasets
       with:
         path: ./ophys_testing_data
-        key: ophys-datasets-${{ inputs.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
+        key: ophys-datasets-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
+        enableCrossOsArchive: true
 
     - name: Get behavior_testing_data current head hash
       id: behavior
@@ -56,7 +58,8 @@ runs:
       id: cache-behavior-datasets
       with:
         path: ./behavior_testing_data
-        key: behavior-datasets-${{ inputs.os }}-${{ steps.behavior.outputs.HASH_BEHAVIOR_DATASET }}
+        key: behavior-datasets-${{ steps.behavior.outputs.HASH_BEHAVIOR_DATASET }}
+        enableCrossOsArchive: true
 
     - name: Determine if downloads are required
       id: download-check

--- a/.github/workflows/dev-testing.yml
+++ b/.github/workflows/dev-testing.yml
@@ -82,7 +82,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           s3-gin-bucket: ${{ secrets.S3_GIN_BUCKET }}
-          os: ${{ matrix.os }}
 
 
       - name: Run full pytest

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -50,7 +50,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           s3-gin-bucket: ${{ secrets.S3_GIN_BUCKET }}
-          os: ${{ matrix.os }}
 
 
       - name: Run doctests

--- a/.github/workflows/live-service-testing.yml
+++ b/.github/workflows/live-service-testing.yml
@@ -47,8 +47,8 @@ jobs:
         run: |
           python -m pip install -U pip  # Official recommended way
 
-      - name: Install full requirements
-        run: pip install ".[test,dandi,spikeglx,phy,]"
+      - name: Install test requirements
+        run: pip install ".[test,dandi,spikeglx,phy]"
 
       - name: Prepare data for tests
         uses: ./.github/actions/load-data

--- a/.github/workflows/live-service-testing.yml
+++ b/.github/workflows/live-service-testing.yml
@@ -56,7 +56,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           s3-gin-bucket: ${{ secrets.S3_GIN_BUCKET }}
-          os: ${{ matrix.os }}
 
       - name: Run subset of tests that use DANDI live services
         run: pytest -rsx -n auto tests/remote_transfer_services/dandi_transfer_tools.py

--- a/.github/workflows/live-service-testing.yml
+++ b/.github/workflows/live-service-testing.yml
@@ -38,7 +38,6 @@ jobs:
         os: ${{ fromJson(inputs.os-versions) }}
     steps:
       - uses: actions/checkout@v4
-      - run: git fetch --prune --unshallow --tags
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -47,11 +46,9 @@ jobs:
       - name: Global Setup
         run: |
           python -m pip install -U pip  # Official recommended way
-          git config --global user.email "CI@example.com"
-          git config --global user.name "CI Almighty"
 
       - name: Install full requirements
-        run: pip install .[test,full]
+        run: pip install ".[test,dandi,spikeglx,phy,]"
 
       - name: Prepare data for tests
         uses: ./.github/actions/load-data

--- a/.github/workflows/neuroconv_docker_testing.yml
+++ b/.github/workflows/neuroconv_docker_testing.yml
@@ -41,7 +41,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           s3-gin-bucket: ${{ secrets.S3_GIN_BUCKET }}
-          os: ${{ matrix.os }}
 
       - name: Pull docker image
         run: |

--- a/.github/workflows/neuroconv_docker_testing.yml
+++ b/.github/workflows/neuroconv_docker_testing.yml
@@ -35,49 +35,13 @@ jobs:
           pip install pytest
           pip install .
 
-      - name: Get ephy_testing_data current head hash
-        id: ephys
-        run: echo "HASH_EPHY_DATASET=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
-      - name: Cache ephys dataset - ${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
-        uses: actions/cache@v4
-        id: cache-ephys-datasets
+      - name: Prepare data for tests
+        uses: ./.github/actions/load-data
         with:
-          path: ./ephy_testing_data
-          key: ephys-datasets-2024-08-30-${{ matrix.os }}-${{ steps.ephys.outputs.HASH_EPHY_DATASET }}
-      - name: Get ophys_testing_data current head hash
-        id: ophys
-        run: echo "HASH_OPHYS_DATASET=$(git ls-remote https://gin.g-node.org/CatalystNeuro/ophys_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
-      - name: Cache ophys dataset - ${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
-        uses: actions/cache@v4
-        id: cache-ophys-datasets
-        with:
-          path: ./ophys_testing_data
-          key: ophys-datasets-2022-08-18-${{ matrix.os }}-${{ steps.ophys.outputs.HASH_OPHYS_DATASET }}
-      - name: Get behavior_testing_data current head hash
-        id: behavior
-        run: echo "HASH_BEHAVIOR_DATASET=$(git ls-remote https://gin.g-node.org/CatalystNeuro/behavior_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
-      - name: Cache behavior dataset - ${{ steps.behavior.outputs.HASH_BEHAVIOR_DATASET }}
-        uses: actions/cache@v4
-        id: cache-behavior-datasets
-        with:
-          path: ./behavior_testing_data
-          key: behavior-datasets-2023-07-26-${{ matrix.os }}-${{ steps.behavior.outputs.HASH_behavior_DATASET }}
-
-      - if: steps.cache-ephys-datasets.outputs.cache-hit != 'true' || steps.cache-ophys-datasets.outputs.cache-hit != 'true' || steps.cache-behavior-datasets.outputs.cache-hit != 'true'
-        name: Install and configure AWS CLI
-        run: |
-          pip install awscli
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - if: steps.cache-ephys-datasets.outputs.cache-hit != 'true'
-        name: Download ephys dataset from S3
-        run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/ephy_testing_data ./ephy_testing_data
-      - if: steps.cache-ophys-datasets.outputs.cache-hit != 'true'
-        name: Download ophys dataset from S3
-        run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/ophys_testing_data ./ophys_testing_data
-      - if: steps.cache-behavior-datasets.outputs.cache-hit != 'true'
-        name: Download behavior dataset from S3
-        run: aws s3 cp --recursive ${{ secrets.S3_GIN_BUCKET }}/behavior_testing_data ./behavior_testing_data
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          s3-gin-bucket: ${{ secrets.S3_GIN_BUCKET }}
+          os: ${{ matrix.os }}
 
       - name: Pull docker image
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -151,7 +151,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           s3-gin-bucket: ${{ secrets.S3_GIN_BUCKET }}
-          os: ${{ matrix.os }}
 
       - name: Install full requirements in base environment
         run: python -m pip install ".[full]"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,6 @@ jobs:
         os: ${{ fromJson(inputs.os-versions) }}
     steps:
       - uses: actions/checkout@v4
-      - run: git fetch --prune --unshallow --tags
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -43,8 +42,6 @@ jobs:
       - name: Global Setup
         run: |
           python -m pip install -U pip  # Official recommended way
-          git config --global user.email "CI@example.com"
-          git config --global user.name "CI Almighty"
 
       - name: Install NeuroConv with minimal requirements
         run: python -m pip install "."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## Improvements
 * Add a `how to` documentation for adding extracellular electrophysiology metadata [PR #1311](https://github.com/catalystneuro/neuroconv/pull/1311)
 * Improved the docker dailies [PR #1372](https://github.com/catalystneuro/neuroconv/pull/1372)
+* Implemented cross-OS caches in GitHub Actions load-data action to enable cache sharing between Ubuntu, Windows, and macOS runners, reducing cache storage usage and improving CI efficiency [PR #1385](https://github.com/catalystneuro/neuroconv/pull/1385)
 
 # v0.7.4 (May 23, 2025)
 


### PR DESCRIPTION
This is a discussion that started on 
https://github.com/catalystneuro/neuroconv/issues/1084 and https://github.com/catalystneuro/neuroconv/issues/993

Implements cross OS caching as described by the github actions docs:
https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cross-os-cache

Which will reduce our cache usage by a factor three. This will be good to spend less on AWS downloads and also free the cache space we have so we can use it for dependency caching instead which in turn should make testing faster overall.

This is ready, To test this I erased all the caches before running this:
![image](https://github.com/user-attachments/assets/664392e0-156f-456b-b1a3-05719691804b)

And now the actions is successful recovering the data with only one cache per modality instead one cache per modality per OS as we had before.
