### PR TITLE
Use PyData theme  version switcher in the documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * Added `rename_unit_ids()` method to `BaseSortingExtractorInterface` for dictionary-based unit ID renaming, enabling clean handling of multiple sorting interfaces with overlapping unit IDs [PR #1451](https://github.com/catalystneuro/neuroconv/pull/1451)
 * Added support for setting ProbeGroup objects in `BaseRecordingExtractorInterface.set_probe()` method[PR #1464](https://github.com/catalystneuro/neuroconv/pull/1464)
 * Added comprehensive tests for `set_probe` method in `BaseRecordingExtractorInterface` to verify probe and probe group functionality with proper electrode group organization in NWB files [PR #1464](https://github.com/catalystneuro/neuroconv/pull/1464)
-* Added PyData Sphinx Theme version switcher to documentation navbar, enabling users to switch between stable (latest release) and main (development) versions. Removed duplicate Read the Docs version switcher to provide a cleaner interface [PR #1478](https://github.com/catalystneuro/neuroconv/pull/1478)
+* Added PyData Sphinx Theme version switcher to documentation navbar, enabling users to switch between stable (latest release) and main (development) versions [PR #1478](https://github.com/catalystneuro/neuroconv/pull/1478)
 
 ## Improvements
 * Added comprehensive FFmpeg video conversion how-to guide for converting bespoke video formats to DANDI-compatible formats [PR #1426](https://github.com/catalystneuro/neuroconv/pull/1426)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * Added `rename_unit_ids()` method to `BaseSortingExtractorInterface` for dictionary-based unit ID renaming, enabling clean handling of multiple sorting interfaces with overlapping unit IDs [PR #1451](https://github.com/catalystneuro/neuroconv/pull/1451)
 * Added support for setting ProbeGroup objects in `BaseRecordingExtractorInterface.set_probe()` method[PR #1464](https://github.com/catalystneuro/neuroconv/pull/1464)
 * Added comprehensive tests for `set_probe` method in `BaseRecordingExtractorInterface` to verify probe and probe group functionality with proper electrode group organization in NWB files [PR #1464](https://github.com/catalystneuro/neuroconv/pull/1464)
-* Added PyData Sphinx Theme version switcher to documentation navbar, enabling users to switch between stable (latest release) and main (development) versions [PR #1478](https://github.com/catalystneuro/neuroconv/pull/1478)
+* Added PyData Sphinx Theme version switcher to documentation navbar, enabling users to switch between stable (latest release) and main (development) versions. Removed duplicate Read the Docs version switcher to provide a cleaner interface [PR #1478](https://github.com/catalystneuro/neuroconv/pull/1478)
 
 ## Improvements
 * Added comprehensive FFmpeg video conversion how-to guide for converting bespoke video formats to DANDI-compatible formats [PR #1426](https://github.com/catalystneuro/neuroconv/pull/1426)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Added `rename_unit_ids()` method to `BaseSortingExtractorInterface` for dictionary-based unit ID renaming, enabling clean handling of multiple sorting interfaces with overlapping unit IDs [PR #1451](https://github.com/catalystneuro/neuroconv/pull/1451)
 * Added support for setting ProbeGroup objects in `BaseRecordingExtractorInterface.set_probe()` method[PR #1464](https://github.com/catalystneuro/neuroconv/pull/1464)
 * Added comprehensive tests for `set_probe` method in `BaseRecordingExtractorInterface` to verify probe and probe group functionality with proper electrode group organization in NWB files [PR #1464](https://github.com/catalystneuro/neuroconv/pull/1464)
+* Added PyData Sphinx Theme version switcher to documentation navbar, enabling users to switch between stable (latest release) and main (development) versions [PR #1478](https://github.com/catalystneuro/neuroconv/pull/1478)
 
 ## Improvements
 * Added comprehensive FFmpeg video conversion how-to guide for converting bespoke video formats to DANDI-compatible formats [PR #1426](https://github.com/catalystneuro/neuroconv/pull/1426)

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -14,13 +14,3 @@ dt em.sig-param:last-of-type::after {
 dl.class > dt:first-of-type {
     display: block !important;
 }
-
-/* Hide Read the Docs version switcher (bottom-right) to avoid duplication with navbar switcher */
-.rst-versions,
-div.rst-versions,
-.rst-versions.rst-badge,
-.injected .rst-versions {
-    display: none !important;
-    visibility: hidden !important;
-    opacity: 0 !important;
-}

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -14,3 +14,8 @@ dt em.sig-param:last-of-type::after {
 dl.class > dt:first-of-type {
     display: block !important;
 }
+
+/* Hide Read the Docs version switcher (bottom-right) to avoid duplication with navbar switcher */
+.rst-versions {
+    display: none !important;
+}

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -16,6 +16,11 @@ dl.class > dt:first-of-type {
 }
 
 /* Hide Read the Docs version switcher (bottom-right) to avoid duplication with navbar switcher */
-.rst-versions {
+.rst-versions,
+div.rst-versions,
+.rst-versions.rst-badge,
+.injected .rst-versions {
     display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
 }

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,0 +1,12 @@
+[
+    {
+        "name": "stable (latest release)",
+        "version": "stable",
+        "url": "https://neuroconv.readthedocs.io/en/stable/"
+    },
+    {
+        "name": "main (development)",
+        "version": "main",
+        "url": "https://neuroconv.readthedocs.io/en/latest/"
+    }
+]

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -5,8 +5,8 @@
         "url": "https://neuroconv.readthedocs.io/en/stable/"
     },
     {
-        "name": "main (development)",
-        "version": "main",
+        "name": "latest (development)",
+        "version": "latest",
         "url": "https://neuroconv.readthedocs.io/en/latest/"
     }
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ html_theme_options = {
         },
     ],
     "switcher": {
-        "json_url": "https://neuroconv.readthedocs.io/en/latest/_static/switcher.json",
+        "json_url": "_static/switcher.json",
         "version_match": "latest",  # This will be set correctly when deployed to RTD
     }
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,9 +32,9 @@ html_static_path = ["_static"]
 html_favicon = "_static/favicon.ico"
 
 # These paths are either relative to html_static_path or fully qualified paths (eg. https://...)
-# html_css_files = [
-#     "css/custom.css",
-# ]
+html_css_files = [
+    "css/custom.css",
+]
 
 html_context = {
     # "github_url": "https://github.com", # or your GitHub Enterprise site
@@ -46,6 +46,7 @@ html_context = {
 
 html_theme_options = {
     "use_edit_page_button": True,
+    "navbar_end": ["version-switcher", "navbar-icon-links"],  # Version switcher in navbar like NumPy/SciPy
     "icon_links": [
         {
             "name": "GitHub",
@@ -54,6 +55,10 @@ html_theme_options = {
             "type": "fontawesome",
         },
     ],
+    "switcher": {
+        "json_url": "https://neuroconv.readthedocs.io/en/stable/_static/switcher.json",
+        "version_match": "stable",  # Set stable as the default version
+    }
 }
 
 # Prevent Sphinx from prefixing class and function names with their module paths

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,8 +56,8 @@ html_theme_options = {
         },
     ],
     "switcher": {
-        "json_url": "https://neuroconv.readthedocs.io/en/stable/_static/switcher.json",
-        "version_match": "stable",  # Set stable as the default version
+        "json_url": "https://neuroconv.readthedocs.io/en/latest/_static/switcher.json",
+        "version_match": "latest",  # This will be set correctly when deployed to RTD
     }
 }
 


### PR DESCRIPTION
Current we are using the RTD widget for switching between stable and latest versions of the documentation. This is a generic widget that RTD provides. 

On the other hand, we are using the PyData theme for our docs. This PR adds the [PyData native version switcher](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/version-dropdown.html) to the docs:

<img width="1993" height="179" alt="image" src="https://github.com/user-attachments/assets/0d51d464-73e9-4cb6-84db-b43fb01620f9" />

This change aligns our package with other documentation packages from the scientific Python ecosystem such as NumPy, SciPy and Scikit-learn in the placement of the version switcher (see https://numpy.org/doc/stable/ in the top upper corner). 

Once, and if, this is approved released we will remove the RTD native switcher as the latter needs to be deactivated on the RTD configuration (not in code).

Another benefit of this is that in #1476, the chat button can be displayed without interfering with the RTD version switcher.

