### PR TITLE
Simplify roiextractors metadata flow I 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Support NIDQ analog streams in `OpenEphysBinaryAnalogInterface` [PR #1503](https://github.com/catalystneuro/neuroconv/pull/1503)
 
 ## Improvements
+* Refactored ophys metadata functions to use a single source of truth pattern, preventing accidental mutation of global state and improving maintainability [PR #1521](https://github.com/catalystneuro/neuroconv/pull/1521)
 * Replaced deprecated `frame_to_time()` method calls with `get_timestamps()` in optical physiology interfaces [PR #1513](https://github.com/catalystneuro/neuroconv/pull/1513)
 * Added SpikeGLXNIDQ interface to conversion gallery with documentation on how different channel types (XA, MA, MD, XD) are converted to NWB [PR #1505](https://github.com/catalystneuro/neuroconv/pull/1505)
 * Updated `TDTFiberPhotometryInterface` to support the latest version of `ndx-fiber-photometry` (v0.2.1) [PR #1430](https://github.com/catalystneuro/neuroconv/pull/1430)

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -42,101 +42,104 @@ from ...utils import (
 from ...utils.str_utils import human_readable_size
 
 
-def _get_default_ophys_metadata() -> DeepDict:
-    """Fill default metadata for Device and ImagingPlane."""
+def _get_default_ophys_metadata():
+    """
+    Returns fresh ophys default metadata dictionary.
+
+    Single source of truth for all ophys default metadata.
+    Structure matches the output of get_nwb_imaging_metadata() and get_nwb_segmentation_metadata().
+    Each call returns a new instance to prevent accidental mutation of global state.
+    """
     metadata = get_default_nwbfile_metadata()
 
-    default_device = dict(name="Microscope")
-
-    default_optical_channel = dict(
-        name="OpticalChannel",
-        emission_lambda=np.nan,
-        description="An optical channel of the microscope.",
-    )
-
-    default_imaging_plane = dict(
-        name="ImagingPlane",
-        description="The plane or volume being imaged by the microscope.",
-        excitation_lambda=np.nan,
-        indicator="unknown",
-        location="unknown",
-        device=default_device["name"],
-        optical_channel=[default_optical_channel],
-    )
-
-    metadata.update(
-        Ophys=dict(
-            Device=[default_device],
-            ImagingPlane=[default_imaging_plane],
-        ),
-    )
+    metadata["Ophys"] = {
+        "Device": [{"name": "Microscope"}],
+        "ImagingPlane": [
+            {
+                "name": "ImagingPlane",
+                "description": "The plane or volume being imaged by the microscope.",
+                "excitation_lambda": np.nan,
+                "indicator": "unknown",
+                "location": "unknown",
+                "device": "Microscope",
+                "optical_channel": [
+                    {
+                        "name": "OpticalChannel",
+                        "emission_lambda": np.nan,
+                        "description": "An optical channel of the microscope.",
+                    }
+                ],
+            }
+        ],
+        "TwoPhotonSeries": [
+            {
+                "name": "TwoPhotonSeries",
+                "description": "Imaging data from two-photon excitation microscopy.",
+                "unit": "n.a.",
+                "imaging_plane": "ImagingPlane",
+            }
+        ],
+        "OnePhotonSeries": [
+            {
+                "name": "OnePhotonSeries",
+                "description": "Imaging data from one-photon excitation microscopy.",
+                "unit": "n.a.",
+                "imaging_plane": "ImagingPlane",
+            }
+        ],
+        "Fluorescence": {
+            "name": "Fluorescence",
+            "PlaneSegmentation": {
+                "raw": {"name": "RoiResponseSeries", "description": "Array of raw fluorescence traces.", "unit": "n.a."}
+            },
+            "BackgroundPlaneSegmentation": {
+                "neuropil": {"name": "neuropil", "description": "Array of neuropil traces.", "unit": "n.a."}
+            },
+        },
+        "DfOverF": {
+            "name": "DfOverF",
+            "PlaneSegmentation": {
+                "dff": {"name": "RoiResponseSeries", "description": "Array of df/F traces.", "unit": "n.a."}
+            },
+        },
+        "ImageSegmentation": {
+            "name": "ImageSegmentation",
+            "plane_segmentations": [
+                {"name": "PlaneSegmentation", "description": "Segmented ROIs", "imaging_plane": "ImagingPlane"},
+                {
+                    "name": "BackgroundPlaneSegmentation",
+                    "description": "Segmented Background Components",
+                    "imaging_plane": "ImagingPlane",
+                },
+            ],
+        },
+        "SegmentationImages": {
+            "name": "SegmentationImages",
+            "description": "The summary images of the segmentation.",
+            "PlaneSegmentation": {"correlation": {"name": "correlation", "description": "The correlation image."}},
+        },
+    }
 
     return metadata
 
 
 def _get_default_segmentation_metadata() -> DeepDict:
-    """Fill default metadata for segmentation."""
-    metadata = _get_default_ophys_metadata()
+    """Fill default metadata for segmentation using _get_default_ophys_metadata()."""
+    from neuroconv.tools.nwb_helpers import get_default_nwbfile_metadata
 
-    default_fluorescence_roi_response_series = dict(
-        name="RoiResponseSeries", description="Array of raw fluorescence traces.", unit="n.a."
-    )
+    # Start with base NWB metadata
+    metadata = get_default_nwbfile_metadata()
 
-    default_fluorescence = dict(
-        name="Fluorescence",
-        PlaneSegmentation=dict(
-            raw=default_fluorescence_roi_response_series,
-        ),
-        BackgroundPlaneSegmentation=dict(
-            neuropil=dict(name="neuropil", description="Array of neuropil traces.", unit="n.a."),
-        ),
-    )
-
-    default_dff_roi_response_series = dict(
-        name="RoiResponseSeries",
-        description="Array of df/F traces.",
-        unit="n.a.",
-    )
-
-    default_df_over_f = dict(
-        name="DfOverF",
-        PlaneSegmentation=dict(
-            dff=default_dff_roi_response_series,
-        ),
-    )
-
-    default_image_segmentation = dict(
-        name="ImageSegmentation",
-        plane_segmentations=[
-            dict(
-                name="PlaneSegmentation",
-                description="Segmented ROIs",
-                imaging_plane=metadata["Ophys"]["ImagingPlane"][0]["name"],
-            ),
-            dict(
-                name="BackgroundPlaneSegmentation",
-                description="Segmented Background Components",
-                imaging_plane=metadata["Ophys"]["ImagingPlane"][0]["name"],
-            ),
-        ],
-    )
-
-    default_segmentation_images = dict(
-        name="SegmentationImages",
-        description="The summary images of the segmentation.",
-        PlaneSegmentation=dict(
-            correlation=dict(name="correlation", description="The correlation image."),
-        ),
-    )
-
-    metadata["Ophys"].update(
-        dict(
-            Fluorescence=default_fluorescence,
-            DfOverF=default_df_over_f,
-            ImageSegmentation=default_image_segmentation,
-            SegmentationImages=default_segmentation_images,
-        ),
-    )
+    # Get fresh ophys defaults and add to metadata
+    ophys_defaults = _get_default_ophys_metadata()
+    metadata["Ophys"] = {
+        "Device": ophys_defaults["Ophys"]["Device"],
+        "ImagingPlane": ophys_defaults["Ophys"]["ImagingPlane"],
+        "Fluorescence": ophys_defaults["Ophys"]["Fluorescence"],
+        "DfOverF": ophys_defaults["Ophys"]["DfOverF"],
+        "ImageSegmentation": ophys_defaults["Ophys"]["ImageSegmentation"],
+        "SegmentationImages": ophys_defaults["Ophys"]["SegmentationImages"],
+    }
 
     return metadata
 
@@ -161,34 +164,33 @@ def get_nwb_imaging_metadata(
         Dictionary containing metadata for devices, imaging planes, and photon series
         specific to the imaging data.
     """
+    # Get fresh ophys defaults
     metadata = _get_default_ophys_metadata()
 
     # TODO: get_num_channels is deprecated, remove
     channel_name_list = imgextractor.get_channel_names() or ["OpticalChannel"]
 
-    imaging_plane = metadata["Ophys"]["ImagingPlane"][0]
-    for index, channel_name in enumerate(channel_name_list):
-        if index == 0:
-            imaging_plane["optical_channel"][index]["name"] = channel_name
-        else:
-            imaging_plane["optical_channel"].append(
-                dict(
-                    name=channel_name,
-                    emission_lambda=np.nan,
-                    description="An optical channel of the microscope.",
-                )
-            )
+    # Update optical channels based on extractor data
+    optical_channels = []
+    for channel_name in channel_name_list:
+        optical_channel = metadata["Ophys"]["ImagingPlane"][0]["optical_channel"][0].copy()
+        optical_channel["name"] = channel_name
+        optical_channels.append(optical_channel)
 
-    one_photon_description = "Imaging data from one-photon excitation microscopy."
-    two_photon_description = "Imaging data from two-photon excitation microscopy."
-    photon_series_metadata = dict(
-        name=photon_series_type,
-        description=two_photon_description if photon_series_type == "TwoPhotonSeries" else one_photon_description,
-        unit="n.a.",
-        imaging_plane=imaging_plane["name"],
-        dimension=list(imgextractor.get_sample_shape()),
-    )
-    metadata["Ophys"].update({photon_series_type: [photon_series_metadata]})
+    # Update imaging plane with correct optical channels
+    metadata["Ophys"]["ImagingPlane"][0]["optical_channel"] = optical_channels
+
+    # Add photon series with dimension from extractor
+    photon_series_metadata = metadata["Ophys"][photon_series_type][0].copy()
+    photon_series_metadata["dimension"] = list(imgextractor.get_sample_shape())
+    metadata["Ophys"][photon_series_type] = [photon_series_metadata]
+
+    # Keep only Device, ImagingPlane, and the specific photon series type
+    metadata["Ophys"] = {
+        "Device": metadata["Ophys"]["Device"],
+        "ImagingPlane": metadata["Ophys"]["ImagingPlane"],
+        photon_series_type: metadata["Ophys"][photon_series_type],
+    }
 
     return metadata
 

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -47,7 +47,6 @@ def _get_default_ophys_metadata():
     Returns fresh ophys default metadata dictionary.
 
     Single source of truth for all ophys default metadata.
-    Structure matches the output of get_nwb_imaging_metadata() and get_nwb_segmentation_metadata().
     Each call returns a new instance to prevent accidental mutation of global state.
     """
     metadata = get_default_nwbfile_metadata()

--- a/tests/test_modalities/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_modalities/test_ophys/test_tools_roiextractors.py
@@ -2058,3 +2058,9 @@ class TestDefaultOphysMetadataImmutability(unittest.TestCase):
         assert metadata2["Ophys"]["Device"][0]["name"] == "Microscope"
         assert metadata2["Ophys"]["ImagingPlane"][0]["name"] == "ImagingPlane"
         assert metadata2["Ophys"]["Fluorescence"]["PlaneSegmentation"]["raw"]["name"] == "RoiResponseSeries"
+
+        # Get a third instance after modifications to ensure fresh defaults
+        metadata3 = _get_default_ophys_metadata()
+        assert metadata3["Ophys"]["Device"][0]["name"] == "Microscope"
+        assert metadata3["Ophys"]["ImagingPlane"][0]["name"] == "ImagingPlane"
+        assert metadata3["Ophys"]["Fluorescence"]["PlaneSegmentation"]["raw"]["name"] == "RoiResponseSeries"


### PR DESCRIPTION
This is the first step to solve #1511. The idea here is to start from the top-down. First, define a immutable global reference for the ophys default metadata. Then, in other PRs, I will be clearing each of the writing branches of intermediate metadata mutations and only calling the defaults at the end.