### PR TITLE
feat: Add Context7 integration configuration

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "https://context7.com/schema/context7.json",
+  
+    "projectTitle": "NeuroConv",
+    "description": "Convert 40+ neurophysiology data formats to NWB with automatic metadata extraction.",
+  
+    "folders": [
+      "docs/"
+    ],
+  
+    "excludeFolders": [
+      "src/",
+      "tests/",
+      "dockerfiles/",
+      ".github/",
+      ".venv/",
+      "build/",
+      "dist/",
+      "docs/_build/",
+      "docs/_static/"
+    ],
+  
+    "excludeFiles": [
+      "CHANGELOG.md",
+      "license.txt",
+      "MANIFEST.in",
+      "pyproject.toml",
+      "CITATION.cff",
+      "codecov.yml"
+    ],
+  
+    "rules": [
+      "Always use the data‑specific interface that matches your file format (e.g., SpikeGLXRecordingInterface for SpikeGLX).",
+      "Install optional extras with pip install \"neuroconv[format_name]\" when working with proprietary formats.",
+      "Combine multiple streams with NWBConverter to preserve temporal alignment.",
+      "Call get_metadata() and enrich the returned dict before running conversion.",
+      "Use run_conversion() with backend compression settings for large recordings.",
+      "Leverage chunking options to keep NWB files manageable.",
+      "Run check_read() on every interface before conversion to catch I/O issues early.",
+      "Prefer YAML conversion specifications for repeatable batch jobs.",
+      "Align timestamps from separate devices using set_aligned_timestamps().",
+      "Validate final NWB files with pynwb.validate() and the NWB NeurodataValidator."
+    ],
+  
+    "previousVersions": [
+      { "tag": "v0.7.5", "title": "version 0.7.5" },
+      { "tag": "v0.7.4", "title": "version 0.7.4" },
+      { "tag": "v0.7.3", "title": "version 0.7.3" },
+      { "tag": "v0.7.2", "title": "version 0.7.2" },
+      { "tag": "v0.7.1", "title": "version 0.7.1" },
+      { "tag": "v0.7.0", "title": "version 0.7.0" },
+      { "tag": "v0.6.7", "title": "version 0.6.7" }
+    ]
+  }

--- a/context7.json
+++ b/context7.json
@@ -1,13 +1,13 @@
 {
     "$schema": "https://context7.com/schema/context7.json",
-  
+
     "projectTitle": "NeuroConv",
     "description": "Convert 40+ neurophysiology data formats to NWB with automatic metadata extraction.",
-  
+
     "folders": [
       "docs/"
     ],
-  
+
     "excludeFolders": [
       "src/",
       "tests/",
@@ -19,7 +19,7 @@
       "docs/_build/",
       "docs/_static/"
     ],
-  
+
     "excludeFiles": [
       "CHANGELOG.md",
       "license.txt",
@@ -28,7 +28,7 @@
       "CITATION.cff",
       "codecov.yml"
     ],
-  
+
     "rules": [
       "Always use the data‑specific interface that matches your file format (e.g., SpikeGLXRecordingInterface for SpikeGLX).",
       "Install optional extras with pip install \"neuroconv[format_name]\" when working with proprietary formats.",
@@ -41,7 +41,7 @@
       "Align timestamps from separate devices using set_aligned_timestamps().",
       "Validate final NWB files with pynwb.validate() and the NWB NeurodataValidator."
     ],
-  
+
     "previousVersions": [
       { "tag": "v0.7.5", "title": "version 0.7.5" },
       { "tag": "v0.7.4", "title": "version 0.7.4" },


### PR DESCRIPTION
## Add Context7 Configuration for NeuroConv

This pull request adds **first‑class Context7 support** for NeuroConv so that AI coding assistants (Cursor, Copilot Chat, Zed, etc.) can access version‑specific conversion guidance directly in prompts.

### Benefits for users
* **Accurate version-specific code examples** – agents retrieve *current* NeuroConv APIs instead of hallucinating.
* **Format‑aware recommendations** – rules instruct models to pick the right `*Interface` and to validate with `check_read()`.
* **Reproducibility** – version history lets downstream projects pin documentation to a specific tag.


### Details on the approach

I have tried to follow the best practices outlined in [their document](https://github.com/upstash/context7/blob/master/docs/adding-projects.md) for guiding this. Some of the highlights are:

| Item | Purpose |
|------|---------|
| **`context7.json`** | Using this config file in the project source helps to control and optimize how the MCP server provides help for Neuroconv |
| **Docs‑only crawl** | Source code, tests, CI files, and build artefacts are excluded, keeping responses focused and fast. |
| **Schema validation** | The `$schema` key enables auto‑completion in IDEs and guarantees the file adheres to the Context7 JSON‑Schema. |
