### PR TITLE
Add documentation for miniscope interface

### DIFF
--- a/docs/conversion_examples_gallery/imaging/miniscope.rst
+++ b/docs/conversion_examples_gallery/imaging/miniscope.rst
@@ -8,8 +8,38 @@ Install NeuroConv with the additional dependencies necessary for reading Minisco
     pip install "neuroconv[miniscope]"
 
 Miniscope simultaneously records optical physiology and behavior in the form of video data.
-The :py:class:`~neuroconv.datainterfaces.ophys.miniscope.miniscopeconverter.MiniscopeConverter` combines the two data streams
-into a single conversion.
+
+MiniscopeConverter: Multi-recording format
+==========================================
+
+The :py:class:`~neuroconv.datainterfaces.ophys.miniscope.miniscopeconverter.MiniscopeConverter` is designed for
+data where multiple recordings are organized in timestamp subfolders. It combines both imaging
+and behavioral video data streams into a single conversion.
+
+**Expected folder structure:**
+
+.. code-block::
+
+    main_folder/
+    ├── 15_03_28/              # timestamp folder
+    │   ├── Miniscope/         # imaging data
+    │   │   ├── 0.avi
+    │   │   ├── 1.avi
+    │   │   ├── metaData.json
+    │   │   └── timeStamps.csv
+    │   ├── BehavCam_2/        # behavioral video
+    │   │   ├── 0.avi
+    │   │   ├── metaData.json
+    │   │   └── timeStamps.csv
+    │   └── metaData.json
+    ├── 15_06_28/              # another timestamp folder
+    │   ├── Miniscope/
+    │   ├── BehavCam_2/
+    │   └── metaData.json
+    └── 15_12_28/
+        └── ...
+
+**Usage:**
 
 .. code-block:: python
 
@@ -18,7 +48,7 @@ into a single conversion.
     >>> from pathlib import Path
     >>> from neuroconv.converters import MiniscopeConverter
     >>>
-    >>> # The 'folder_path' is the path to the main Miniscope folder containing both the recording and behavioral data streams in separate subfolders.
+    >>> # The 'folder_path' is the path to the main Miniscope folder containing timestamp subfolders
     >>> folder_path = str(OPHYS_DATA_PATH / "imaging_datasets" / "Miniscope" / "C6-J588_Disc5")
     >>> converter = MiniscopeConverter(folder_path=folder_path, verbose=False)
     >>>
@@ -31,3 +61,64 @@ into a single conversion.
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"
     >>> converter.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)
+
+MiniscopeImagingInterface: Flexible single-recording format
+===========================================================
+
+For alternative folder structures or when you only need to convert imaging data (without behavioral video),
+use the more flexible :py:class:`~neuroconv.datainterfaces.ophys.miniscope.MiniscopeImagingInterface`.
+
+**Standard Usage with folder_path:**
+
+For the standard case, the interface expects a folder with the following structure:
+
+.. code-block::
+
+    miniscope_folder/
+    ├── 0.avi                  # video file 1
+    ├── 1.avi                  # video file 2 (optional)
+    ├── 2.avi                  # video file 3 (optional)
+    ├── metaData.json          # required configuration file
+    └── timeStamps.csv         # optional timestamps file
+
+.. code-block:: python
+
+    >>> from neuroconv.datainterfaces import MiniscopeImagingInterface
+    >>>
+    >>> # Point directly to a Miniscope folder containing .avi files and metaData.json
+    >>> folder_path = str(OPHYS_DATA_PATH / "imaging_datasets" / "Miniscope" / "C6-J588_Disc5" / "15_03_28" / "Miniscope")
+    >>> interface = MiniscopeImagingInterface(folder_path=folder_path)
+    >>>
+    >>> # Convert to NWB
+    >>> nwbfile_path = "miniscope_single_recording.nwb"
+    >>> interface.run_conversion(nwbfile_path=nwbfile_path)
+
+**Alternative Parameters for Non-Standard Structures:**
+
+If you don't have the required configuration file in the expected location, or if the timestamps are stored elsewhere,
+you can specify the file paths directly using these parameters:
+
+- ``file_paths`` (*list*): List of .avi file paths to be processed from the same recording session
+- ``configuration_file_path`` (*str*): Path to the metaData.json configuration file
+- ``timeStamps_file_path`` (*str, optional*): Path to the timeStamps.csv file containing timestamps for this recording
+
+**Example with custom file paths:**
+
+.. code-block:: python
+
+    >>> from neuroconv.datainterfaces import MiniscopeImagingInterface
+    >>>
+    >>> # Specify individual files for non-standard folder structures
+    >>> file_paths = ["/path/to/video1.avi", "/path/to/video2.avi"]
+    >>> configuration_file_path = "/path/to/metaData.json"
+    >>> timeStamps_file_path = "/path/to/timeStamps.csv"  # optional
+    >>>
+    >>> interface = MiniscopeImagingInterface(
+    ...     file_paths=file_paths,
+    ...     configuration_file_path=configuration_file_path,
+    ...     timeStamps_file_path=timeStamps_file_path
+    ... )
+    >>>
+    >>> # Convert to NWB
+    >>> nwbfile_path = "miniscope_custom_structure.nwb"
+    >>> interface.run_conversion(nwbfile_path=nwbfile_path)

