### PR TITLE
Make extractor import and initialization explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Removals, Deprecations and Changes
 * Ophys: Passing `pynwb.device.Device` objects in `metadata['Ophys']['Device']` to `add_devices_to_nwbfile` now issues a `FutureWarning` and is deprecated. This feature will be removed on or after March 2026. Pass device definitions as dictionaries instead (e.g., `{ "name": "Microscope" }`). . [PR #1513](https://github.com/catalystneuro/neuroconv/pull/1513)
+* Extractor interfaces: The `extractor` attribute and `get_extractor()` method are deprecated and will be removed on or after March 2026. These were confusingly named as they return extractor classes, not instances. Use the private `_extractor_class` attribute or access the instance directly via `_extractor_instance` [PR #1513](https://github.com/catalystneuro/neuroconv/pull/1513)
 
 ## Bug Fixes
 
@@ -10,6 +11,7 @@
 
 ## Improvements
 * Added SpikeGLXNIDQ interface to conversion gallery with documentation on how different channel types (XA, MA, MD, XD) are converted to NWB [PR #1505](https://github.com/catalystneuro/neuroconv/pull/1505)
+* Refactored extractor interfaces to use explicit `_initialize_extractor` method instead of implicit string-based initialization, improving code clarity and maintainability across all recording, sorting, imaging, and segmentation interfaces [PR #1513](https://github.com/catalystneuro/neuroconv/pull/1513)
 
 # v0.8.1 (September 16, 2025)
 

--- a/src/neuroconv/datainterfaces/ecephys/alphaomega/alphaomegadatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/alphaomega/alphaomegadatainterface.py
@@ -22,10 +22,14 @@ class AlphaOmegaRecordingInterface(BaseRecordingExtractorInterface):
         source_schema["properties"]["folder_path"]["description"] = "Path to the folder of .mpx files."
         return source_schema
 
-    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            AlphaOmegaRecordingExtractor,
+        )
+
         extractor_kwargs = source_data.copy()
         extractor_kwargs["stream_id"] = self.stream_id
-        return extractor_kwargs
+        return AlphaOmegaRecordingExtractor(**extractor_kwargs)
 
     def __init__(self, folder_path: DirectoryPath, verbose: bool = False, es_key: str = "ElectricalSeries"):
         """

--- a/src/neuroconv/datainterfaces/ecephys/axon/axondatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/axon/axondatainterface.py
@@ -27,11 +27,13 @@ class AxonRecordingInterface(BaseRecordingExtractorInterface):
         source_schema["properties"]["file_path"]["description"] = "Path to an Axon Binary Format (.abf) file"
         return source_schema
 
-    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import AxonRecordingExtractor
+
         extractor_kwargs = source_data.copy()
         extractor_kwargs["all_annotations"] = True
 
-        return extractor_kwargs
+        return AxonRecordingExtractor(**extractor_kwargs)
 
     def __init__(
         self,

--- a/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
@@ -32,11 +32,13 @@ class AxonaRecordingInterface(BaseRecordingExtractorInterface):
         source_schema["properties"]["file_path"]["description"] = "Path to .bin file."
         return source_schema
 
-    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import AxonaRecordingExtractor
+
         extractor_kwargs = source_data.copy()
         extractor_kwargs["all_annotations"] = True
 
-        return extractor_kwargs
+        return AxonaRecordingExtractor(**extractor_kwargs)
 
     def __init__(self, file_path: FilePath, verbose: bool = False, es_key: str = "ElectricalSeries"):
         """
@@ -149,7 +151,15 @@ class AxonaLFPDataInterface(BaseLFPExtractorInterface):
     associated_suffixes = (".bin", ".set")
     info = "Interface for Axona LFP data."
 
-    ExtractorName = "NumpyRecording"
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.core import NumpyRecording
+
+        extractor_kwargs = source_data.copy()
+        extractor_kwargs.pop("file_path")
+        extractor_kwargs["traces_list"] = self.traces_list
+        extractor_kwargs["sampling_frequency"] = self.sampling_frequency
+
+        return NumpyRecording(**extractor_kwargs)
 
     @classmethod
     def get_source_schema(cls) -> dict:
@@ -159,15 +169,6 @@ class AxonaLFPDataInterface(BaseLFPExtractorInterface):
             type="object",
             additionalProperties=False,
         )
-
-    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
-
-        extractor_kwargs = source_data.copy()
-        extractor_kwargs.pop("file_path")
-        extractor_kwargs["traces_list"] = self.traces_list
-        extractor_kwargs["sampling_frequency"] = self.sampling_frequency
-
-        return extractor_kwargs
 
     def __init__(self, file_path: FilePath):
         data = read_all_eeg_file_lfp_data(file_path).T

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -19,8 +19,6 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
 
     keywords = ("extracellular electrophysiology", "voltage", "recording")
 
-    ExtractorModuleName = "spikeinterface.extractors.extractor_classes"
-
     def __init__(self, verbose: bool = False, es_key: str = "ElectricalSeries", **source_data):
         """
         Parameters
@@ -133,12 +131,8 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
         timestamps: numpy.ndarray or list of numpy.ndarray
             The timestamps for the data stream; if the recording has multiple segments, then a list of timestamps is returned.
         """
-        new_recording = self.get_extractor()(
-            **{
-                keyword: value
-                for keyword, value in self.extractor_kwargs.items()
-                if keyword not in ["verbose", "es_key"]
-            }
+        new_recording = self._initialize_extractor(
+            {keyword: value for keyword, value in self.extractor_kwargs.items() if keyword not in ["verbose", "es_key"]}
         )
         if self._number_of_segments == 1:
             return new_recording.get_times()

--- a/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py
@@ -16,8 +16,6 @@ class BaseSortingExtractorInterface(BaseExtractorInterface):
 
     keywords = ("extracellular electrophysiology", "spike sorting")
 
-    ExtractorModuleName = "spikeinterface.extractors.extractor_classes"
-
     def __init__(self, verbose: bool = False, **source_data):
 
         super().__init__(**source_data)

--- a/src/neuroconv/datainterfaces/ecephys/biocam/biocamdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/biocam/biocamdatainterface.py
@@ -14,6 +14,11 @@ class BiocamRecordingInterface(BaseRecordingExtractorInterface):
     associated_suffixes = (".bwr",)
     info = "Interface for Biocam recording data."
 
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import BiocamRecordingExtractor
+
+        return BiocamRecordingExtractor(**source_data)
+
     @classmethod
     def get_source_schema(cls) -> dict:
         schema = super().get_source_schema()

--- a/src/neuroconv/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -28,11 +28,15 @@ class BlackrockRecordingInterface(BaseRecordingExtractorInterface):
         ] = "Path to the Blackrock file with suffix being .ns1, .ns2, .ns3, .ns4m .ns4, or .ns6."
         return source_schema
 
-    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            BlackrockRecordingExtractor,
+        )
+
         extractor_kwargs = source_data.copy()
         extractor_kwargs["stream_id"] = self.stream_id
 
-        return extractor_kwargs
+        return BlackrockRecordingExtractor(**extractor_kwargs)
 
     def __init__(
         self,
@@ -92,6 +96,13 @@ class BlackrockSortingInterface(BaseSortingExtractorInterface):
         metadata_schema["additionalProperties"] = True
         metadata_schema["properties"]["file_path"].update(description="Path to Blackrock .nev file.")
         return metadata_schema
+
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            BlackrockSortingExtractor,
+        )
+
+        return BlackrockSortingExtractor(**source_data)
 
     def __init__(
         self,

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -418,11 +418,15 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
     associated_suffixes = (".mat", ".sessionInfo", ".spikes", ".cellinfo")
     info = "Interface for CellExplorer sorting data."
 
-    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            CellExplorerSortingExtractor,
+        )
+
         extractor_kwargs = source_data.copy()
         extractor_kwargs["sampling_frequency"] = self.sampling_frequency
 
-        return extractor_kwargs
+        return CellExplorerSortingExtractor(**extractor_kwargs)
 
     def __init__(self, file_path: FilePath, verbose: bool = False):
         """
@@ -541,7 +545,7 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
             sampling_frequency = int(extracellular_data["sr"])
 
             # Create a dummy recording extractor
-            from spikeinterface.core.numpyextractors import NumpyRecording
+            from spikeinterface.core import NumpyRecording
 
             traces_list = [np.empty(shape=(1, num_channels))]
             channel_ids = [str(1 + i) for i in range(num_channels)]

--- a/src/neuroconv/datainterfaces/ecephys/edf/edfdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/edf/edfdatainterface.py
@@ -53,14 +53,15 @@ class EDFRecordingInterface(BaseRecordingExtractorInterface):
 
         return channel_ids.tolist()
 
-    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import EDFRecordingExtractor
 
         extractor_kwargs = source_data.copy()
         extractor_kwargs.pop("channels_to_skip")
         extractor_kwargs["all_annotations"] = True
         extractor_kwargs["use_names_as_ids"] = True
 
-        return extractor_kwargs
+        return EDFRecordingExtractor(**extractor_kwargs)
 
     def __init__(
         self,

--- a/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
@@ -30,12 +30,14 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
         source_schema["properties"]["file_path"]["description"] = "Path to either a .rhd or a .rhs file"
         return source_schema
 
-    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import IntanRecordingExtractor
+
         extractor_kwargs = source_data.copy()
         extractor_kwargs["all_annotations"] = True
         extractor_kwargs["stream_id"] = self.stream_id
 
-        return extractor_kwargs
+        return IntanRecordingExtractor(**extractor_kwargs)
 
     def __init__(
         self,

--- a/src/neuroconv/datainterfaces/ecephys/kilosort/kilosortdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/kilosort/kilosortdatainterface.py
@@ -19,6 +19,11 @@ class KiloSortSortingInterface(BaseSortingExtractorInterface):
         ] = "Path to the output Phy folder (containing the params.py)"
         return source_schema
 
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors import read_kilosort
+
+        return read_kilosort(**source_data)
+
     def __init__(
         self,
         folder_path: DirectoryPath,

--- a/src/neuroconv/datainterfaces/ecephys/maxwell/maxonedatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/maxwell/maxonedatainterface.py
@@ -19,7 +19,12 @@ class MaxOneRecordingInterface(BaseRecordingExtractorInterface):  # pragma: no c
     associated_suffixes = (".raw", ".h5")
     info = "Interface for MaxOne recording data."
 
-    ExtractorName = "MaxwellRecordingExtractor"
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            MaxwellRecordingExtractor,
+        )
+
+        return MaxwellRecordingExtractor(**source_data)
 
     @staticmethod
     def auto_install_maxwell_hdf5_compression_plugin(

--- a/src/neuroconv/datainterfaces/ecephys/mcsraw/mcsrawdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/mcsraw/mcsrawdatainterface.py
@@ -14,6 +14,11 @@ class MCSRawRecordingInterface(BaseRecordingExtractorInterface):
     associated_suffixes = (".raw",)
     info = "Interface for MCSRaw recording data."
 
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import MCSRawRecordingExtractor
+
+        return MCSRawRecordingExtractor(**source_data)
+
     @classmethod
     def get_source_schema(cls) -> dict:
         source_schema = super().get_source_schema()

--- a/src/neuroconv/datainterfaces/ecephys/mearec/mearecdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/mearec/mearecdatainterface.py
@@ -18,6 +18,11 @@ class MEArecRecordingInterface(BaseRecordingExtractorInterface):
     associated_suffixes = (".h5",)
     info = "Interface for MEArec recording data."
 
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import MEArecRecordingExtractor
+
+        return MEArecRecordingExtractor(**source_data)
+
     @classmethod
     def get_source_schema(cls) -> dict:
         source_schema = super().get_source_schema()

--- a/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -36,11 +36,15 @@ class NeuralynxRecordingInterface(BaseRecordingExtractorInterface):
         ] = 'Path to Neuralynx directory containing ".ncs", ".nse", ".ntt", ".nse", or ".nev" files.'
         return source_schema
 
-    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            NeuralynxRecordingExtractor,
+        )
+
         extractor_kwargs = source_data.copy()
         extractor_kwargs["all_annotations"] = True
 
-        return extractor_kwargs
+        return NeuralynxRecordingExtractor(**extractor_kwargs)
 
     def __init__(
         self,
@@ -115,6 +119,13 @@ class NeuralynxSortingInterface(BaseSortingExtractorInterface):
     display_name = "Neuralynx Sorting"
     associated_suffixes = (".nse", ".ntt", ".nse", ".nev")
     info = "Interface for Neuralynx sorting data."
+
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            NeuralynxSortingExtractor,
+        )
+
+        return NeuralynxSortingExtractor(**source_data)
 
     def __init__(
         self,

--- a/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -101,6 +101,18 @@ class NeuroScopeRecordingInterface(BaseRecordingExtractorInterface):
     associated_suffixes = (".dat", ".xml")
     info = "Interface for converting NeuroScope recording data."
 
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            NeuroScopeRecordingExtractor,
+        )
+
+        extractor_kwargs = source_data.copy()
+        # xml_file_path is handled in __init__, not passed to extractor
+        extractor_kwargs.pop("gain", None)
+        extractor_kwargs.pop("xml_file_path", None)
+
+        return NeuroScopeRecordingExtractor(**extractor_kwargs)
+
     @classmethod
     def get_source_schema(self) -> dict:
         source_schema = super().get_source_schema()
@@ -188,7 +200,7 @@ class NeuroScopeRecordingInterface(BaseRecordingExtractorInterface):
 
     def get_original_timestamps(self) -> np.ndarray:
         # TODO: add generic method for aliasing from NeuroConv signature to SI init
-        new_recording = self.get_extractor()(file_path=self.source_data["file_path"])
+        new_recording = self._initialize_extractor({"file_path": self.source_data["file_path"]})
         if self._number_of_segments == 1:
             return new_recording.get_times()
         else:
@@ -205,7 +217,17 @@ class NeuroScopeLFPInterface(BaseLFPExtractorInterface):
     associated_suffixes = (".lfp", ".eeg", ".xml")
     info = "Interface for converting NeuroScope LFP data."
 
-    ExtractorName = "NeuroScopeRecordingExtractor"
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            NeuroScopeRecordingExtractor,
+        )
+
+        extractor_kwargs = source_data.copy()
+        # xml_file_path is handled in __init__, not passed to extractor
+        extractor_kwargs.pop("gain", None)
+        extractor_kwargs.pop("xml_file_path", None)
+
+        return NeuroScopeRecordingExtractor(**extractor_kwargs)
 
     @classmethod
     def get_source_schema(self) -> dict:
@@ -280,6 +302,13 @@ class NeuroScopeSortingInterface(BaseSortingExtractorInterface):
             "description"
         ] = "Path to .xml file containing device and electrode configuration."
         return source_schema
+
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            NeuroScopeSortingExtractor,
+        )
+
+        return NeuroScopeSortingExtractor(**source_data)
 
     def __init__(
         self,

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
@@ -15,7 +15,12 @@ class OpenEphysBinaryRecordingInterface(BaseRecordingExtractorInterface):
     associated_suffixes = (".dat", ".oebin", ".npy")
     info = "Interface for converting binary OpenEphys recording data."
 
-    ExtractorName = "OpenEphysBinaryRecordingExtractor"
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            OpenEphysBinaryRecordingExtractor,
+        )
+
+        return OpenEphysBinaryRecordingExtractor(**source_data)
 
     @classmethod
     def get_stream_names(cls, folder_path: DirectoryPath) -> list[str]:

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysdatainterface.py
@@ -14,7 +14,12 @@ class OpenEphysRecordingInterface(BaseRecordingExtractorInterface):
     associated_suffixes = (".dat", ".oebin", ".npy")
     info = "Interface for converting any OpenEphys recording data."
 
-    ExtractorName = "OpenEphysBinaryRecordingExtractor"
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            OpenEphysBinaryRecordingExtractor,
+        )
+
+        return OpenEphysBinaryRecordingExtractor(**source_data)
 
     @classmethod
     def get_source_schema(cls) -> dict:

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephyslegacydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephyslegacydatainterface.py
@@ -18,6 +18,13 @@ class OpenEphysLegacyRecordingInterface(BaseRecordingExtractorInterface):
     associated_suffixes = (".continuous", ".openephys", ".xml")
     info = "Interface for converting legacy OpenEphys recording data."
 
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            OpenEphysLegacyRecordingExtractor,
+        )
+
+        return OpenEphysLegacyRecordingExtractor(**source_data)
+
     @classmethod
     def get_stream_names(cls, folder_path: DirectoryPath) -> list[str]:
         """

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephyssortingdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephyssortingdatainterface.py
@@ -31,9 +31,13 @@ class OpenEphysSortingInterface(BaseSortingExtractorInterface):
         metadata_schema["additionalProperties"] = False
         return metadata_schema
 
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            OpenEphysSortingExtractor,
+        )
+
+        return OpenEphysSortingExtractor(**source_data)
+
     @validate_call
     def __init__(self, folder_path: DirectoryPath, experiment_id: int = 0, recording_id: int = 0):
