### PR TITLE
Remove support for Device object in metadata dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.8.2 (Upcoming)
 
 ## Removals, Deprecations and Changes
+* Ophys: Passing `pynwb.device.Device` objects in `metadata['Ophys']['Device']` to `add_devices_to_nwbfile` now issues a `FutureWarning` and is deprecated. This feature will be removed on or after March 2026. Pass device definitions as dictionaries instead (e.g., `{ "name": "Microscope" }`). . [PR #1513](https://github.com/catalystneuro/neuroconv/pull/1513)
 
 ## Bug Fixes
 

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -196,9 +196,14 @@ def get_nwb_imaging_metadata(
 def add_devices_to_nwbfile(nwbfile: NWBFile, metadata: dict | None = None) -> NWBFile:
     """
     Add optical physiology devices from metadata.
-    The metadata concerning the optical physiology should be stored in metadata["Ophys]["Device"]
-    This function handles both a text specification of the device to be built and an actual pynwb.Device object.
 
+    Notes
+    -----
+    The metadata concerning the optical physiology should be stored in ``metadata['Ophys']['Device']``.
+
+    Deprecation: Passing ``pynwb.device.Device`` objects directly inside
+    ``metadata['Ophys']['Device']`` is deprecated and will be removed on or after March 2026.
+    Please pass device definitions as dictionaries instead (e.g., ``{"name": "Microscope"}``).
     """
     metadata_copy = {} if metadata is None else deepcopy(metadata)
     default_metadata = _get_default_ophys_metadata()
@@ -206,6 +211,13 @@ def add_devices_to_nwbfile(nwbfile: NWBFile, metadata: dict | None = None) -> NW
     device_metadata = metadata_copy["Ophys"]["Device"]
 
     for device in device_metadata:
+        if not isinstance(device, dict):
+            warnings.warn(
+                "Passing pynwb.device.Device objects in metadata['Ophys']['Device'] is deprecated and will be "
+                "removed on or after March 2026. Please pass device definitions as dictionaries instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
         device_name = device["name"] if isinstance(device, dict) else device.name
         if device_name not in nwbfile.devices:
             device = Device(**device) if isinstance(device, dict) else device

--- a/tests/test_modalities/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_modalities/test_ophys/test_tools_roiextractors.py
@@ -18,7 +18,6 @@ from numpy.testing import assert_array_equal, assert_raises
 from numpy.typing import ArrayLike
 from parameterized import param, parameterized
 from pynwb import NWBHDF5IO, NWBFile
-from pynwb.device import Device
 from pynwb.ophys import OnePhotonSeries
 from roiextractors.testing import (
     generate_dummy_imaging_extractor,
@@ -144,31 +143,6 @@ class TestAddDevices(unittest.TestCase):
         devices = self.nwbfile.devices
 
         assert len(devices) == 0
-
-    def test_device_object(self):
-        device_name = "device_object"
-        device_object = Device(name=device_name)
-        device_list = [device_object]
-        self.metadata["Ophys"].update(Device=device_list)
-        add_devices_to_nwbfile(self.nwbfile, metadata=self.metadata)
-
-        devices = self.nwbfile.devices
-
-        assert len(devices) == 1
-        assert device_name in devices
-
-    def test_device_object_and_metadata_mix(self):
-        device_object = Device(name="device_object")
-        device_metadata = dict(name="device_metadata")
-        device_list = [device_object, device_metadata]
-        self.metadata["Ophys"].update(Device=device_list)
-        add_devices_to_nwbfile(self.nwbfile, metadata=self.metadata)
-
-        devices = self.nwbfile.devices
-
-        assert len(devices) == 2
-        assert "device_metadata" in devices
-        assert "device_object" in devices
 
 
 class TestAddImagingPlane(TestCase):


### PR DESCRIPTION
As in the title. The metadata is meant to be mostly serializable (see date time objects). Supporting this is an unnecessary complication.