--- a/src/neuroconv/datainterfaces/ophys/miniscope/miniscopeconverter.py
+++ b/src/neuroconv/datainterfaces/ophys/miniscope/miniscopeconverter.py
@@ -1,18 +1,25 @@
 from pydantic import DirectoryPath, validate_call
 from pynwb import NWBFile
 
-from ... import MiniscopeBehaviorInterface, MiniscopeImagingInterface
+from .miniscopeimagingdatainterface import _MiniscopeMultiRecordingInterface
+from ... import MiniscopeBehaviorInterface
 from ....nwbconverter import NWBConverter
 from ....tools.nwb_helpers import make_or_load_nwbfile
 from ....utils import get_json_schema_from_method_signature
 
 
 class MiniscopeConverter(NWBConverter):
-    """Primary conversion class for handling Miniscope data streams."""
+    """Primary conversion class for handling Miniscope multi-recording data streams.
+
+    This converter is designed for data where multiple recordings are organized
+    in timestamp subfolders, each containing Miniscope and behavioral camera subfolders.
+    """
 
     display_name = "Miniscope Imaging and Video"
-    keywords = MiniscopeImagingInterface.keywords + MiniscopeBehaviorInterface.keywords
-    associated_suffixes = MiniscopeImagingInterface.associated_suffixes + MiniscopeBehaviorInterface.associated_suffixes
+    keywords = _MiniscopeMultiRecordingInterface.keywords + MiniscopeBehaviorInterface.keywords
+    associated_suffixes = (
+        _MiniscopeMultiRecordingInterface.associated_suffixes + MiniscopeBehaviorInterface.associated_suffixes
+    )
     info = "Converter for handling both imaging and video recordings from Miniscope."
 
     @classmethod