-        from spikeextractors import OpenEphysSortingExtractor
-
-        self.Extractor = OpenEphysSortingExtractor
         super().__init__(folder_path=str(folder_path), experiment_id=experiment_id, recording_id=recording_id)

--- a/src/neuroconv/datainterfaces/ecephys/phy/phydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/phy/phydatainterface.py
@@ -24,6 +24,11 @@ class PhySortingInterface(BaseSortingExtractorInterface):
         ] = "Path to the output Phy folder (containing the params.py)."
         return source_schema
 
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors import read_phy
+
+        return read_phy(**source_data)
+
     @validate_call
     def __init__(
         self,

--- a/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
@@ -19,6 +19,11 @@ class PlexonRecordingInterface(BaseRecordingExtractorInterface):
     associated_suffixes = (".plx",)
     info = "Interface for Plexon recording data."
 
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import PlexonRecordingExtractor
+
+        return PlexonRecordingExtractor(**source_data)
+
     @classmethod
     def get_source_schema(cls) -> dict:
         source_schema = super().get_source_schema()
@@ -76,7 +81,11 @@ class PlexonLFPInterface(BaseLFPExtractorInterface):
     display_name = "Plexon LFP Recording"
     associated_suffixes = (".plx",)
     info = "Interface for Plexon low pass filtered data."
-    ExtractorName = "PlexonRecordingExtractor"
+
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import PlexonRecordingExtractor
+
+        return PlexonRecordingExtractor(**source_data)
 
     @classmethod
     def get_source_schema(cls) -> dict:
@@ -146,12 +155,16 @@ class Plexon2RecordingInterface(BaseRecordingExtractorInterface):
         source_schema["properties"]["file_path"]["description"] = "Path to the .pl2 file."
         return source_schema
 
-    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            Plexon2RecordingExtractor,
+        )
+
         extractor_kwargs = source_data.copy()
         extractor_kwargs["all_annotations"] = True
         extractor_kwargs["stream_id"] = self.stream_id
 
