### PR TITLE
Temporary ceiling on hdmf-zarr version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Ophys: Passing `pynwb.device.Device` objects in `metadata['Ophys']['Device']` to `add_devices_to_nwbfile` now issues a `FutureWarning` and is deprecated. This feature will be removed on or after March 2026. Pass device definitions as dictionaries instead (e.g., `{ "name": "Microscope" }`). . [PR #1513](https://github.com/catalystneuro/neuroconv/pull/1513)
 
 ## Bug Fixes
+* Temporary ceiling on hdmf‑zarr (<0.12) to retain compatibility with existing code that uses read_io.file.store [PR #1547](https://github.com/catalystneuro/neuroconv/pull/1547)
 * Fixed `append_on_disk_nwbfile=True` raising ValueError when file exists. Replaced `make_or_load_nwbfile` with direct pynwb `NWBHDF5IO` usage in append mode and improved code organization with private helper methods `_write_nwbfile` and `_append_nwbfile` in both `BaseDataInterface` and `NWBConverter` [PR #1540](https://github.com/catalystneuro/neuroconv/pull/1540)
 
 ## Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "PyYAML>=5.4",
     "h5py>=3.9.0",
     "hdmf>=4.0.0",
-    "hdmf_zarr>=0.11",
+    "hdmf_zarr<0.12",
     "pynwb>=3.0.0",
     "pydantic>=2.0",
     "typing_extensions>=4.1.0",


### PR DESCRIPTION
This unblock the CI from failure while we think on a better solution for https://github.com/catalystneuro/neuroconv/pull/1545 