### PR TITLE
Use PEP 735 dependency groups

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,7 +19,10 @@ jobs:
           python -m pip install -U pip  # Official recommended way
 
       - name: Install NeuroConv with full testing requirements
-        run: python -m pip install ".[full,test,docs]"
+        run: |
+          python -m pip install ".[full]"
+          python -m pip install --group test
+          python -m pip install --group docs
 
       - name: Install Wine (For Plexon2 Data Tests)
         uses: ./.github/actions/install-wine
@@ -28,7 +31,7 @@ jobs:
 
       - name: Install pre-commit hooks
         run: |
-          python -m pip install pre-commit
+          python -m pip install --group dev
           pre-commit install --install-hooks
 
       - name: Prepare data for tests

--- a/.github/workflows/dev-testing.yml
+++ b/.github/workflows/dev-testing.yml
@@ -53,7 +53,9 @@ jobs:
           os: ${{ runner.os }}
 
       - name: Install full requirements
-        run: pip install --no-cache-dir .[full,test]
+        run: |
+          pip install --no-cache-dir .[full]
+          pip install --group test
 
       - name: Dev gallery - ROIExtractors
         run: pip install --no-cache-dir git+https://github.com/CatalystNeuro/roiextractors@main

--- a/.github/workflows/formatwise-installation-testing.yml
+++ b/.github/workflows/formatwise-installation-testing.yml
@@ -125,7 +125,8 @@ jobs:
             fi
 
             # Install dependencies with uv (much faster than pip)
-            uv pip install --quiet ".[test,$name]"
+            uv pip install --quiet ".[$name]"
+            uv pip install --group test
 
             # Check if the gallery file exists before running pytest
             gallery_file="docs/conversion_examples_gallery/$type/$name.rst"

--- a/.github/workflows/live-service-testing.yml
+++ b/.github/workflows/live-service-testing.yml
@@ -48,7 +48,9 @@ jobs:
           python -m pip install -U pip  # Official recommended way
 
       - name: Install test requirements
-        run: pip install ".[test,dandi,spikeglx,phy]"
+        run: |
+          pip install ".[dandi,spikeglx,phy]"
+          pip install --group test
 
       - name: Prepare data for tests
         uses: ./.github/actions/load-data

--- a/.github/workflows/test-external-links.yml
+++ b/.github/workflows/test-external-links.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install package for API docs
-        run: pip install .[docs]
+        run: |
+          pip install .
+          pip install --group docs
       - name: Test External Links
         run: sphinx-build -b linkcheck ./docs ./docs/_build/

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -55,7 +55,9 @@ jobs:
 
 
       - name: Install NeuroConv with testing requirements
-        run: python -m pip install ".[test]"
+        run: |
+          python -m pip install "."
+          python -m pip install --group test
       - name: Run import tests
         run: |
           pytest tests/imports.py::TestImportStructure::test_top_level
@@ -77,7 +79,8 @@ jobs:
             source env_ecephys/bin/activate
           fi
           python -m pip install -U pip
-          python -m pip install ".[test,ecephys_minimal,sorting_analyzer]"  # we test the sorting analyzer here so we need its dependencies
+          python -m pip install ".[ecephys_minimal,sorting_analyzer]"  # we test the sorting analyzer here so we need its dependencies
+          python -m pip install --group test
           python -m pytest tests/test_modalities/test_ecephys -vv -rsx -n auto --dist loadscope
           if [ "${{ runner.os }}" == "Windows" ]; then
             deactivate
@@ -97,7 +100,8 @@ jobs:
             source env_ophys/bin/activate
           fi
           python -m pip install -U pip
-          python -m pip install ".[test,ophys_minimal]"
+          python -m pip install ".[ophys_minimal]"
+          python -m pip install --group test
           python -m pytest tests/test_modalities/test_ophys -vv -rsx -n auto --dist loadscope
           if [ "${{ runner.os }}" == "Windows" ]; then
             deactivate
