### PR TITLE
Remove assert array equal deprecated numpy

### DIFF
--- a/tests/test_modalities/test_ecephys/test_mock_nidq_interface.py
+++ b/tests/test_modalities/test_ecephys/test_mock_nidq_interface.py
@@ -17,7 +17,7 @@ def test_current_default_inferred_ttl_times():
     expected_ttl_times = [[1.0 * (1 + 2 * period) + 0.1 * channel for period in range(3)] for channel in range(8)]
     for channel_index, channel_name in enumerate(channel_names):
         inferred_ttl_times = interface.get_event_times_from_ttl(channel_name=channel_name)
-        assert_array_almost_equal(x=inferred_ttl_times, y=expected_ttl_times[channel_index], decimal=4)
+        assert_array_almost_equal(inferred_ttl_times, expected_ttl_times[channel_index], decimal=4)
 
 
 def test_explicit_original_default_inferred_ttl_times():
@@ -27,7 +27,7 @@ def test_explicit_original_default_inferred_ttl_times():
     expected_ttl_times = [[1.0 * (1 + 2 * period) + 0.1 * channel for period in range(3)] for channel in range(8)]
     for channel_index, channel_name in enumerate(channel_names):
         inferred_ttl_times = interface.get_event_times_from_ttl(channel_name=channel_name)
-        assert_array_almost_equal(x=inferred_ttl_times, y=expected_ttl_times[channel_index], decimal=4)
+        assert_array_almost_equal(inferred_ttl_times, expected_ttl_times[channel_index], decimal=4)
 
 
 def test_custom_inferred_ttl_times():
@@ -37,7 +37,7 @@ def test_custom_inferred_ttl_times():
     channel_names = ["nidq#XA0", "nidq#XA1", "nidq#XA2", "nidq#XA3"]
     for channel_index, channel_name in enumerate(channel_names):
         inferred_ttl_times = interface.get_event_times_from_ttl(channel_name=channel_name)
-        assert_array_almost_equal(x=inferred_ttl_times, y=custom_ttl_times[channel_index], decimal=4)
+        assert_array_almost_equal(inferred_ttl_times, custom_ttl_times[channel_index], decimal=4)
 
 
 def test_mock_metadata():

--- a/tests/test_on_data/ecephys/test_lfp.py
+++ b/tests/test_on_data/ecephys/test_lfp.py
@@ -97,7 +97,7 @@ class TestEcephysLFPNwbConversions(unittest.TestCase):
             if not isinstance(recording, BaseRecording):
                 raise ValueError("recordings of interfaces should be BaseRecording objects from spikeinterface ")
 
-            npt.assert_array_equal(x=recording.get_traces(return_scaled=False), y=nwb_lfp_unscaled)
+            npt.assert_array_equal(recording.get_traces(return_scaled=False), nwb_lfp_unscaled)
             # This can only be tested if both gain and offset are present
             if recording.has_scaleable_traces():
                 channel_conversion = nwb_lfp_electrical_series.channel_conversion
@@ -110,7 +110,7 @@ class TestEcephysLFPNwbConversions(unittest.TestCase):
                 nwb_lfp_offset = nwb_lfp_electrical_series.offset
                 recording_data_volts = recording.get_traces(return_scaled=True) * 1e-6
                 nwb_data_volts = nwb_lfp_unscaled * nwb_lfp_conversion_vector * nwb_lfp_conversion + nwb_lfp_offset
-                npt.assert_array_almost_equal(x=recording_data_volts, y=nwb_data_volts)
+                npt.assert_array_almost_equal(recording_data_volts, nwb_data_volts)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
New release of numpy, new failures (we were warned).