-        return extractor_kwargs
+        return Plexon2RecordingExtractor(**extractor_kwargs)
 
     @validate_call
     def __init__(self, file_path: FilePath, verbose: bool = False, es_key: str = "ElectricalSeries"):
@@ -210,6 +223,11 @@ class PlexonSortingInterface(BaseSortingExtractorInterface):
         source_schema = super().get_source_schema()
         source_schema["properties"]["file_path"]["description"] = "Path to the plexon spiking data (.plx file)."
         return source_schema
+
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import PlexonSortingExtractor
+
+        return PlexonSortingExtractor(**source_data)
 
     @validate_call
     def __init__(self, file_path: FilePath, verbose: bool = False):

--- a/src/neuroconv/datainterfaces/ecephys/spike2/spike2datainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spike2/spike2datainterface.py
@@ -28,7 +28,10 @@ class Spike2RecordingInterface(BaseRecordingExtractorInterface):
     associated_suffixes = (".smrx",)
     info = "Interface for Spike2 recording data from CED (Cambridge Electronic Design)."
 
-    ExtractorName = "CedRecordingExtractor"
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import CedRecordingExtractor
+
+        return CedRecordingExtractor(**source_data)
 
     @classmethod
     def get_source_schema(cls) -> dict:
@@ -53,7 +56,9 @@ class Spike2RecordingInterface(BaseRecordingExtractorInterface):
             Dictionary containing information about all channels in the Spike2 file.
         """
         _test_sonpy_installation()
-        return cls.get_extractor().get_all_channels_info(file_path=file_path)
+        from spikeinterface.extractors.extractor_classes import CedRecordingExtractor
+
+        return CedRecordingExtractor.get_all_channels_info(file_path=file_path)
 
     @validate_call
     def __init__(self, file_path: FilePath, verbose: bool = False, es_key: str = "ElectricalSeries"):

--- a/src/neuroconv/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
@@ -15,6 +15,16 @@ class SpikeGadgetsRecordingInterface(BaseRecordingExtractorInterface):
     associated_suffixes = (".rec",)
     info = "Interface for SpikeGadgets recording data."
 
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            SpikeGadgetsRecordingExtractor,
+        )
+
+        extractor_kwargs = source_data.copy()
+        extractor_kwargs.pop("gains", None)  # Remove gains as it's handled in __init__
+
+        return SpikeGadgetsRecordingExtractor(**extractor_kwargs)
+
     @classmethod
     def get_source_schema(cls) -> dict:
         source_schema = get_json_schema_from_method_signature(cls, exclude=["source_data"])

--- a/src/neuroconv/datainterfaces/ecephys/tdt/tdtdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/tdt/tdtdatainterface.py
@@ -10,12 +10,13 @@ class TdtRecordingInterface(BaseRecordingExtractorInterface):
     associated_suffixes = (".tbk", ".tbx", ".tev", ".tsq")
     info = "Interface for TDT recording data."
 
-    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import TdtRecordingExtractor
 
         extractor_kwargs = source_data.copy()
         extractor_kwargs.pop("gain")
 
-        return extractor_kwargs
+        return TdtRecordingExtractor(**extractor_kwargs)
 
     @validate_call
     def __init__(

--- a/src/neuroconv/datainterfaces/ecephys/whitematter/whitematterdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/whitematter/whitematterdatainterface.py
@@ -16,7 +16,12 @@ class WhiteMatterRecordingInterface(BaseRecordingExtractorInterface):
     associated_suffixes = (".bin",)
     info = "Interface for converting binary WhiteMatter recording data."
 
-    ExtractorName = "WhiteMatterRecordingExtractor"
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.extractors.extractor_classes import (
+            WhiteMatterRecordingExtractor,
+        )
+
+        return WhiteMatterRecordingExtractor(**source_data)
 
     def __init__(
         self,

--- a/src/neuroconv/datainterfaces/icephys/abf/abfdatainterface.py
+++ b/src/neuroconv/datainterfaces/icephys/abf/abfdatainterface.py
@@ -44,7 +44,16 @@ class AbfInterface(BaseIcephysInterface):
     associated_suffixes = (".abf",)
     info = "Interface for ABF intracellular electrophysiology data."
 
-    ExtractorName = "AxonIO"
+    def _initialize_extractor(self, source_data: dict):
+        from neo import AxonIO
+
+        extractor_kwargs = {}
+        if "filename" in source_data:
+            extractor_kwargs["filename"] = source_data["filename"]
+        elif "file_paths" in source_data and source_data["file_paths"]:
+            extractor_kwargs["filename"] = source_data["file_paths"][0]
+
+        return AxonIO(**extractor_kwargs)
 
     @classmethod
     def get_source_schema(cls) -> dict:

--- a/src/neuroconv/datainterfaces/icephys/baseicephysinterface.py
+++ b/src/neuroconv/datainterfaces/icephys/baseicephysinterface.py
@@ -19,8 +19,6 @@ class BaseIcephysInterface(BaseExtractorInterface):
 
     keywords = ("intracellular electrophysiology", "patch clamp", "current clamp")
 
-    ExtractorModuleName = "neo"
-
     @classmethod
     def get_source_schema(cls) -> dict:
         source_schema = get_json_schema_from_method_signature(method=cls.__init__, exclude=[])
@@ -42,12 +40,12 @@ class BaseIcephysInterface(BaseExtractorInterface):
 
         from ...tools.neo import get_number_of_electrodes, get_number_of_segments
 
-        self.source_data = dict()
-        self.source_data["file_paths"] = file_paths
+        super().__init__(file_paths=file_paths)
 
         self.readers_list = list()
         for f in file_paths:
-            self.readers_list.append(self.get_extractor()(filename=f))
+            file_source_data = {"filename": f}
+            self.readers_list.append(self._initialize_extractor(file_source_data))
 
         self.n_segments = get_number_of_segments(neo_reader=self.readers_list[0], block=0)
         self.n_channels = get_number_of_electrodes(neo_reader=self.readers_list[0])

--- a/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
@@ -32,8 +32,6 @@ class BaseImagingExtractorInterface(BaseExtractorInterface):
         "calcium imaging",
     )
 
-    ExtractorModuleName = "roiextractors"
-
     def __init__(
         self,
         verbose: bool = False,
@@ -133,7 +131,7 @@ class BaseImagingExtractorInterface(BaseExtractorInterface):
         return metadata
 
     def get_original_timestamps(self) -> np.ndarray:
-        reinitialized_extractor = self.get_extractor()(**self.extractor_kwargs)
+        reinitialized_extractor = self._initialize_extractor(self.extractor_kwargs)
         return reinitialized_extractor.get_timestamps()
 
     def get_timestamps(self) -> np.ndarray:

--- a/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
@@ -20,8 +20,6 @@ class BaseSegmentationExtractorInterface(BaseExtractorInterface):
 
     keywords = ("segmentation", "roi", "cells")
 
-    ExtractorModuleName = "roiextractors"
-
     def __init__(self, verbose: bool = False, **source_data):
         super().__init__(**source_data)
         self.verbose = verbose
@@ -122,7 +120,7 @@ class BaseSegmentationExtractorInterface(BaseExtractorInterface):
         return metadata
 
     def get_original_timestamps(self) -> np.ndarray:
-        reinitialized_extractor = self.get_extractor()(**self.source_data)
+        reinitialized_extractor = self._initialize_extractor(self.extractor_kwargs)
         return reinitialized_extractor.frame_to_time(frames=np.arange(stop=reinitialized_extractor.get_num_samples()))
 
     def get_timestamps(self) -> np.ndarray:

--- a/src/neuroconv/datainterfaces/ophys/brukertiff/brukertiffdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/brukertiff/brukertiffdatainterface.py
@@ -89,6 +89,11 @@ class BrukerTiffMultiPlaneImagingInterface(BaseImagingExtractorInterface):
         self._stream_name = self.imaging_extractor.stream_name.replace("_", "")
         self._frame_shape = self.imaging_extractor.get_frame_shape()
 
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import BrukerTiffMultiPlaneImagingExtractor
+
+        return BrukerTiffMultiPlaneImagingExtractor(**source_data)
+
     def _determine_position_current(self) -> list[float]:
         """
         Returns y, x, and z position values. The unit of values is in the microscope reference frame.
