### PR TITLE
Miniscope temporary re-route

### DIFF
--- a/src/neuroconv/datainterfaces/ophys/miniscope/miniscopeimagingdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/miniscope/miniscopeimagingdatainterface.py
@@ -16,6 +16,7 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
     display_name = "Miniscope Imaging"
     associated_suffixes = (".avi", ".csv", ".json")
     info = "Interface for Miniscope imaging data."
+    ExtractorName = "MiniscopeMultiRecordingImagingExtractor"
 
     @classmethod
     def get_source_schema(cls) -> dict:


### PR DESCRIPTION
The previous miniscope extractor was too general. This PR temporary remaps this to the correct one before we amend the extractor, testing and documentation here.