### PR TITLE
Fix package import check

### DIFF
--- a/src/neuroconv/tools/importing.py
+++ b/src/neuroconv/tools/importing.py
@@ -126,7 +126,7 @@ def get_package(
     if package_name in sys.modules:
         return sys.modules[package_name]
 
-    if is_package_installed(package_name=package_name) is not None:
+    if is_package_installed(package_name=package_name):
         return import_module(name=package_name)
 
     raise ModuleNotFoundError(

--- a/tests/test_minimal/test_tools/test_importing.py
+++ b/tests/test_minimal/test_tools/test_importing.py
@@ -1,6 +1,9 @@
 """Tests for neuroconv.tools.importing module."""
 
+import pytest
+
 from neuroconv import get_format_summaries
+from neuroconv.tools.importing import get_package
 
 
 def test_guide_attributes():
@@ -29,3 +32,15 @@ def test_guide_attributes():
                 ), f"{name} incorrectly specified GUIDE-related attribute 'associated_suffixes' (must be tuple)."
             if isinstance(value, tuple):
                 assert len(value) > 0, f"{name} is missing entries in GUIDE related attribute {key}."
+
+
+def test_get_package_missing():
+    package_name = "nonexistent_package_abc123"
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        get_package(package_name)
+    assert package_name in str(excinfo.value)
+
+
+def test_get_package_existing():
+    module = get_package("json")
+    assert module.__name__ == "json"


### PR DESCRIPTION
## Summary
- correct `get_package` detection of installed modules
- add tests for `get_package` behaviour

## Testing
- `ruff check .`
- `black --check tests/test_minimal/test_tools/test_importing.py src/neuroconv/tools/importing.py`
- `pytest tests/test_minimal/test_tools/test_importing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684b4bb52880832dbdd639b0e9bd5707