@@ -275,6 +280,11 @@ class BrukerTiffSinglePlaneImagingInterface(BaseImagingExtractorInterface):
         self.folder_path = folder_path
         self._stream_name = self.imaging_extractor.stream_name.replace("_", "")
         self._frame_shape = self.imaging_extractor.get_frame_shape()
+
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import BrukerTiffSinglePlaneImagingExtractor
+
+        return BrukerTiffSinglePlaneImagingExtractor(**source_data)
 
     def _determine_position_current(self) -> list[float]:
         """

--- a/src/neuroconv/datainterfaces/ophys/caiman/caimandatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/caiman/caimandatainterface.py
@@ -36,3 +36,8 @@ class CaimanSegmentationInterface(BaseSegmentationExtractorInterface):
         """
         super().__init__(file_path=file_path)
         self.verbose = verbose
+
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import CaimanSegmentationExtractor
+
+        return CaimanSegmentationExtractor(**source_data)

--- a/src/neuroconv/datainterfaces/ophys/cnmfe/cnmfedatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/cnmfe/cnmfedatainterface.py
@@ -13,3 +13,8 @@ class CnmfeSegmentationInterface(BaseSegmentationExtractorInterface):
     def __init__(self, file_path: FilePath, verbose: bool = False):
         super().__init__(file_path=file_path)
         self.verbose = verbose
