### PR TITLE
Fix broken links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,6 +85,7 @@ linkcheck_anchors = False
 linkcheck_ignore = [
     "https://buzsakilab.com/wp/",  # Ignoring because their ssl certificate is expired
     r"https://stackoverflow\.com/.*",  # The r is because of the regex, stackoverflow links are forbidden to bots
+    "https://catalystneuro.com/*/",
 ]
 
 # --------------------------------------------------

--- a/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
@@ -258,7 +258,7 @@ class InternalVideoInterface(BaseDataInterface):
         iterator_options : dict, optional
             Options for controlling iterative write when buffer_data=True.
             See the `pynwb tutorial on iterative write
-            <https://pynwb.readthedocs.io/en/stable/tutorials/general/iterative_write.html>`_
+            <https://pynwb.readthedocs.io/en/stable/tutorials/advanced_io/plot_iterative_write.html#sphx-glr-tutorials-advanced-io-plot-iterative-write-py>`_
             for more information on chunked data writing.
 
             Available options:

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -359,7 +359,7 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
         iterator_options : dict, optional
             Options for controlling iterative write when iterator_type='v2'.
             See the `pynwb tutorial on iterative write
-            <https://pynwb.readthedocs.io/en/stable/tutorials/general/iterative_write.html>`_
+            <https://pynwb.readthedocs.io/en/stable/tutorials/advanced_io/plot_iterative_write.html#sphx-glr-tutorials-advanced-io-plot-iterative-write-py>`_
             for more information on chunked data writing.
 
             Available options:

--- a/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
@@ -186,7 +186,7 @@ class BaseImagingExtractorInterface(BaseExtractorInterface):
             Note: 'v1' is deprecated and will be removed on or after March 2026.
         iterator_options : dict, optional
             Options for controlling the iterative write process (buffer size, progress bars).
-            See the `pynwb tutorial on iterative write <https://pynwb.readthedocs.io/en/stable/tutorials/general/iterative_write.html>`_
+            See the `pynwb tutorial on iterative write <https://pynwb.readthedocs.io/en/stable/tutorials/advanced_io/plot_iterative_write.html#sphx-glr-tutorials-advanced-io-plot-iterative-write-py>`_
             for more information on chunked data writing.
 
             Note: To configure chunk size and compression, use the backend configuration system

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -756,7 +756,7 @@ def _imaging_frames_to_hdmf_iterator(
         Note: 'v1' is deprecated and will be removed on or after March 2026.
     iterator_options : dict, optional
         Options for controlling the iterative write process. See the
-        `pynwb tutorial on iterative write <https://pynwb.readthedocs.io/en/stable/tutorials/general/iterative_write.html>`_
+        `pynwb tutorial on iterative write <https://pynwb.readthedocs.io/en/stable/tutorials/advanced_io/plot_iterative_write.html#sphx-glr-tutorials-advanced-io-plot-iterative-write-py>`_
         for more information on chunked data writing.
 
     Returns
@@ -897,7 +897,7 @@ def write_imaging_to_nwbfile(
         Note: 'v1' is deprecated and will be removed on or after March 2026.
     iterator_options : dict, optional
         Options for controlling the iterative write process. See the
-        `pynwb tutorial on iterative write <https://pynwb.readthedocs.io/en/stable/tutorials/general/iterative_write.html>`_
+        `pynwb tutorial on iterative write <https://pynwb.readthedocs.io/en/stable/tutorials/advanced_io/plot_iterative_write.html#sphx-glr-tutorials-advanced-io-plot-iterative-write-py>`_
         for more information on chunked data writing.
     """
     assert (


### PR DESCRIPTION
I introduced this wrong link in https://github.com/catalystneuro/neuroconv/pull/1546

I am also removing the link to the catalyst neuro page which keeps failing intermittently. 