### PR TITLE
Add documentation and tests for set probe in recording interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 * Added `images_container_metadata_key` parameter to `ImageInterface` to allow custom naming and organization of image containers in NWB files. This enables multiple image interfaces to coexist with distinct container names. [PR #1439](https://github.com/catalystneuro/neuroconv/pull/1439)
 * Added per-image metadata support to `ImageInterface` allowing users to specify individual `resolution` (pixels/cm), name and `description` for each image through metadata structure. [PR #1441](https://github.com/catalystneuro/neuroconv/pull/1441)
 * Added `rename_unit_ids()` method to `BaseSortingExtractorInterface` for dictionary-based unit ID renaming, enabling clean handling of multiple sorting interfaces with overlapping unit IDs [PR #1451](https://github.com/catalystneuro/neuroconv/pull/1451)
+* Added support for setting ProbeGroup objects in `BaseRecordingExtractorInterface.set_probe()` method[PR #1464](https://github.com/catalystneuro/neuroconv/pull/1464)
+* Added comprehensive tests for `set_probe` method in `BaseRecordingExtractorInterface` to verify probe and probe group functionality with proper electrode group organization in NWB files [PR #1464](https://github.com/catalystneuro/neuroconv/pull/1464)
 
 ## Improvements
 * Added comprehensive FFmpeg video conversion how-to guide for converting bespoke video formats to DANDI-compatible formats [PR #1426](https://github.com/catalystneuro/neuroconv/pull/1426)

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -234,18 +234,27 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
             ]
             self.set_aligned_segment_timestamps(aligned_segment_timestamps=aligned_segment_timestamps)
 
-    def set_probe(self, probe, group_mode: Literal["by_shank", "by_probe"]):
+    def set_probe(self, probe: "Probe | ProbeGroup", group_mode: Literal["by_shank", "by_probe"]):
         """
         Set the probe information via a ProbeInterface object.
 
         Parameters
         ----------
-        probe : probeinterface.Probe
-            The probe object.
+        probe : probeinterface.Probe or probeinterface.ProbeGroup
+            The probe object(s). Can be a single Probe or a ProbeGroup containing multiple probes.
         group_mode : {'by_shank', 'by_probe'}
-            How to group the channels. If 'by_shank', channels are grouped by the shank_id column.
-            If 'by_probe', channels are grouped by the probe_id column.
-            This is a required parameter to avoid the pitfall of using the wrong mode.
+            How to group the channels for electrode group assignment in the NWB file:
+
+            - 'by_probe': Each probe becomes a separate electrode group. For a ProbeGroup with
+            multiple probes, each probe gets its own group (group 0, 1, 2, etc.). For a single
+            probe, all channels are assigned to group 0.
+
+            - 'by_shank': Each unique combination of probe and shank becomes a separate electrode
+            group. Requires that shank_ids are defined for all probes. Groups are assigned
+            sequentially for each unique (probe_index, shank_id) pair.
+
+            The resulting groups determine how electrode groups and electrodes are organized
+            in the NWB file, with each group corresponding to one ElectrodeGroup.
         """
         # Set the probe to the recording extractor
         self.recording_extractor._set_probes(
@@ -253,8 +262,10 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
             in_place=True,
             group_mode=group_mode,
         )
+
         # Spike interface sets the "group" property
         # But neuroconv allows "group_name" property to override spike interface "group" value
+        # So we re-set this here to avoid a conflict
         self.recording_extractor.set_property("group_name", self.recording_extractor.get_property("group").astype(str))
 
     def has_probe(self) -> bool:

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -437,7 +437,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
             # The NwbRecordingExtractor on spikeinterface experiences an issue when duplicated channel_ids
             # are specified, which occurs during check_recordings_equal when there is only one channel
             if self.nwb_recording.get_channel_ids()[0] != self.nwb_recording.get_channel_ids()[-1]:
-                check_recordings_equal(RX1=recording, RX2=self.nwb_recording, return_scaled=False)
+                check_recordings_equal(RX1=recording, RX2=self.nwb_recording, return_in_uV=False)
 
                 # This was added to test probe, we should just compare the probes
                 for property_name in ["rel_x", "rel_y", "rel_z"]:
@@ -449,7 +449,7 @@ class RecordingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlign
                             recording.get_property(property_name), self.nwb_recording.get_property(property_name)
                         )
                 if recording.has_scaleable_traces() and self.nwb_recording.has_scaleable_traces():
-                    check_recordings_equal(RX1=recording, RX2=self.nwb_recording, return_scaled=True)
+                    check_recordings_equal(RX1=recording, RX2=self.nwb_recording, return_in_uV=True)
 
             # Compare channel groups
             # Neuroconv ALWAYS writes a string property `group_name` to the electrode table.


### PR DESCRIPTION
This will close #1444.

In, https://github.com/catalystneuro/neuroconv/pull/1464, support to pobe groups was added but I realized that we don't really have good documentation or tests of this feature. 

This takes care of both.