+
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import CnmfeSegmentationExtractor
+
+        return CnmfeSegmentationExtractor(**source_data)

--- a/src/neuroconv/datainterfaces/ophys/extract/extractdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/extract/extractdatainterface.py
@@ -32,3 +32,8 @@ class ExtractSegmentationInterface(BaseSegmentationExtractorInterface):
             sampling_frequency=sampling_frequency,
             output_struct_name=output_struct_name,
         )
+
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import ExtractSegmentationExtractor
+
+        return ExtractSegmentationExtractor(**source_data)

--- a/src/neuroconv/datainterfaces/ophys/femtonics/femtonicsdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/femtonics/femtonicsdatainterface.py
@@ -81,6 +81,11 @@ class FemtonicsImagingInterface(BaseImagingExtractorInterface):
         # TODO: remove this once roiextractors 0.6.1
         self.imaging_extractor.get_num_channels = lambda: 1  # Override to ensure only one channel is reported
 
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import FemtonicsImagingExtractor
+
+        return FemtonicsImagingExtractor(**source_data)
+
     def get_metadata(self) -> DeepDict:
         """
         Extract metadata specific to Femtonics imaging data.
@@ -213,8 +218,9 @@ class FemtonicsImagingInterface(BaseImagingExtractorInterface):
         list of str
             List of available session keys.
         """