@@ -54,7 +61,7 @@ class MiniscopeConverter(NWBConverter):
         """
         self.verbose = verbose
         self.data_interface_objects = dict(
-            MiniscopeImaging=MiniscopeImagingInterface(folder_path=folder_path),
+            MiniscopeImaging=_MiniscopeMultiRecordingInterface(folder_path=folder_path),
             MiniscopeBehavCam=MiniscopeBehaviorInterface(folder_path=folder_path),
         )
 

--- a/src/neuroconv/datainterfaces/ophys/miniscope/miniscopeimagingdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/miniscope/miniscopeimagingdatainterface.py
@@ -10,12 +10,12 @@ from ..baseimagingextractorinterface import BaseImagingExtractorInterface
 from ....utils import DeepDict, dict_deep_update
 
 
-class MiniscopeImagingInterface(BaseImagingExtractorInterface):
-    """Data Interface for MiniscopeImagingExtractor."""
+class _MiniscopeMultiRecordingInterface(BaseImagingExtractorInterface):
+    """Data Interface for MiniscopeMultiRecordingImagingExtractor."""
 
-    display_name = "Miniscope Imaging"
+    display_name = "Miniscope Multi-Recording Imaging"
     associated_suffixes = (".avi", ".csv", ".json")
-    info = "Interface for Miniscope imaging data."
+    info = "Interface for Miniscope multi-recording imaging data."
     ExtractorName = "MiniscopeMultiRecordingImagingExtractor"
 
     @classmethod
@@ -161,4 +161,158 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
             nwbfile=nwbfile,
             metadata=metadata,
             photon_series_type=photon_series_type,
+        )
+
+
+class MiniscopeImagingInterface(BaseImagingExtractorInterface):
+    """Data Interface for MiniscopeImagingExtractor.
+
+    This interface handles single Miniscope recordings from a folder containing .avi files
+    and a metaData.json configuration file. It provides flexible options for different
+    folder structures.
+
+    Expected folder structure for folder_path:
+
+    .. code-block::
+
+        miniscope_folder/
+        ├── 0.avi                  # video file 1
+        ├── 1.avi                  # video file 2 (optional)
+        ├── 2.avi                  # video file 3 (optional)
+        ├── metaData.json          # required configuration file
+        └── timeStamps.csv         # optional timestamps file
+
+    Two usage modes:
+    1. folder_path: Point directly to a Miniscope folder containing .avi files and metaData.json
+    2. file_paths + configuration_file_path: Specify individual files for non-standard structures
+    """
+
+    display_name = "Miniscope Imaging"
+    associated_suffixes = (".avi", ".csv", ".json")
+    info = "Interface for Miniscope imaging data from single recordings."
+    ExtractorName = "MiniscopeImagingExtractor"
+
+    def _source_data_to_extractor_kwargs(self, source_data: dict) -> dict:
+        """
+        Map interface parameters to extractor parameters.
+
+        The interface uses timeStamps_file_path but the extractor expects timestamps_path.
+        """
+        extractor_kwargs = source_data.copy()
+
+        # Map timeStamps_file_path to timestamps_path for the extractor
+        if "timeStamps_file_path" in extractor_kwargs:
+            extractor_kwargs["timestamps_path"] = extractor_kwargs.pop("timeStamps_file_path")
+
+        return extractor_kwargs
+
+    @validate_call
+    def __init__(
+        self,
+        folder_path: DirectoryPath = None,
+        file_paths: list = None,
+        configuration_file_path: str = None,
+        timeStamps_file_path: str = None,
+        verbose: bool = False,
+    ):
+        """
+        Initialize reading the Miniscope imaging data.
+
+        Parameters
+        ----------
+        folder_path : DirectoryPath, optional
+            Path to the Miniscope folder containing .avi files and metaData.json.
+            Use this for standard single-recording folder structures.
+        file_paths : list, optional
+            List of .avi file paths to be processed. These files should be from the same
+            recording session and will be concatenated in the order provided.
+            Use this for non-standard folder structures.
+        configuration_file_path : str, optional
+            Path to the metaData.json configuration file containing recording parameters.
+            Required when using file_paths parameter.
+        timeStamps_file_path : str, optional
+            Path to the timeStamps.csv file containing timestamps relative to the recording start.
+            If not provided, the extractor will look for timeStamps.csv in the same directory
+            as the configuration file.
+        verbose : bool, optional
+            If True, enables verbose mode for detailed logging, by default False.
+        """
+        # Validate parameter combinations
+        if folder_path is None and (file_paths is None or configuration_file_path is None):
+            raise ValueError(
+                "Either 'folder_path' must be provided, or both 'file_paths' and 'configuration_file_path' must be provided."
+            )
+
+        if folder_path is not None and (file_paths is not None or configuration_file_path is not None):
+            raise ValueError(
+                "When 'folder_path' is provided, 'file_paths' and 'configuration_file_path' cannot be specified. "
+                "Use either folder_path alone or provide file_paths with configuration_file_path."
+            )
+
+        # Initialize with the provided parameters
+        super().__init__(
+            folder_path=folder_path,
+            file_paths=file_paths,
+            configuration_file_path=configuration_file_path,
+            timestamps_path=timeStamps_file_path,
+            verbose=verbose,
+        )
+
+        self.photon_series_type = "OnePhotonSeries"
+
+    def get_metadata(self) -> dict:
+        """Get metadata with device information from Miniscope configuration."""
+        metadata = super().get_metadata()
+
+        # Extract device metadata from the extractor's config
+        device_metadata = metadata["Ophys"]["Device"][0]
+        device_name = self.imaging_extractor._miniscope_config.get("deviceName", "Miniscope")
+
+        # Only include valid Device schema fields
+        valid_device_fields = ["name", "description", "manufacturer", "model_number", "model_name", "serial_number"]
+        device_updates = {"name": device_name}
+
+        # Map deviceType to model_name if available
+        if "deviceType" in self.imaging_extractor._miniscope_config:
+            device_updates["model_name"] = self.imaging_extractor._miniscope_config["deviceType"]
+
+        device_metadata.update(device_updates)
+
+        # Update imaging plane metadata
+        imaging_plane_metadata = metadata["Ophys"]["ImagingPlane"][0]
+        imaging_plane_metadata.update(
+            device=device_name,
+            imaging_rate=self.imaging_extractor.get_sampling_frequency(),
+        )
+
+        # Update photon series metadata
+        if "OnePhotonSeries" in metadata["Ophys"]:
+            one_photon_series_metadata = metadata["Ophys"]["OnePhotonSeries"][0]
+            one_photon_series_metadata.update(unit="px")
+
+        return metadata
+
+    def add_to_nwbfile(
+        self,
+        nwbfile: NWBFile,
+        metadata: dict | None = None,
+        photon_series_type: Literal["TwoPhotonSeries", "OnePhotonSeries"] = "OnePhotonSeries",
+        **kwargs,
+    ):
+        """
+        Add imaging data to the NWBFile with Miniscope-specific device.
+
+        This method adds the Miniscope device and then delegates to the parent class.
+        """
+        from ndx_miniscope.utils import add_miniscope_device
+
+        # Add Miniscope device - required for proper ndx_miniscope.Miniscope device type
+        device_metadata = metadata["Ophys"]["Device"][0]
+        add_miniscope_device(nwbfile=nwbfile, device_metadata=device_metadata)
+
+        super().add_to_nwbfile(
+            nwbfile=nwbfile,
+            metadata=metadata,
+            photon_series_type=photon_series_type,
+            **kwargs,
         )


### PR DESCRIPTION
Ok, this PR ports the work that @alessandratrapani has done in roiextractors to improve our miniscope conversion:

* To keep backwards compatibility it keeps the `MiniscopeConverter` working was it was before. It is still overfitting to the structure of the Tye Lab in two important ways that are discussed here: https://github.com/catalystneuro/roiextractors/issues/356. We can then slowly improve this to be better by removing the assumption of contigous sub-sessions and using the [configuration file to get the folder structure](https://github.com/catalystneuro/roiextractors/issues/356#issuecomment-3325184204) when available. To accomplish this, the PR introduces a private `_MiniscopeMultiRecordingInterface` which is the previous interface without any modifications so everything keeps working as it was.
* There should be a way of converting data and while we work on improving the converter we expose a now more flexible `MiniscopeImagingInterface` that can handle a single session recording when it has the expected structure with a `folder_path` and has a fallback `file_paths` parameter, together with an optional localization of the configuration file path and the timestamps for extra flexibility. The idea is that while we improve the converter this will allow users to conver their data and we can use the interface as the base for future improvmeents fo the converter.
* Finally, it is important to note that we don't have a flexible way of converting single session behavior data associated with Miniscope. This will have to wait.