### PR TITLE
Add chatbot to docs (side panel) 

### DIFF
--- a/docs/_static/css/neuroconv_assistant.css
+++ b/docs/_static/css/neuroconv_assistant.css
@@ -1,0 +1,212 @@
+/* NeuroConv Assistant Chatbot Styles */
+/* Adapted from PyNWB assistant for pydata_sphinx_theme */
+
+/* Accordion-style assistant toggle tab */
+.assistant-toggle {
+    position: fixed;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 1001;
+    padding: 12px 8px;
+    background-color: #2980b9;
+    color: white;
+    border: none;
+    border-radius: 8px 0 0 8px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: bold;
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
+    box-shadow: -2px 0 5px rgba(0,0,0,0.2);
+    transition: background-color 0.3s ease-in-out, transform 0.3s ease-in-out, right 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+    min-height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.assistant-toggle:hover {
+    background-color: #3498db;
+    transform: translateY(-50%) translateX(-2px);
+    box-shadow: -4px 0 8px rgba(0,0,0,0.3);
+}
+
+/* Change tab appearance when assistant is open */
+.assistant-container.show ~ .assistant-toggle {
+    background-color: #e74c3c;
+    right: 400px;
+}
+
+.assistant-container.show ~ .assistant-toggle {
+    font-size: 0; /* Hide original text */
+}
+
+.assistant-container.show ~ .assistant-toggle::before {
+    content: "Close Assistant";
+    font-size: 14px; /* Restore font size for the pseudo-element */
+}
+
+.assistant-container.show ~ .assistant-toggle:hover {
+    background-color: #c0392b;
+}
+
+.assistant-container {
+    position: fixed;
+    right: 0;
+    top: 0;
+    width: 0;
+    height: 100vh;
+    z-index: 1000;
+    background: white;
+    border-left: 1px solid #ddd;
+    box-shadow: -2px 0 10px rgba(0,0,0,0.1);
+    transition: width 0.3s ease-in-out;
+    overflow: hidden;
+}
+
+.assistant-container.show {
+    width: 400px;
+}
+
+.assistant-iframe {
+    width: 400px;
+    height: 100%;
+    border: none;
+    background: white;
+}
+
+/* Add close button inside the assistant */
+.assistant-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: #e74c3c;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    cursor: pointer;
+    font-size: 18px;
+    line-height: 1;
+    z-index: 1002;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.assistant-close:hover {
+    background: #c0392b;
+}
+
+/* Adjust main content when assistant is open */
+/* Note: pydata_sphinx_theme uses different class structure than sphinx_rtd_theme */
+.bd-main {
+    transition: margin-right 0.3s ease-in-out;
+}
+
+.assistant-container.show ~ .bd-main {
+    margin-right: 400px;
+}
+
+/* Alternative selectors for pydata_sphinx_theme */
+main.bd-main,
+.bd-content {
+    transition: margin-right 0.3s ease-in-out;
+}
+
+.assistant-container.show ~ main.bd-main,
+.assistant-container.show ~ .bd-content {
+    margin-right: 400px;
+}
+
+/* Tablet and medium screens */
+@media (max-width: 1200px) and (min-width: 768px) {
+    .assistant-container.show {
+        width: 350px;
+    }
+
+    .assistant-iframe {
+        width: 350px;
+    }
+
+    .assistant-container.show ~ .bd-main,
+    .assistant-container.show ~ main.bd-main,
+    .assistant-container.show ~ .bd-content {
+        margin-right: 350px;
+    }
+
+    .assistant-container.show ~ .assistant-toggle {
+        right: 350px;
+    }
+}
+
+/* Mobile devices - full overlay */
+@media (max-width: 767px) {
+    .assistant-toggle {
+        right: 10px;
+        top: 20px;
+        transform: none;
+        writing-mode: horizontal-tb;
+        text-orientation: unset;
+        border-radius: 4px;
+        padding: 8px 12px;
+        min-height: auto;
+    }
+
+    .assistant-toggle:hover {
+        transform: translateX(-2px);
+    }
+
+    .assistant-container.show ~ .assistant-toggle {
+        position: fixed;
+        right: 10px;
+        top: 20px;
+        transform: none;
+        z-index: 1003;
+    }
+
+    .assistant-container {
+        width: 0;
+        border-left: none;
+    }
+
+    .assistant-container.show {
+        width: 100vw;
+    }
+
+    .assistant-iframe {
+        width: 100vw;
+    }
+
+    .assistant-container.show ~ .bd-main,
+    .assistant-container.show ~ main.bd-main,
+    .assistant-container.show ~ .bd-content {
+        margin-right: 0;
+    }
+}
+
+/* For very large screens, use more space */
+@media (min-width: 1400px) {
+    .assistant-container.show {
+        width: calc(100vw - 1140px);
+        max-width: 600px;
+    }
+
+    .assistant-iframe {
+        width: calc(100vw - 1140px);
+        max-width: 600px;
+    }
+
+    .assistant-container.show ~ .bd-main,
+    .assistant-container.show ~ main.bd-main,
+    .assistant-container.show ~ .bd-content {
+        margin-right: calc(100vw - 1140px);
+    }
+
+    .assistant-container.show ~ .assistant-toggle {
+        right: calc(100vw - 1140px);
+        max-right: 600px;
+    }
+}

--- a/docs/_static/js/neuroconv_assistant.js
+++ b/docs/_static/js/neuroconv_assistant.js
@@ -1,0 +1,42 @@
+/**
+ * NeuroConv Assistant Chatbot
+ * Dynamically injects the NWB Assistant chatbot into every documentation page
+ */
+
+// document is the whole html, we adda an event listener that fires
+// when the HTML is fully loaded and parsed (i.e. DOMContentLoaded)
+document.addEventListener('DOMContentLoaded', function() {
+
+    const container = document.createElement('div');
+    // we give it a name to style it in css
+    container.className = 'assistant-container';
+
+    // Create the iframe for the chatbot
+    const iframe = document.createElement('iframe');
+    iframe.className = 'assistant-iframe';
+    container.appendChild(iframe);
+
+    // Create the toggle button
+    const toggle = document.createElement('button');
+    toggle.className = 'assistant-toggle';
+    toggle.textContent = 'Open Chat Assistant';
+
+    // Append elements to the body
+    document.body.appendChild(container);
+    document.body.appendChild(toggle);
+
+    // Track whether iframe has been loaded
+    let iframeLoaded = false;
+
+    // Add click event handler for the toggle button
+    toggle.addEventListener('click', function() {
+        const isShowing = container.classList.toggle('show');
+
+        // Load iframe content only when first opened for performance
+        if (isShowing && !iframeLoaded) {
+            // I think the loading happens here
+            iframe.src = 'https://magland.github.io/nwb-assistant/chat';
+            iframeLoaded = true;
+        }
+    });
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,9 +32,10 @@ html_static_path = ["_static"]
 html_favicon = "_static/favicon.ico"
 
 # These paths are either relative to html_static_path or fully qualified paths (eg. https://...)
-# html_css_files = [
-#     "css/custom.css",
-# ]
+html_css_files = [
+    "css/custom.css",
+    "css/neuroconv_assistant.css",
+]
 
 html_context = {
     # "github_url": "https://github.com", # or your GitHub Enterprise site

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,10 @@ html_css_files = [
     "css/neuroconv_assistant.css",
 ]
 
+html_js_files = [
+    "js/neuroconv_assistant.js",
+]
+
 html_context = {
     # "github_url": "https://github.com", # or your GitHub Enterprise site
     "github_user": "catalystneuro",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,31 @@ Features:
 * Minimizes the size of the NWB files by automatically applying chunking and lossless compression.
 * Supports ensembles of multiple data streams, and supports common methods for temporal alignment of streams.
 
+.. raw:: html
+
+   <div class="assistant-container">
+     <iframe class="assistant-iframe"></iframe>
+   </div>
+   <button class="assistant-toggle">Open Assistant</button>
+   <script>
+     document.addEventListener('DOMContentLoaded', function() {
+       const toggle = document.querySelector('.assistant-toggle');
+       const container = document.querySelector('.assistant-container');
+       const iframe = document.querySelector('.assistant-iframe');
+       let iframeLoaded = false;
+
+       toggle.addEventListener('click', function() {
+         const isShowing = container.classList.toggle('show');
+
+         // Load iframe content only when first opened
+         if (isShowing && !iframeLoaded) {
+           iframe.src = 'https://magland.github.io/nwb-assistant/chat';
+           iframeLoaded = true;
+         }
+       });
+     });
+   </script>
+
 Installation
 ------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,31 +19,6 @@ Features:
 * Minimizes the size of the NWB files by automatically applying chunking and lossless compression.
 * Supports ensembles of multiple data streams, and supports common methods for temporal alignment of streams.
 
-.. raw:: html
-
-   <div class="assistant-container">
-     <iframe class="assistant-iframe"></iframe>
-   </div>
-   <button class="assistant-toggle">Open Assistant</button>
-   <script>
-     document.addEventListener('DOMContentLoaded', function() {
-       const toggle = document.querySelector('.assistant-toggle');
-       const container = document.querySelector('.assistant-container');
-       const iframe = document.querySelector('.assistant-iframe');
-       let iframeLoaded = false;
-
-       toggle.addEventListener('click', function() {
-         const isShowing = container.classList.toggle('show');
-
-         // Load iframe content only when first opened
-         if (isShowing && !iframeLoaded) {
-           iframe.src = 'https://magland.github.io/nwb-assistant/chat';
-           iframeLoaded = true;
-         }
-       });
-     });
-   </script>
-
 Installation
 ------------
 


### PR DESCRIPTION
This PR adds the chatbot currently used in the `pynwb` documentation to `neuroconv`. You can see it in action in the build here:  
<https://neuroconv--1474.org.readthedocs.build/en/1474/>  

Compared to the `pynwb` documentation, one improvement is that the chatbot now appears on **all pages**, rather than being limited to the index page.  

This is done by using a [Sphinx hook](https://docs.readthedocs.com/platform/stable/guides/adding-custom-css.html) that allows us to inject JavaScript code across the site. With this hook, the implementation remains relatively simple.  

One problem with the current approach is that it does not have content persistency when users navigate the documentation (that is, if you click in another section of the documentation the chatbot content rests). An approach to solve this is outlined in #1476.

There are still some UX/design details to refine. For example, on very wide screens the button is pushed too far away from the main content:  

<img width="2404" height="1255" alt="image" src="https://github.com/user-attachments/assets/aba9b9d5-b422-40a0-9204-2d0d2175c190" />  

When the window is resized closer to common display widths, the layout issue resolves:  

<img width="1371" height="1388" alt="image" src="https://github.com/user-attachments/assets/4fb3abd6-2207-4b56-b33f-f4e2507667fe" />  

Rather than fixing these alignment details now, I suggest we first decide whether we want to continue with this anchored approach as a side panel or move toward the alternative discussed in #1476. That choice will likely affect how much effort we should put into polishing the layout itself. 
