### PR TITLE
Fix version switcher in pr

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,8 +172,10 @@ def update_version_switcher_in_read_the_docs(app, config):
 
     # Create entry for current PR/branch
     # PR builds use format: https://neuroconv--1483.org.readthedocs.build/en/1483/
+    # For PR builds, rtd_version is just the number (e.g., "1483")
+    display_name = f"PR {rtd_version}" if rtd_version.isdigit() else rtd_version
     current_entry = {
-        "name": f"{rtd_version} (current)",
+        "name": f"{display_name} (current)",
         "version": rtd_version,
         "url": f"https://neuroconv--{rtd_version}.org.readthedocs.build/en/{rtd_version}/"
     }


### PR DESCRIPTION
Currently for build PRs the task switcher displays choose version by default. This changes this to the current format:

<img width="598" height="118" alt="image" src="https://github.com/user-attachments/assets/52ebb295-30fe-4965-909c-3777fafabb47" />

This has #1483 as a base. 