-        Extractor = cls.get_extractor()
-        return Extractor.get_available_sessions(file_path=file_path)
+        from roiextractors import FemtonicsImagingExtractor
+
+        return FemtonicsImagingExtractor.get_available_sessions(file_path=file_path)
 
     @classmethod
     def get_available_munits(cls, file_path: FilePath, session_name: str = None) -> list[str]:
@@ -235,7 +241,7 @@ class FemtonicsImagingInterface(BaseImagingExtractorInterface):
         list of str
             List of available unit keys.
         """
-        Extractor = cls.get_extractor()
+        from roiextractors import FemtonicsImagingExtractor
 
         # If no session_name provided, only auto-select if there's exactly one session
         if session_name is None:
@@ -248,7 +254,7 @@ class FemtonicsImagingInterface(BaseImagingExtractorInterface):
                 )
             session_name = available_sessions[0]
 
-        return Extractor.get_available_munits(file_path=file_path, session_name=session_name)
+        return FemtonicsImagingExtractor.get_available_munits(file_path=file_path, session_name=session_name)
 
     @classmethod
     def get_available_channels(cls, file_path: FilePath, session_name: str = None, munit_name: str = None) -> list[str]:
@@ -273,7 +279,7 @@ class FemtonicsImagingInterface(BaseImagingExtractorInterface):
         list of str
             List of available channel names.
         """
-        Extractor = cls.get_extractor()
+        from roiextractors import FemtonicsImagingExtractor
 
         # If no session_name provided, only auto-select if there's exactly one session
         if session_name is None:
@@ -298,4 +304,6 @@ class FemtonicsImagingInterface(BaseImagingExtractorInterface):
                 )
             munit_name = available_munits[0]
 
-        return Extractor.get_available_channels(file_path=file_path, session_name=session_name, munit_name=munit_name)
+        return FemtonicsImagingExtractor.get_available_channels(
+            file_path=file_path, session_name=session_name, munit_name=munit_name
+        )

--- a/src/neuroconv/datainterfaces/ophys/hdf5/hdf5datainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/hdf5/hdf5datainterface.py
@@ -48,3 +48,8 @@ class Hdf5ImagingInterface(BaseImagingExtractorInterface):
             verbose=verbose,
             photon_series_type=photon_series_type,
         )
+
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import Hdf5ImagingExtractor
+
+        return Hdf5ImagingExtractor(**source_data)

--- a/src/neuroconv/datainterfaces/ophys/inscopix/inscopiximagingdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/inscopix/inscopiximagingdatainterface.py
@@ -66,6 +66,11 @@ class InscopixImagingInterface(BaseImagingExtractorInterface):
             **kwargs,
         )
 
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import InscopixImagingExtractor
+
+        return InscopixImagingExtractor(**source_data)
+
     def get_metadata(self) -> DeepDict:
         """
         Retrieve the metadata for the Inscopix imaging data.

--- a/src/neuroconv/datainterfaces/ophys/inscopix/inscopixsegmentationdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/inscopix/inscopixsegmentationdatainterface.py
@@ -27,6 +27,11 @@ class InscopixSegmentationInterface(BaseSegmentationExtractorInterface):
         """
         super().__init__(file_path=file_path, verbose=verbose)
 
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import InscopixSegmentationExtractor
+
+        return InscopixSegmentationExtractor(**source_data)
+
     def get_metadata(self) -> DeepDict:
         """
         Retrieve the metadata for the Inscopix segmentation data.

--- a/src/neuroconv/datainterfaces/ophys/micromanagertiff/micromanagertiffdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/micromanagertiff/micromanagertiffdatainterface.py
@@ -46,6 +46,11 @@ class MicroManagerTiffImagingInterface(BaseImagingExtractorInterface):
         channel_name = self.imaging_extractor._channel_names[0]
         self.imaging_extractor._channel_names = [f"OpticalChannel{channel_name}"]
 
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import MicroManagerTiffImagingExtractor
+
+        return MicroManagerTiffImagingExtractor(**source_data)
+
     def get_metadata(self) -> DeepDict:
         """
         Get metadata for the Micro-Manager TIFF imaging data.