@@ -117,7 +121,8 @@ jobs:
             source env_fiber_photometry/bin/activate
           fi
           python -m pip install -U pip
-          python -m pip install ".[test,fiber_photometry]"
+          python -m pip install ".[fiber_photometry]"
+          python -m pip install --group test
           python -m pytest tests/test_modalities/test_fiber_photometry -vv -rsx -n auto --dist loadscope
           if [ "${{ runner.os }}" == "Windows" ]; then
             deactivate
@@ -137,7 +142,8 @@ jobs:
             source env_behavior/bin/activate
           fi
           python -m pip install -U pip
-          python -m pip install ".[test,behavior]"
+          python -m pip install ".[behavior]"
+          python -m pip install --group test
           python -m pytest tests/test_modalities/test_behavior -vv -rsx -n auto --dist loadscope
           if [ "${{ runner.os }}" == "Windows" ]; then
             deactivate

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,7 @@ build:
     python: "3.13"
   jobs:
     install:
+      - pip install -U pip  # Official recommended way
       - pip install .
       - pip install --group docs
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,18 +6,14 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.13"
+  jobs:
+    install:
+      - pip install .
+      - pip install --group docs
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
-
-# Python requirements required to build your docs
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ## Improvements
 * Added comprehensive FFmpeg video conversion how-to guide for converting bespoke video formats to DANDI-compatible formats [PR #1426](https://github.com/catalystneuro/neuroconv/pull/1426)
+* Implemented PEP 735 dependency groups for test, docs, and dev dependencies [PR #1434](https://github.com/catalystneuro/neuroconv/pull/1434)
 
 # v0.7.5 (June 11, 2025)
 

--- a/docs/developer_guide/building_documentation.rst
+++ b/docs/developer_guide/building_documentation.rst
@@ -10,7 +10,8 @@ First, create a clean environment and type the following commands in your termin
 
   git clone https://github.com/catalystneuro/neuroconv
   cd neuroconv
-  pip install --editable .[docs]
+  pip install --editable .
+  pip install --group docs
 
 These commands install both the latest version of the repo and the dependencies necessary to build the documentation.
 

--- a/docs/developer_guide/testing_suite.rst
+++ b/docs/developer_guide/testing_suite.rst
@@ -30,7 +30,8 @@ Then install all required and optional dependencies in a fresh environment.
 
 .. code:: bash
 
-  pip install --editable ".[test,full]"
+  pip install --editable ".[full]"
+  pip install --group test
 
 
 Then simply run all tests with pytest
@@ -51,7 +52,7 @@ These test internal functionality using only minimal dependencies or pre-downloa
 
 Sub-folders: `tests/test_minimal <https://github.com/catalystneuro/neuroconv/tree/main/tests/test_minimal>`_
 
-These can be run using only ``pip install --editable ".[test]"`` and calling ``pytest tests/test_minimal``
+These can be run using only ``pip install --editable "."``, ``pip install --group test`` and calling ``pytest tests/test_minimal``
 
 
 Modality Tests
@@ -69,7 +70,7 @@ Modalities:
 * `behavior <https://github.com/catalystneuro/neuroconv/tree/main/tests/test_modalities/test_behavior>`_
 * `text <https://github.com/catalystneuro/neuroconv/tree/main/tests/test_modalities/test_text>`_
 
-These can be run in isolation using ``pip install --editable ".[test,<modality>]"`` and calling
+These can be run in isolation using ``pip install --editable ".[<modality>]"``, ``pip install --group test`` and calling
 ``pytest tests/test_modalities/test_<modality>`` where ``<modality>`` can be any of ``ophys``, ``fiber_photometry``, ``ecephys``, ``image``, ``text``, or ``behavior``.
 
 Ideally, these tests should not require data and run in mock testing interfaces but there are exceptions.
@@ -119,7 +120,7 @@ running. To examine these files for quality assessment purposes, set the flag ``
 
 Sub-folders: `tests/test_on_data <https://github.com/catalystneuro/neuroconv/tree/main/tests/test_on_data>`_
 
-These can be run in total using ``pip install --editable ".[test,full]"`` and calling ``pytest tests/test_on_data`` or
+These can be run in total using ``pip install --editable ".[full]"``, ``pip install --group test`` and calling ``pytest tests/test_on_data`` or
 in isolation by installing the required ``<modality>`` as in the previous section and calling
 ``pytest tests/test_on_data/<modality>``.
 
@@ -159,7 +160,8 @@ Since these tests are not automatically collected, you need to run them explicit
 .. code:: bash
 
     # Install required dependencies
-    pip install --editable ".[test,aws]"
+    pip install --editable ".[aws]"
+    pip install --group test
 
     # Run specific service tests
     pytest tests/remote_transfer_services/dandi_transfer_tools.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,26 +66,8 @@ dependencies = [
 neuroconv = "neuroconv.tools.yaml_conversion_specification._yaml_conversion_specification:run_conversion_from_yaml_cli"
 
 [project.optional-dependencies]
-test = [
-    "pytest",
-    "pytest-cov",
-    "parameterized>=0.8.1",
-    "pytest-xdist"  # Runs tests on parallel
-]
 sorting_analyzer = [   # These dependencies are for testing the sorting analyzer tool
     "scipy",
-]
-
-
-docs = [
-    "Sphinx==8.2.3",  # Latest as of April 2025.
-    "readthedocs-sphinx-search==0.1.2",  # Deprecated, probably should be removed see https://github.com/readthedocs/readthedocs-sphinx-search/issues/144
-    "sphinx-toggleprompt==0.6.0",  # Latest as of April 2025.
-    "sphinx-copybutton==0.5.2",  # Latest as of April 2025.
-    "pydata_sphinx_theme==0.16.1",  # Latest as of April 2025.
-    "roiextractors",  # Needed for the API documentation
-    "spikeinterface>=0.102.2",  # Needed for the API documentation
-    "pytest" # used to build the documentation for tools.testing
 ]
 
 dandi = ["dandi>=0.69"]
@@ -456,3 +438,26 @@ known-first-party = ["neuroconv"]
 skip = '.git*,*.pdf,*.css,*.svg'
 check-hidden = true
 ignore-words-list = 'assertin'
+
+[dependency-groups]
+test = [
+    "pytest",
+    "pytest-cov",
+    "parameterized>=0.8.1",
+    "pytest-xdist"  # Runs tests on parallel
+]
+
+docs = [
+    "Sphinx==8.2.3",  # Latest as of April 2025.
+    "readthedocs-sphinx-search==0.1.2",  # Deprecated, probably should be removed see https://github.com/readthedocs/readthedocs-sphinx-search/issues/144
+    "sphinx-toggleprompt==0.6.0",  # Latest as of April 2025.
+    "sphinx-copybutton==0.5.2",  # Latest as of April 2025.
+    "pydata_sphinx_theme==0.16.1",  # Latest as of April 2025.
+    "roiextractors",  # Needed for the API documentation
+    "spikeinterface>=0.102.2",  # Needed for the API documentation
+    "pytest" # used to build the documentation for tools.testing
+]
+
+dev = [
+    "pre-commit",
+]


### PR DESCRIPTION
This should fix [issue #1366](https://github.com/catalystneuro/neuroconv/issues/1366).

I’ve been encountering dependency issues when trying to install neuroconv and solve the full installation. The problem is that the documentation dependencies are pinned to very specific versions (as they probably should be for reproducibility of the documentation style), but since they’re defined as extras, the package manager tries to resolve them and fails.

Fortunately, PEP 735 offers a clear solution by excluding these from the extras as dependency groups.

More concretely, this change reorganizes the testing, documentation, and development dependencies from [project.optional-dependencies] format into the new standardized [dependency-groups] section. Specifically, the test, docs, and dev (including pre-commit) dependencies are now defined as dependency groups, while domain-specific extras like ecephys, ophys, and behavior remain as extras dependencies.