### PR TITLE
Add GeneralTiffImagingInterface for MultiTiffMultiPageExtractor

### DIFF
--- a/src/neuroconv/datainterfaces/ophys/tiff/tiffdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/tiff/tiffdatainterface.py
@@ -73,7 +73,6 @@ class GeneralTiffImagingInterface(BaseImagingExtractorInterface):
             num_acquisition_cycles=num_acquisition_cycles,
             verbose=verbose,
         )
-        self.imaging_extractor.get_num_channels = lambda: 1
 
     def get_metadata(self) -> dict:
         return super().get_metadata()


### PR DESCRIPTION
A more general `tiff` interface that utilizes the new `roiextractors.MultiTIFFMultiPageExtractor` from https://github.com/catalystneuro/roiextractors/pull/402