--- a/src/neuroconv/datainterfaces/ophys/miniscope/miniscopeimagingdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/miniscope/miniscopeimagingdatainterface.py
@@ -59,6 +59,11 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
         self._recording_start_times = get_recording_start_times(folder_path=folder_path)
         self.photon_series_type = "OnePhotonSeries"
 
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import MiniscopeImagingExtractor
+
+        return MiniscopeImagingExtractor(**source_data)
+
     def get_metadata(self) -> DeepDict:
         """
         Get metadata for the Miniscope imaging data.

--- a/src/neuroconv/datainterfaces/ophys/sbx/sbxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/sbx/sbxdatainterface.py
@@ -37,6 +37,11 @@ class SbxImagingInterface(BaseImagingExtractorInterface):
             photon_series_type=photon_series_type,
         )
 
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import SbxImagingExtractor
+
+        return SbxImagingExtractor(**source_data)
+
     def get_metadata(self) -> DeepDict:
         """
         Get metadata for the Scanbox imaging data.

--- a/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterfaces.py
+++ b/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterfaces.py
@@ -37,8 +37,6 @@ class ScanImageImagingInterface(BaseImagingExtractorInterface):
     associated_suffixes = (".tif", ".tiff")
     info = "Interface for ScanImage TIFF files."
 
