### PR TITLE
added copilot setup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,34 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Global Setup
+        run: |
+          python -m pip install -U pip  # Official recommended way
+
+      - name: Install NeuroConv with full testing requirements
+        run: python -m pip install ".[full,test]"
+
+      - name: Install Wine (For Plexon2 Data Tests)
+        uses: ./.github/actions/install-wine
+        with:
+          os: ubuntu-latest
+
+      - name: Prepare data for tests
+        uses: ./.github/actions/load-data
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          s3-gin-bucket: ${{ secrets.S3_GIN_BUCKET }}


### PR DESCRIPTION
This PR adds a copilot set up steps workflow that copilot will run when it initiates each PR that it makes in agent mode. 

See documentation [here](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/customizing-the-development-environment-for-copilot-coding-agent).

I need to have a version of this workflow on the main branch to test it properly, so I might need a follow-up PR to fix any bugs.