### PR TITLE
Add chatbot to docs (external window)

### DIFF
--- a/docs/_static/css/neuroconv_assistant.css
+++ b/docs/_static/css/neuroconv_assistant.css
@@ -1,0 +1,212 @@
+/* NeuroConv Assistant Chatbot Styles */
+/* Adapted from PyNWB assistant for pydata_sphinx_theme */
+
+/* Accordion-style assistant toggle tab */
+.assistant-toggle {
+    position: fixed;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 1001;
+    padding: 12px 8px;
+    background-color: #2980b9;
+    color: white;
+    border: none;
+    border-radius: 8px 0 0 8px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: bold;
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
+    box-shadow: -2px 0 5px rgba(0,0,0,0.2);
+    transition: background-color 0.3s ease-in-out, transform 0.3s ease-in-out, right 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+    min-height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.assistant-toggle:hover {
+    background-color: #3498db;
+    transform: translateY(-50%) translateX(-2px);
+    box-shadow: -4px 0 8px rgba(0,0,0,0.3);
+}
+
+/* Change tab appearance when assistant is open */
+.assistant-container.show ~ .assistant-toggle {
+    background-color: #e74c3c;
+    right: 400px;
+}
+
+.assistant-container.show ~ .assistant-toggle {
+    font-size: 0; /* Hide original text */
+}
+
+.assistant-container.show ~ .assistant-toggle::before {
+    content: "Close Assistant";
+    font-size: 14px; /* Restore font size for the pseudo-element */
+}
+
+.assistant-container.show ~ .assistant-toggle:hover {
+    background-color: #c0392b;
+}
+
+.assistant-container {
+    position: fixed;
+    right: 0;
+    top: 0;
+    width: 0;
+    height: 100vh;
+    z-index: 1000;
+    background: white;
+    border-left: 1px solid #ddd;
+    box-shadow: -2px 0 10px rgba(0,0,0,0.1);
+    transition: width 0.3s ease-in-out;
+    overflow: hidden;
+}
+
+.assistant-container.show {
+    width: 400px;
+}
+
+.assistant-iframe {
+    width: 400px;
+    height: 100%;
+    border: none;
+    background: white;
+}
+
+/* Add close button inside the assistant */
+.assistant-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: #e74c3c;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    cursor: pointer;
+    font-size: 18px;
+    line-height: 1;
+    z-index: 1002;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.assistant-close:hover {
+    background: #c0392b;
+}
+
+/* Adjust main content when assistant is open */
+/* Note: pydata_sphinx_theme uses different class structure than sphinx_rtd_theme */
+.bd-main {
+    transition: margin-right 0.3s ease-in-out;
+}
+
+.assistant-container.show ~ .bd-main {
+    margin-right: 400px;
+}
+
+/* Alternative selectors for pydata_sphinx_theme */
+main.bd-main,
+.bd-content {
+    transition: margin-right 0.3s ease-in-out;
+}
+
+.assistant-container.show ~ main.bd-main,
+.assistant-container.show ~ .bd-content {
+    margin-right: 400px;
+}
+
+/* Tablet and medium screens */
+@media (max-width: 1200px) and (min-width: 768px) {
+    .assistant-container.show {
+        width: 350px;
+    }
+
+    .assistant-iframe {
+        width: 350px;
+    }
+
+    .assistant-container.show ~ .bd-main,
+    .assistant-container.show ~ main.bd-main,
+    .assistant-container.show ~ .bd-content {
+        margin-right: 350px;
+    }
+
+    .assistant-container.show ~ .assistant-toggle {
+        right: 350px;
+    }
+}
+
+/* Mobile devices - full overlay */
+@media (max-width: 767px) {
+    .assistant-toggle {
+        right: 10px;
+        top: 20px;
+        transform: none;
+        writing-mode: horizontal-tb;
+        text-orientation: unset;
+        border-radius: 4px;
+        padding: 8px 12px;
+        min-height: auto;
+    }
+
+    .assistant-toggle:hover {
+        transform: translateX(-2px);
+    }
+
+    .assistant-container.show ~ .assistant-toggle {
+        position: fixed;
+        right: 10px;
+        top: 20px;
+        transform: none;
+        z-index: 1003;
+    }
+
+    .assistant-container {
+        width: 0;
+        border-left: none;
+    }
+
+    .assistant-container.show {
+        width: 100vw;
+    }
+
+    .assistant-iframe {
+        width: 100vw;
+    }
+
+    .assistant-container.show ~ .bd-main,
+    .assistant-container.show ~ main.bd-main,
+    .assistant-container.show ~ .bd-content {
+        margin-right: 0;
+    }
+}
+
+/* For very large screens, use more space */
+@media (min-width: 1400px) {
+    .assistant-container.show {
+        width: calc(100vw - 1140px);
+        max-width: 600px;
+    }
+
+    .assistant-iframe {
+        width: calc(100vw - 1140px);
+        max-width: 600px;
+    }
+
+    .assistant-container.show ~ .bd-main,
+    .assistant-container.show ~ main.bd-main,
+    .assistant-container.show ~ .bd-content {
+        margin-right: calc(100vw - 1140px);
+    }
+
+    .assistant-container.show ~ .assistant-toggle {
+        right: calc(100vw - 1140px);
+        max-right: 600px;
+    }
+}

--- a/docs/_static/css/neuroconv_assistant.css
+++ b/docs/_static/css/neuroconv_assistant.css
@@ -1,7 +1,7 @@
 /* NeuroConv Assistant Chatbot Styles */
-/* Adapted from PyNWB assistant for pydata_sphinx_theme */
+/* Popup window approach - only button styling needed */
 
-/* Accordion-style assistant toggle tab */
+/* Assistant toggle button - fixed position on right side */
 .assistant-toggle {
     position: fixed;
     right: 0;
@@ -19,7 +19,7 @@
     writing-mode: vertical-rl;
     text-orientation: mixed;
     box-shadow: -2px 0 5px rgba(0,0,0,0.2);
-    transition: background-color 0.3s ease-in-out, transform 0.3s ease-in-out, right 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+    transition: background-color 0.3s ease-in-out, transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
     min-height: 80px;
     display: flex;
     align-items: center;
@@ -32,117 +32,7 @@
     box-shadow: -4px 0 8px rgba(0,0,0,0.3);
 }
 
-/* Change tab appearance when assistant is open */
-.assistant-container.show ~ .assistant-toggle {
-    background-color: #e74c3c;
-    right: 400px;
-}
-
-.assistant-container.show ~ .assistant-toggle {
-    font-size: 0; /* Hide original text */
-}
-
-.assistant-container.show ~ .assistant-toggle::before {
-    content: "Close Assistant";
-    font-size: 14px; /* Restore font size for the pseudo-element */
-}
-
-.assistant-container.show ~ .assistant-toggle:hover {
-    background-color: #c0392b;
-}
-
-.assistant-container {
-    position: fixed;
-    right: 0;
-    top: 0;
-    width: 0;
-    height: 100vh;
-    z-index: 1000;
-    background: white;
-    border-left: 1px solid #ddd;
-    box-shadow: -2px 0 10px rgba(0,0,0,0.1);
-    transition: width 0.3s ease-in-out;
-    overflow: hidden;
-}
-
-.assistant-container.show {
-    width: 400px;
-}
-
-.assistant-iframe {
-    width: 400px;
-    height: 100%;
-    border: none;
-    background: white;
-}
-
-/* Add close button inside the assistant */
-.assistant-close {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    background: #e74c3c;
-    color: white;
-    border: none;
-    border-radius: 50%;
-    width: 30px;
-    height: 30px;
-    cursor: pointer;
-    font-size: 18px;
-    line-height: 1;
-    z-index: 1002;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.assistant-close:hover {
-    background: #c0392b;
-}
-
-/* Adjust main content when assistant is open */
-/* Note: pydata_sphinx_theme uses different class structure than sphinx_rtd_theme */
-.bd-main {
-    transition: margin-right 0.3s ease-in-out;
-}
-
-.assistant-container.show ~ .bd-main {
-    margin-right: 400px;
-}
-
-/* Alternative selectors for pydata_sphinx_theme */
-main.bd-main,
-.bd-content {
-    transition: margin-right 0.3s ease-in-out;
-}
-
-.assistant-container.show ~ main.bd-main,
-.assistant-container.show ~ .bd-content {
-    margin-right: 400px;
-}
-
-/* Tablet and medium screens */
-@media (max-width: 1200px) and (min-width: 768px) {
-    .assistant-container.show {
-        width: 350px;
-    }
-
-    .assistant-iframe {
-        width: 350px;
-    }
-
-    .assistant-container.show ~ .bd-main,
-    .assistant-container.show ~ main.bd-main,
-    .assistant-container.show ~ .bd-content {
-        margin-right: 350px;
-    }
-
-    .assistant-container.show ~ .assistant-toggle {
-        right: 350px;
-    }
-}
-
-/* Mobile devices - full overlay */
+/* Mobile devices - horizontal button layout */
 @media (max-width: 767px) {
     .assistant-toggle {
         right: 10px;
@@ -157,56 +47,5 @@ main.bd-main,
 
     .assistant-toggle:hover {
         transform: translateX(-2px);
-    }
-
-    .assistant-container.show ~ .assistant-toggle {
-        position: fixed;
-        right: 10px;
-        top: 20px;
-        transform: none;
-        z-index: 1003;
-    }
-
-    .assistant-container {
-        width: 0;
-        border-left: none;
-    }
-
-    .assistant-container.show {
-        width: 100vw;
-    }
-
-    .assistant-iframe {
-        width: 100vw;
-    }
-
-    .assistant-container.show ~ .bd-main,
-    .assistant-container.show ~ main.bd-main,
-    .assistant-container.show ~ .bd-content {
-        margin-right: 0;
-    }
-}
-
-/* For very large screens, use more space */
-@media (min-width: 1400px) {
-    .assistant-container.show {
-        width: calc(100vw - 1140px);
-        max-width: 600px;
-    }
-
-    .assistant-iframe {
-        width: calc(100vw - 1140px);
-        max-width: 600px;
-    }
-
-    .assistant-container.show ~ .bd-main,
-    .assistant-container.show ~ main.bd-main,
-    .assistant-container.show ~ .bd-content {
-        margin-right: calc(100vw - 1140px);
-    }
-
-    .assistant-container.show ~ .assistant-toggle {
-        right: calc(100vw - 1140px);
-        max-right: 600px;
     }
 }

--- a/docs/_static/css/neuroconv_assistant.css
+++ b/docs/_static/css/neuroconv_assistant.css
@@ -1,51 +1,46 @@
 /* NeuroConv Assistant Chatbot Styles */
 /* Popup window approach - only button styling needed */
 
-/* Assistant toggle button - fixed position on right side */
+/* Assistant toggle button - bottom-right position (industry standard) */
 .assistant-toggle {
     position: fixed;
-    right: 0;
-    top: 50%;
-    transform: translateY(-50%);
+    right: 24px;
+    bottom: 24px;
     z-index: 1001;
-    padding: 12px 8px;
+    padding: 12px 16px;
     background-color: #2980b9;
     color: white;
     border: none;
-    border-radius: 8px 0 0 8px;
+    border-radius: 8px;
     cursor: pointer;
     font-size: 14px;
     font-weight: bold;
-    writing-mode: vertical-rl;
-    text-orientation: mixed;
-    box-shadow: -2px 0 5px rgba(0,0,0,0.2);
-    transition: background-color 0.3s ease-in-out, transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
-    min-height: 80px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+    transition: all 0.3s ease-in-out;
     display: flex;
     align-items: center;
     justify-content: center;
+    min-width: 120px;
+    white-space: nowrap;
 }
 
 .assistant-toggle:hover {
     background-color: #3498db;
-    transform: translateY(-50%) translateX(-2px);
-    box-shadow: -4px 0 8px rgba(0,0,0,0.3);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(0,0,0,0.3);
 }
 
-/* Mobile devices - horizontal button layout */
+/* Mobile devices - smaller button */
 @media (max-width: 767px) {
     .assistant-toggle {
-        right: 10px;
-        top: 20px;
-        transform: none;
-        writing-mode: horizontal-tb;
-        text-orientation: unset;
-        border-radius: 4px;
-        padding: 8px 12px;
-        min-height: auto;
+        right: 16px;
+        bottom: 16px;
+        padding: 10px 14px;
+        font-size: 13px;
+        min-width: 100px;
     }
 
     .assistant-toggle:hover {
-        transform: translateX(-2px);
+        transform: translateY(-1px);
     }
 }

--- a/docs/_static/js/neuroconv_assistant.js
+++ b/docs/_static/js/neuroconv_assistant.js
@@ -16,17 +16,21 @@ document.addEventListener('DOMContentLoaded', function() {
     // Track the popup window reference
     let chatbotWindow = null;
 
-    // Function to get optimal popup size based on screen
+    // Function to get optimal popup size and position for multi-monitor setups
     const getOptimalPopupSize = () => {
-        const screenWidth = window.screen.width;
-        const screenHeight = window.screen.height;
+        // Get current window position to determine which screen we're on
+        const currentLeft = window.screenX || window.screenLeft || 0;
+        const currentTop = window.screenY || window.screenTop || 0;
+        const currentWidth = window.outerWidth;
 
+        // Determine popup size based on screen size
+        const screenWidth = window.screen.width;
         let width, height;
 
         if (screenWidth <= 768) {
             // Mobile: smaller popup
             width = Math.min(400, screenWidth - 40);
-            height = Math.min(600, screenHeight - 100);
+            height = Math.min(600, window.screen.height - 100);
         } else if (screenWidth <= 1024) {
             // Tablet: medium popup
             width = 450;
@@ -41,9 +45,22 @@ document.addEventListener('DOMContentLoaded', function() {
             height = 800;
         }
 
-        // Center the popup
-        const left = Math.round((screenWidth - width) / 2);
-        const top = Math.round((screenHeight - height) / 2);
+        // Position popup near current window (same monitor)
+        // Try to place it to the right of current window
+        let left = currentLeft + currentWidth + 20; // 20px gap from browser window
+        let top = currentTop + 50; // Small offset from top of browser
+
+        // If popup would extend beyond screen, center it instead
+        const maxLeft = currentLeft + screenWidth - width;
+        if (left > maxLeft) {
+            left = currentLeft + Math.round((screenWidth - width) / 2);
+        }
+
+        // Ensure popup doesn't go below screen
+        const maxTop = window.screen.height - height - 50;
+        if (top > maxTop) {
+            top = Math.max(50, Math.round((window.screen.height - height) / 2));
+        }
 
         return { width, height, left, top };
     };

--- a/docs/_static/js/neuroconv_assistant.js
+++ b/docs/_static/js/neuroconv_assistant.js
@@ -1,0 +1,38 @@
+/**
+ * NeuroConv Assistant Chatbot
+ * Dynamically injects the NWB Assistant chatbot into every documentation page
+ */
+
+document.addEventListener('DOMContentLoaded', function() {
+    // Create the assistant container
+    const container = document.createElement('div');
+    container.className = 'assistant-container';
+
+    // Create the iframe for the chatbot
+    const iframe = document.createElement('iframe');
+    iframe.className = 'assistant-iframe';
+    container.appendChild(iframe);
+
+    // Create the toggle button
+    const toggle = document.createElement('button');
+    toggle.className = 'assistant-toggle';
+    toggle.textContent = 'Open Assistant';
+
+    // Append elements to the body
+    document.body.appendChild(container);
+    document.body.appendChild(toggle);
+
+    // Track whether iframe has been loaded
+    let iframeLoaded = false;
+
+    // Add click event handler for the toggle button
+    toggle.addEventListener('click', function() {
+        const isShowing = container.classList.toggle('show');
+
+        // Load iframe content only when first opened for performance
+        if (isShowing && !iframeLoaded) {
+            iframe.src = 'https://magland.github.io/nwb-assistant/chat';
+            iframeLoaded = true;
+        }
+    });
+});

--- a/docs/_static/js/neuroconv_assistant.js
+++ b/docs/_static/js/neuroconv_assistant.js
@@ -16,15 +16,50 @@ document.addEventListener('DOMContentLoaded', function() {
     // Track the popup window reference
     let chatbotWindow = null;
 
+    // Function to get optimal popup size based on screen
+    const getOptimalPopupSize = () => {
+        const screenWidth = window.screen.width;
+        const screenHeight = window.screen.height;
+
+        let width, height;
+
+        if (screenWidth <= 768) {
+            // Mobile: smaller popup
+            width = Math.min(400, screenWidth - 40);
+            height = Math.min(600, screenHeight - 100);
+        } else if (screenWidth <= 1024) {
+            // Tablet: medium popup
+            width = 450;
+            height = 650;
+        } else if (screenWidth <= 1440) {
+            // Desktop: standard popup
+            width = 500;
+            height = 700;
+        } else {
+            // Large desktop: bigger popup
+            width = 600;
+            height = 800;
+        }
+
+        // Center the popup
+        const left = Math.round((screenWidth - width) / 2);
+        const top = Math.round((screenHeight - height) / 2);
+
+        return { width, height, left, top };
+    };
+
     // Add click event handler for the toggle button
     toggle.addEventListener('click', function() {
         // Check if window exists and is still open
         if (!chatbotWindow || chatbotWindow.closed) {
-            // Open new popup window
+            // Get optimal size for current screen
+            const { width, height, left, top } = getOptimalPopupSize();
+
+            // Open new popup window with responsive sizing
             chatbotWindow = window.open(
                 'https://magland.github.io/nwb-assistant/chat',
                 'nwb-assistant', // Window name (ensures only one window)
-                'width=500,height=700,scrollbars=yes,resizable=yes,location=no,menubar=no,toolbar=no,status=no'
+                `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes,location=no,menubar=no,toolbar=no,status=no`
             );
 
             // Update button text when window is opened

--- a/docs/_static/js/neuroconv_assistant.js
+++ b/docs/_static/js/neuroconv_assistant.js
@@ -3,9 +3,12 @@
  * Dynamically injects the NWB Assistant chatbot into every documentation page
  */
 
+// document is the whole html, we adda an event listener that fires
+// when the HTML is fully loaded and parsed (i.e. DOMContentLoaded)
 document.addEventListener('DOMContentLoaded', function() {
-    // Create the assistant container
+
     const container = document.createElement('div');
+    // we give it a name to style it in css
     container.className = 'assistant-container';
 
     // Create the iframe for the chatbot
@@ -16,7 +19,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Create the toggle button
     const toggle = document.createElement('button');
     toggle.className = 'assistant-toggle';
-    toggle.textContent = 'Open Assistant';
+    toggle.textContent = 'Open Chat Assistant';
 
     // Append elements to the body
     document.body.appendChild(container);
@@ -31,6 +34,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // Load iframe content only when first opened for performance
         if (isShowing && !iframeLoaded) {
+            // I think the loading happens here
             iframe.src = 'https://magland.github.io/nwb-assistant/chat';
             iframeLoaded = true;
         }

--- a/docs/_static/js/neuroconv_assistant.js
+++ b/docs/_static/js/neuroconv_assistant.js
@@ -1,42 +1,48 @@
 /**
  * NeuroConv Assistant Chatbot
- * Dynamically injects the NWB Assistant chatbot into every documentation page
+ * Opens the NWB Assistant chatbot in a persistent popup window
+ * that maintains conversation state across documentation page navigation
  */
 
-// document is the whole html, we adda an event listener that fires
-// when the HTML is fully loaded and parsed (i.e. DOMContentLoaded)
 document.addEventListener('DOMContentLoaded', function() {
-
-    const container = document.createElement('div');
-    // we give it a name to style it in css
-    container.className = 'assistant-container';
-
-    // Create the iframe for the chatbot
-    const iframe = document.createElement('iframe');
-    iframe.className = 'assistant-iframe';
-    container.appendChild(iframe);
-
-    // Create the toggle button
+    // Create the toggle button only (no container or iframe needed for popup)
     const toggle = document.createElement('button');
     toggle.className = 'assistant-toggle';
-    toggle.textContent = 'Open Chat Assistant';
+    toggle.textContent = 'Open Assistant';
 
-    // Append elements to the body
-    document.body.appendChild(container);
+    // Append button to the body
     document.body.appendChild(toggle);
 
-    // Track whether iframe has been loaded
-    let iframeLoaded = false;
+    // Track the popup window reference
+    let chatbotWindow = null;
 
     // Add click event handler for the toggle button
     toggle.addEventListener('click', function() {
-        const isShowing = container.classList.toggle('show');
+        // Check if window exists and is still open
+        if (!chatbotWindow || chatbotWindow.closed) {
+            // Open new popup window
+            chatbotWindow = window.open(
+                'https://magland.github.io/nwb-assistant/chat',
+                'nwb-assistant', // Window name (ensures only one window)
+                'width=500,height=700,scrollbars=yes,resizable=yes,location=no,menubar=no,toolbar=no,status=no'
+            );
 
-        // Load iframe content only when first opened for performance
-        if (isShowing && !iframeLoaded) {
-            // I think the loading happens here
-            iframe.src = 'https://magland.github.io/nwb-assistant/chat';
-            iframeLoaded = true;
+            // Update button text when window is opened
+            if (chatbotWindow) {
+                toggle.textContent = 'Focus Assistant';
+
+                // Check if window gets closed and update button text
+                const checkClosed = setInterval(function() {
+                    if (chatbotWindow.closed) {
+                        toggle.textContent = 'Open Assistant';
+                        chatbotWindow = null;
+                        clearInterval(checkClosed);
+                    }
+                }, 1000);
+            }
+        } else {
+            // Window exists, just bring it to front
+            chatbotWindow.focus();
         }
     });
 });

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,9 +32,10 @@ html_static_path = ["_static"]
 html_favicon = "_static/favicon.ico"
 
 # These paths are either relative to html_static_path or fully qualified paths (eg. https://...)
-# html_css_files = [
-#     "css/custom.css",
-# ]
+html_css_files = [
+    "css/custom.css",
+    "css/neuroconv_assistant.css",
+]
 
 html_context = {
     # "github_url": "https://github.com", # or your GitHub Enterprise site

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,10 @@ html_css_files = [
     "css/neuroconv_assistant.css",
 ]
 
+html_js_files = [
+    "js/neuroconv_assistant.js",
+]
+
 html_context = {
     # "github_url": "https://github.com", # or your GitHub Enterprise site
     "github_user": "catalystneuro",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,31 @@ Features:
 * Minimizes the size of the NWB files by automatically applying chunking and lossless compression.
 * Supports ensembles of multiple data streams, and supports common methods for temporal alignment of streams.
 
+.. raw:: html
+
+   <div class="assistant-container">
+     <iframe class="assistant-iframe"></iframe>
+   </div>
+   <button class="assistant-toggle">Open Assistant</button>
+   <script>
+     document.addEventListener('DOMContentLoaded', function() {
+       const toggle = document.querySelector('.assistant-toggle');
+       const container = document.querySelector('.assistant-container');
+       const iframe = document.querySelector('.assistant-iframe');
+       let iframeLoaded = false;
+
+       toggle.addEventListener('click', function() {
+         const isShowing = container.classList.toggle('show');
+
+         // Load iframe content only when first opened
+         if (isShowing && !iframeLoaded) {
+           iframe.src = 'https://magland.github.io/nwb-assistant/chat';
+           iframeLoaded = true;
+         }
+       });
+     });
+   </script>
+
 Installation
 ------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,31 +19,6 @@ Features:
 * Minimizes the size of the NWB files by automatically applying chunking and lossless compression.
 * Supports ensembles of multiple data streams, and supports common methods for temporal alignment of streams.
 
-.. raw:: html
-
-   <div class="assistant-container">
-     <iframe class="assistant-iframe"></iframe>
-   </div>
-   <button class="assistant-toggle">Open Assistant</button>
-   <script>
-     document.addEventListener('DOMContentLoaded', function() {
-       const toggle = document.querySelector('.assistant-toggle');
-       const container = document.querySelector('.assistant-container');
-       const iframe = document.querySelector('.assistant-iframe');
-       let iframeLoaded = false;
-
-       toggle.addEventListener('click', function() {
-         const isShowing = container.classList.toggle('show');
-
-         // Load iframe content only when first opened
-         if (isShowing && !iframeLoaded) {
-           iframe.src = 'https://magland.github.io/nwb-assistant/chat';
-           iframeLoaded = true;
-         }
-       });
-     });
-   </script>
-
 Installation
 ------------
 


### PR DESCRIPTION
This is an alternative to https://github.com/catalystneuro/neuroconv/pull/1474 to add a chatbot.

This implementation displays the chatbot in an external window, which avoids the issues of content persistence when navigating through the Sphinx documentation.

You can check it out here:
https://neuroconv--1476.org.readthedocs.build/en/1476/

If we were to solve persistence within an anchored UI element and the current iframe setup, we would need to rely on JavaScript storage methods. Options here would include a URL-as-state mechanism or storage solutions such as localStorage or IndexedDB, both of which would introduce additional complexity and require changes in the nwb-assistant repository.

Using an external window instead has some potential advantages:
* Simplifies the implementation by avoiding custom storage logic.
* Provides a consistent, standalone UI that could be reused across repositories (pynwb, neuroconv, etc.).
* Follows a fairly common pattern for web-based chat interfaces.

Another alternative is to use the same side panel as in pynwb as in: https://github.com/catalystneuro/neuroconv/pull/1474