-    ExtractorName = "ScanImageImagingExtractor"
-
     @validate_call
     def __init__(
         self,
@@ -147,6 +145,11 @@ class ScanImageImagingInterface(BaseImagingExtractorInterface):
         # Make sure the timestamps are available, the extractor caches them
         times = self.imaging_extractor.get_times()
         self.imaging_extractor.set_times(times=times)
+
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import ScanImageImagingExtractor
+
+        return ScanImageImagingExtractor(**source_data)
 
     def get_metadata(self) -> DeepDict:
         """
@@ -388,20 +391,20 @@ class ScanImageLegacyImagingInterface(BaseImagingExtractorInterface):
     associated_suffixes = (".tif",)
     info = "Interface for ScanImage v3.8 TIFF files."
 
-    ExtractorName = "ScanImageLegacyImagingExtractor"
-
     @classmethod
     def get_source_schema(cls) -> dict:
         source_schema = super().get_source_schema()
         source_schema["properties"]["file_path"]["description"] = "Path to Tiff file."
         return source_schema
 
-    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import ScanImageLegacyImagingExtractor
+
         extractor_kwargs = source_data.copy()
         extractor_kwargs.pop("fallback_sampling_frequency", None)
         extractor_kwargs["sampling_frequency"] = self.sampling_frequency
 
-        return extractor_kwargs
+        return ScanImageLegacyImagingExtractor(**extractor_kwargs)
 
     @validate_call
     def __init__(
@@ -484,8 +487,6 @@ class ScanImageMultiFileImagingInterface(BaseImagingExtractorInterface):
     associated_suffixes = (".tif",)
     info = "Interface for ScanImage multi-file (buffered) TIFF files."
 
-    ExtractorName = "ScanImageTiffSinglePlaneMultiFileImagingExtractor"
-
     @classmethod
     def get_source_schema(cls) -> dict:
         """
@@ -564,14 +565,14 @@ class ScanImageMultiPlaneImagingInterface(BaseImagingExtractorInterface):
     associated_suffixes = (".tif",)
     info = "Interface for ScanImage multi plane (volumetric) TIFF files."
 
-    ExtractorName = "ScanImageTiffMultiPlaneImagingExtractor"
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import ScanImageTiffMultiPlaneImagingExtractor
 
-    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
         extractor_kwargs = source_data.copy()
         extractor_kwargs.pop("image_metadata")
         extractor_kwargs["metadata"] = self.image_metadata
 
-        return extractor_kwargs
+        return ScanImageTiffMultiPlaneImagingExtractor(**extractor_kwargs)
 
     @validate_call
     def __init__(
@@ -692,7 +693,15 @@ class ScanImageMultiPlaneMultiFileImagingInterface(BaseImagingExtractorInterface
     associated_suffixes = (".tif",)
     info = "Interface for ScanImage multi-file (buffered) volumetric TIFF files."
 
-    ExtractorName = "ScanImageTiffMultiPlaneMultiFileImagingExtractor"
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import ScanImageTiffMultiPlaneMultiFileImagingExtractor
+
+        extractor_kwargs = source_data.copy()
+        extractor_kwargs.pop("image_metadata", None)
+        extractor_kwargs.pop("parsed_metadata", None)
+        extractor_kwargs.pop("verbose", None)
+
+        return ScanImageTiffMultiPlaneMultiFileImagingExtractor(**extractor_kwargs)
 
     @validate_call
     def __init__(
@@ -828,14 +837,14 @@ class ScanImageSinglePlaneImagingInterface(BaseImagingExtractorInterface):
     associated_suffixes = (".tif",)
     info = "Interface for ScanImage TIFF files."
 
-    ExtractorName = "ScanImageTiffSinglePlaneImagingExtractor"
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import ScanImageTiffSinglePlaneImagingExtractor
 
-    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
         extractor_kwargs = source_data.copy()
         extractor_kwargs.pop("image_metadata")
         extractor_kwargs["metadata"] = self.image_metadata
 
-        return extractor_kwargs
+        return ScanImageTiffSinglePlaneImagingExtractor(**extractor_kwargs)
 
     @validate_call
     def __init__(
@@ -976,7 +985,15 @@ class ScanImageSinglePlaneMultiFileImagingInterface(BaseImagingExtractorInterfac
     associated_suffixes = (".tif",)
     info = "Interface for ScanImage multi-file (buffered) TIFF files."
 
-    ExtractorName = "ScanImageTiffSinglePlaneMultiFileImagingExtractor"
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import ScanImageTiffSinglePlaneMultiFileImagingExtractor
+
+        extractor_kwargs = source_data.copy()
+        extractor_kwargs.pop("image_metadata", None)
+        extractor_kwargs.pop("parsed_metadata", None)
+        extractor_kwargs.pop("verbose", None)
+
+        return ScanImageTiffSinglePlaneMultiFileImagingExtractor(**extractor_kwargs)
 
     @validate_call
     def __init__(

--- a/src/neuroconv/datainterfaces/ophys/sima/simadatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/sima/simadatainterface.py
@@ -20,3 +20,8 @@ class SimaSegmentationInterface(BaseSegmentationExtractorInterface):
         sima_segmentation_label : str, default: "auto_ROIs"
         """
         super().__init__(file_path=file_path, sima_segmentation_label=sima_segmentation_label)
+
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import SimaSegmentationExtractor
+
+        return SimaSegmentationExtractor(**source_data)

--- a/src/neuroconv/datainterfaces/ophys/suite2p/suite2pdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/suite2p/suite2pdatainterface.py
@@ -146,6 +146,11 @@ class Suite2pSegmentationInterface(BaseSegmentationExtractorInterface):
         self.plane_segmentation_name = plane_segmentation_name
         self.verbose = verbose
 
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import Suite2pSegmentationExtractor
+
+        return Suite2pSegmentationExtractor(**source_data)
+
     def get_metadata(self) -> DeepDict:
         """
         Get metadata for the Suite2p segmentation data.

--- a/src/neuroconv/datainterfaces/ophys/thor/thordatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/thor/thordatainterface.py
@@ -25,7 +25,6 @@ class ThorImagingInterface(BaseImagingExtractorInterface):
     display_name = "ThorLabs TIFF Imaging"
     associated_suffixes = (".tif", ".tiff")
     info = "Interface for Thor TIFF files Exporter with ThorImageLS."
-    ExtractorName = "ThorTiffImagingExtractor"
 
     @classmethod
     def get_source_schema(cls) -> dict:
@@ -59,6 +58,11 @@ class ThorImagingInterface(BaseImagingExtractorInterface):
 
         super().__init__(file_path=file_path, channel_name=channel_name, verbose=verbose)
         self.channel_name = channel_name
+
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import ThorTiffImagingExtractor
+
+        return ThorTiffImagingExtractor(**source_data)
 
     def get_metadata(self) -> DeepDict:
         """

--- a/src/neuroconv/datainterfaces/ophys/tiff/tiffdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/tiff/tiffdatainterface.py
@@ -51,3 +51,8 @@ class TiffImagingInterface(BaseImagingExtractorInterface):
             verbose=verbose,
             photon_series_type=photon_series_type,
         )
+
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors import TiffImagingExtractor
+
+        return TiffImagingExtractor(**source_data)

--- a/src/neuroconv/tools/testing/mock_interfaces.py
+++ b/src/neuroconv/tools/testing/mock_interfaces.py
@@ -201,8 +201,10 @@ class MockSpikeGLXNIDQInterface(SpikeGLXNIDQInterface):
 class MockRecordingInterface(BaseRecordingExtractorInterface):
     """An interface with a spikeinterface recording object for testing purposes."""
 
-    ExtractorModuleName = "spikeinterface.core.generate"
-    ExtractorName = "generate_recording"
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.core.generate import generate_recording
+
+        return generate_recording(**source_data)
 
     def __init__(
         self,
@@ -246,8 +248,10 @@ class MockSortingInterface(BaseSortingExtractorInterface):
     # TODO: Implement this class with the lazy generator once is merged
     # https://github.com/SpikeInterface/spikeinterface/pull/2227
 
-    ExtractorModuleName = "spikeinterface.core.generate"
-    ExtractorName = "generate_sorting"
+    def _initialize_extractor(self, source_data: dict):
+        from spikeinterface.core.generate import generate_sorting
+
+        return generate_sorting(**source_data)
 
     def __init__(
         self,
@@ -298,8 +302,10 @@ class MockImagingInterface(BaseImagingExtractorInterface):
     A mock imaging interface for testing purposes.
     """
 
-    ExtractorModuleName = "roiextractors.testing"
-    ExtractorName = "generate_dummy_imaging_extractor"
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors.testing import generate_dummy_imaging_extractor
+
+        return generate_dummy_imaging_extractor(**source_data)
 
     def __init__(
         self,
@@ -378,8 +384,10 @@ class MockImagingInterface(BaseImagingExtractorInterface):
 class MockSegmentationInterface(BaseSegmentationExtractorInterface):
     """A mock segmentation interface for testing purposes."""
 
-    ExtractorModuleName = "roiextractors.testing"
-    ExtractorName = "generate_dummy_segmentation_extractor"
+    def _initialize_extractor(self, source_data: dict):
+        from roiextractors.testing import generate_dummy_segmentation_extractor
+
+        return generate_dummy_segmentation_extractor(**source_data)
 
     def __init__(
         self,


### PR DESCRIPTION
Currently we map the interface name to the class name dynamically with the aid of a module attribute:

https://github.com/catalystneuro/neuroconv/blob/b830d5dd6374784d8b44bce8498e2545f3f8625b/src/neuroconv/baseextractorinterface.py#L32-L36

I think this is confusing and not a very standard practice that makes contributing to our library harder than it should be. I think @rly has been confused by this, I have found it difficult in the past to inherit from `BaseExtractor` because of this, and when I was working with someone in the Flat Iron institute event they also were tripped-off byt this on the context of [this PR](https://github.com/catalystneuro/neuroconv/pull/1457). It also couples the naming of the interface and the extractor and I don't see any benefit of this.

The solution:
Explicit is better than implicit. 

Thanks to the magic of LLMs, we can just add an explicit initialization method to every interface. This new `_initialize_extractor` servers two functions, it imports the extractor lazily at init time and it maps the interface kwargs to the extractor kwargs. I think this is more transparent and therefore easier to understand and modify. It should make it easier to contribute.



