### PR TITLE
Add subject information to conversion examples for DANDI compliance

### DIFF
--- a/docs/conversion_examples_gallery/behavior/audio.rst
+++ b/docs/conversion_examples_gallery/behavior/audio.rst
@@ -25,6 +25,8 @@ This interface can handle conversions from `WAV` format to NWB using the
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> interface.run_conversion(nwbfile_path=path_to_save_nwbfile, metadata=metadata)

--- a/docs/conversion_examples_gallery/behavior/deeplabcut.rst
+++ b/docs/conversion_examples_gallery/behavior/deeplabcut.rst
@@ -26,6 +26,8 @@ This interface supports both .h5 and .csv output files from DeepLabCut.
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> interface.run_conversion(nwbfile_path=path_to_save_nwbfile, metadata=metadata)
 
@@ -104,6 +106,8 @@ use the following structure:
 
     >>> # Add skeleton metadata to the main metadata
     >>> metadata["PoseEstimation"]["Skeletons"] = skeletons_metadata
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "saved_file.nwb"

--- a/docs/conversion_examples_gallery/behavior/fictrac.rst
+++ b/docs/conversion_examples_gallery/behavior/fictrac.rst
@@ -26,7 +26,8 @@ Convert FicTrac spherical motion and fictive animal path data in a FicTrac ``.da
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 
-    >>> # For data provenance we add the time zone information to the conversion
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> interface.run_conversion(nwbfile_path=path_to_save_nwbfile, metadata=metadata)

--- a/docs/conversion_examples_gallery/behavior/lightningpose.rst
+++ b/docs/conversion_examples_gallery/behavior/lightningpose.rst
@@ -28,6 +28,8 @@ Convert LightningPose pose estimation data to NWB using :py:class:`~neuroconv.da
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
     >>> tzinfo = ZoneInfo("US/Pacific")
     >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> converter.run_conversion(nwbfile_path=path_to_save_nwbfile, metadata=metadata)

--- a/docs/conversion_examples_gallery/behavior/medpc.rst
+++ b/docs/conversion_examples_gallery/behavior/medpc.rst
@@ -80,6 +80,8 @@ Convert MedPC output data to NWB using
     ...         "duration_name": "duration_of_port_entry",
     ...     },
     ... ]
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./saved_file.nwb"

--- a/docs/conversion_examples_gallery/behavior/neuralynx_nvt.rst
+++ b/docs/conversion_examples_gallery/behavior/neuralynx_nvt.rst
@@ -29,7 +29,9 @@ Convert Neuralynx NVT data to NWB using
     >>> # We add the time zone information, which is required by NWB
     >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
-    >>>  # Choose a path for saving the nwb file and run the conversion
+    >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./saved_file.nwb"
     >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)

--- a/docs/conversion_examples_gallery/behavior/sleap.rst
+++ b/docs/conversion_examples_gallery/behavior/sleap.rst
@@ -26,6 +26,8 @@ Convert SLEAP pose estimation data to NWB using :py:class:`~neuroconv.datainterf
     >>> # automatically from the source files you must supply one.
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "saved_file.nwb"

--- a/docs/conversion_examples_gallery/behavior/video.rst
+++ b/docs/conversion_examples_gallery/behavior/video.rst
@@ -36,6 +36,8 @@ To follow this convention use the
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "saved_file.nwb"
@@ -63,6 +65,8 @@ To follow this convention use the
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "saved_file.nwb"
@@ -110,6 +114,8 @@ This metadata can then be easily incorporated into the conversion by updating th
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>> metadata = dict_deep_update(metadata, video_metadata)
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "saved_file.nwb"
@@ -144,6 +150,8 @@ Similarly for :py:class:`~neuroconv.datainterfaces.behavior.video.internalvideod
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>> metadata = dict_deep_update(metadata, video_metadata)
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "saved_file.nwb"

--- a/docs/conversion_examples_gallery/combinations/ecephys_pose_estimation.rst
+++ b/docs/conversion_examples_gallery/combinations/ecephys_pose_estimation.rst
@@ -38,6 +38,8 @@ For this specific example were are combining a OpenEphys recording with KiloSort
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific")).isoformat()
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/combinations/spikeglx_and_phy.rst
+++ b/docs/conversion_examples_gallery/combinations/spikeglx_and_phy.rst
@@ -31,6 +31,8 @@ were are combining a SpikeGLX recording with Phy sorting results using the
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/combinations/tiff_and_suite2p.rst
+++ b/docs/conversion_examples_gallery/combinations/tiff_and_suite2p.rst
@@ -31,6 +31,8 @@ workflow in neuroconv for Tiff imaging files segmented using suite2p. This conve
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/fiberphotometry/tdt_fp.rst
+++ b/docs/conversion_examples_gallery/fiberphotometry/tdt_fp.rst
@@ -130,6 +130,8 @@ Convert TDT Fiber Photometry data to NWB using
     >>> interface = TDTFiberPhotometryInterface(folder_path=folder_path, verbose=False)
     >>> metadata = interface.get_metadata()
     >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("US/Pacific"))
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>> metadata = dict_deep_update(metadata, fiber_photometry_metadata)
 
     >>> # Choose a path for saving the nwb file and run the conversion
@@ -507,6 +509,8 @@ This metadata can then be easily incorporated into the conversion by updating th
     >>> interface = TDTFiberPhotometryInterface(folder_path=folder_path, verbose=False)
     >>> metadata = interface.get_metadata()
     >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("US/Pacific"))
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>> metadata = dict_deep_update(metadata, fiber_photometry_metadata)
 
     >>> # Choose a path for saving the nwb file and run the conversion

--- a/docs/conversion_examples_gallery/imaging/brukertiff.rst
+++ b/docs/conversion_examples_gallery/imaging/brukertiff.rst
@@ -26,6 +26,8 @@ Convert Bruker TIFF imaging data to NWB using
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
     >>> tzinfo = ZoneInfo("US/Pacific")
     >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"
@@ -53,6 +55,8 @@ Use "contiguous" to create the volumetric two photon series, and "disjoint" to c
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
     >>> tzinfo = ZoneInfo("US/Pacific")
     >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{output_folder}/test2.nwb"

--- a/docs/conversion_examples_gallery/imaging/femtonics.rst
+++ b/docs/conversion_examples_gallery/imaging/femtonics.rst
@@ -22,6 +22,8 @@ Convert Femtonics imaging data to NWB using :py:class:`~neuroconv.datainterfaces
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/imaging/hdf5imaging.rst
+++ b/docs/conversion_examples_gallery/imaging/hdf5imaging.rst
@@ -23,6 +23,8 @@ Convert HDF5 imaging data to NWB using :py:class:`~neuroconv.datainterfaces.ophy
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/imaging/image.rst
+++ b/docs/conversion_examples_gallery/imaging/image.rst
@@ -66,6 +66,8 @@ Example Usage
     >>> metadata = interface.get_metadata()
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"
     >>> interface.run_conversion(nwbfile_path=path_to_save_nwbfile, metadata=metadata)
@@ -140,6 +142,8 @@ You can customize the container name and add descriptions, names, and resolution
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Customize container description
     >>> metadata["Images"][metadata_key]["description"] = "Collection of experimental stimulus and baseline images"

--- a/docs/conversion_examples_gallery/imaging/inscopix.rst
+++ b/docs/conversion_examples_gallery/imaging/inscopix.rst
@@ -23,6 +23,8 @@ Convert Inscopix imaging data to NWB using :py:class:`~neuroconv.datainterfaces.
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/imaging/micromanagertiff.rst
+++ b/docs/conversion_examples_gallery/imaging/micromanagertiff.rst
@@ -25,6 +25,8 @@ Convert Micro-Manager TIFF imaging data to NWB using
     >>> if session_start_time.tzinfo is None:
     ...     tzinfo = ZoneInfo("US/Pacific")
     ...     metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/imaging/miniscope.rst
+++ b/docs/conversion_examples_gallery/imaging/miniscope.rst
@@ -36,6 +36,8 @@ streams into a single NWB conversion. Behavioral video is handled automatically 
     >>> metadata = converter.get_metadata()
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
     >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=ZoneInfo("US/Pacific")))
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> nwbfile_path = f"{path_to_save_nwbfile}"
     >>> converter.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata, overwrite=True)
@@ -85,6 +87,8 @@ The interface expects a folder with the following structure:
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
     >>> # For data provenance we can add the time zone information to the conversion
     >>> metadata["NWBFile"]["session_start_time"] = session_start_time.replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Convert to NWB
     >>> nwbfile_path = f"{path_to_save_nwbfile}"
@@ -164,6 +168,8 @@ we need to use ``set_aligned_starting_time()`` to shift the timestamps of the se
     >>> metadata = converter.get_metadata()
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
     >>> metadata["NWBFile"]["session_start_time"] = session_start_time.replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Add a second OnePhotonSeries entry to metadata with a unique name
     >>> acquisition2_metadata = metadata["Ophys"]["OnePhotonSeries"][0].copy()

--- a/docs/conversion_examples_gallery/imaging/scanbox.rst
+++ b/docs/conversion_examples_gallery/imaging/scanbox.rst
@@ -24,6 +24,8 @@ Convert Scanbox imaging data to NWB using
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/imaging/scanimage.rst
+++ b/docs/conversion_examples_gallery/imaging/scanimage.rst
@@ -34,6 +34,8 @@ For multi-channel data, you need to specify the channel name, and you can use `p
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/imaging/scanimage_legacy.rst
+++ b/docs/conversion_examples_gallery/imaging/scanimage_legacy.rst
@@ -29,6 +29,8 @@ Convert ScanImage TIFF files to NWB using :py:class:`~neuroconv.datainterfaces.o
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/imaging/thor.rst
+++ b/docs/conversion_examples_gallery/imaging/thor.rst
@@ -18,9 +18,13 @@ Convert Thor TIFF imaging data to NWB using
     >>> file_path = OPHYS_DATA_PATH / "imaging_datasets" / "ThorlabsTiff" / "single_channel_single_plane" / "20231018-002" / "ChanA_001_001_001_001.tif"
     >>> interface = ThorImagingInterface(file_path=file_path, channel_name="ChanA")
     >>>
+    >>> metadata = interface.get_metadata()
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
+    >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"
-    >>> interface.run_conversion(nwbfile_path=nwbfile_path)
+    >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)
 
 
 .. note::

--- a/docs/conversion_examples_gallery/imaging/tiff.rst
+++ b/docs/conversion_examples_gallery/imaging/tiff.rst
@@ -28,6 +28,8 @@ Single File, Planar and Single-Channel TIFF conversion
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"
@@ -88,6 +90,8 @@ number of channels, which channel to extract, and number of planes:
     >>> metadata = interface.get_metadata()
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> nwbfile_path = f"{path_to_save_nwbfile}"
     >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata, overwrite=True)

--- a/docs/conversion_examples_gallery/recording/alphaomega.rst
+++ b/docs/conversion_examples_gallery/recording/alphaomega.rst
@@ -22,6 +22,8 @@ Convert AlphaOmega data to NWB using :py:class:`~neuroconv.datainterfaces.ecephy
     >>>
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/recording/axon.rst
+++ b/docs/conversion_examples_gallery/recording/axon.rst
@@ -21,6 +21,8 @@ Convert Axon ABF data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.
     >>> metadata = interface.get_metadata()
     >>> # session_start_time is automatically extracted from ABF file metadata
     >>> # but can be overridden if needed
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./saved_file.nwb"
     >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)

--- a/docs/conversion_examples_gallery/recording/axona.rst
+++ b/docs/conversion_examples_gallery/recording/axona.rst
@@ -27,6 +27,8 @@ Convert axona data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.axo
     >>> tzinfo = ZoneInfo("US/Pacific")
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
     >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/recording/biocam.rst
+++ b/docs/conversion_examples_gallery/recording/biocam.rst
@@ -25,6 +25,8 @@ Convert Biocam data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.bi
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/recording/blackrock.rst
+++ b/docs/conversion_examples_gallery/recording/blackrock.rst
@@ -28,6 +28,8 @@ Convert Blackrock data to NWB using
     >>> session_start_time = datetime.fromisoformat(metadata["NWBFile"]["session_start_time"])
     >>> session_start_time = session_start_time.replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/recording/edf.rst
+++ b/docs/conversion_examples_gallery/recording/edf.rst
@@ -41,6 +41,8 @@ Other auxiliary signal channels should be excluded using the ``channels_to_skip`
     # For data provenance we add the time zone information to the conversion
     session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     metadata["NWBFile"].update(session_start_time=session_start_time)
+    # Add subject information (required for DANDI upload)
+    metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 
     # Choose a path for saving the nwb file and run the conversion
     nwbfile_path = f"{path_to_save_nwbfile}"
@@ -79,6 +81,8 @@ you'll need to create separate EDFAnalogInterface instances for each unit type:
     # For data provenance we add the time zone information to the conversion
     session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     metadata["NWBFile"].update(session_start_time=session_start_time)
+    # Add subject information (required for DANDI upload)
+    metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 
     # Choose a path for saving the nwb file and run the conversion
     nwbfile_path = f"{path_to_save_nwbfile}"
@@ -137,6 +141,8 @@ Remember to group auxiliary channels by their unit types:
     # For data provenance we add the time zone information to the conversion
     session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     metadata["NWBFile"].update(session_start_time=session_start_time)
+    # Add subject information (required for DANDI upload)
+    metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 
     # REQUIRED: Customize TimeSeries names when using multiple analog interfaces
     user_edited_metadata = {

--- a/docs/conversion_examples_gallery/recording/intan.rst
+++ b/docs/conversion_examples_gallery/recording/intan.rst
@@ -31,6 +31,8 @@ This interface handles the primary neural recordings from the RHD2000 or RHS2000
     >>> # automatically from the source files you must supply one.
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./saved_file.nwb"
     >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata, overwrite=True)
@@ -73,6 +75,8 @@ USB board ADC input channels
     >>> # session_start_time is required but not available on intan
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"
@@ -105,6 +109,8 @@ You can also convert auxiliary input channels (e.g., accelerometer data):
     >>> # session_start_time is required but not available on intan
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata_aux["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata_aux["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path_aux = output_folder / "intan_auxiliary_conversion.nwb"
@@ -137,6 +143,8 @@ For RHS systems, you can also convert DC amplifier channels:
     >>> # session_start_time is required but not available on intan
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata_dc["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata_dc["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path_dc = output_folder / "intan_dc_amplifier_conversion.nwb"
@@ -170,6 +178,8 @@ For RHS systems, you can also convert ADC output channels:
     >>> # automatically from the source files you must supply one.
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata_output["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata_output["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path_output = output_folder / "intan_adc_output_conversion.nwb"

--- a/docs/conversion_examples_gallery/recording/maxwell.rst
+++ b/docs/conversion_examples_gallery/recording/maxwell.rst
@@ -30,6 +30,8 @@ Convert MaxOne data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.ma
     # For data provenance we add the time zone information to the conversion
     session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     metadata["NWBFile"].update(session_start_time=session_start_time)
+    # Add subject information (required for DANDI upload)
+    metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 
     # Choose a path for saving the nwb file and run the conversion
     nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/recording/mcsraw.rst
+++ b/docs/conversion_examples_gallery/recording/mcsraw.rst
@@ -25,6 +25,8 @@ Convert MCSRaw data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.mc
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/recording/mearec.rst
+++ b/docs/conversion_examples_gallery/recording/mearec.rst
@@ -25,6 +25,8 @@ Convert MEArec data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.me
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/recording/neuralynx.rst
+++ b/docs/conversion_examples_gallery/recording/neuralynx.rst
@@ -29,8 +29,10 @@ Convert Neuralynx data to NWB using
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
     >>> session_start_time = session_start_time.replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"]["session_start_time"] = session_start_time
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
-    >>>  # Choose a path for saving the nwb file and run the conversion
+    >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./saved_file.nwb"
     >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)
 

--- a/docs/conversion_examples_gallery/recording/neuroscope.rst
+++ b/docs/conversion_examples_gallery/recording/neuroscope.rst
@@ -28,6 +28,8 @@ Convert NeuroScope data to NWB using
     >>> # automatically from the source files you must supply one.
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>>  # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./saved_file.nwb"

--- a/docs/conversion_examples_gallery/recording/openephys.rst
+++ b/docs/conversion_examples_gallery/recording/openephys.rst
@@ -26,6 +26,8 @@ Convert OpenEphys data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys
     >>> # automatically from the source files you must supply one.
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./saved_file.nwb"

--- a/docs/conversion_examples_gallery/recording/plexon.rst
+++ b/docs/conversion_examples_gallery/recording/plexon.rst
@@ -25,6 +25,8 @@ Convert Plexon recording data to NWB using :py:class:`~neuroconv.datainterfaces.
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/recording/plexon2.rst
+++ b/docs/conversion_examples_gallery/recording/plexon2.rst
@@ -29,6 +29,8 @@ Convert Plexon2 recording data to NWB using :py:class:`~neuroconv.datainterfaces
     tzinfo = ZoneInfo("US/Pacific")
     session_start_time = metadata["NWBFile"]["session_start_time"]
     metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
+    # Add subject information (required for DANDI upload)
+    metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 
     # Choose a path for saving the nwb file and run the conversion
     nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/recording/spike2.rst
+++ b/docs/conversion_examples_gallery/recording/spike2.rst
@@ -27,6 +27,8 @@ Convert Spike2 data to NWB using
     # For data provenance we add the time zone information to the conversion
     session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     metadata["NWBFile"].update(session_start_time=session_start_time)
+    # Add subject information (required for DANDI upload)
+    metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 
     # Choose a path for saving the nwb file and run the conversion
     nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/recording/spikegadgets.rst
+++ b/docs/conversion_examples_gallery/recording/spikegadgets.rst
@@ -27,6 +27,8 @@ Convert spikegadgets data to NWB using
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>>  # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/recording/spikeglx.rst
+++ b/docs/conversion_examples_gallery/recording/spikeglx.rst
@@ -29,6 +29,8 @@ We can easily convert all data stored in the native SpikeGLX folder structure to
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = output_folder / "my_spikeglx_converter_session.nwb"
@@ -60,6 +62,8 @@ Defining a 'stream' as a single band on a single NeuroPixels probe, we can conve
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = output_folder / "my_spikeglx_session.nwb"
@@ -89,6 +93,8 @@ can be used to convert these streams to NWB.
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = output_folder / "my_spikeglx_nidq_session.nwb"
@@ -130,6 +136,8 @@ interfaces in the same conversion, each interface must have a unique ``metadata_
     ...     "description": "TTL pulses triggering stimulation events",
     ...     "labels_map": {0: "stim_off", 1: "stim_on"}
     ... }
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Run conversion with custom metadata
     >>> nwbfile_path = output_folder / "my_spikeglx_nidq_custom.nwb"

--- a/docs/conversion_examples_gallery/recording/tdt.rst
+++ b/docs/conversion_examples_gallery/recording/tdt.rst
@@ -27,6 +27,8 @@ Convert TDT data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.tdt.t
     >>> # automatically from the source files you must supply one.
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>>  # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./saved_file.nwb"

--- a/docs/conversion_examples_gallery/recording/whitematter.rst
+++ b/docs/conversion_examples_gallery/recording/whitematter.rst
@@ -33,6 +33,8 @@ Convert WhiteMatter data to NWB using :py:class:`~neuroconv.datainterfaces.eceph
     >>> # automatically from the source files you must supply one.
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>>  # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./saved_file.nwb"
@@ -99,6 +101,8 @@ This metadata can then be easily incorporated into the conversion by updating th
     >>> # automatically from the source files you must supply one.
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>> metadata = dict_deep_update(metadata, ecephys_metadata)
     >>>
     >>>  # Choose a path for saving the nwb file and run the conversion

--- a/docs/conversion_examples_gallery/segmentation/caiman.rst
+++ b/docs/conversion_examples_gallery/segmentation/caiman.rst
@@ -23,6 +23,8 @@ Convert CaImAn segmentation data to NWB using :py:class:`~neuroconv.datainterfac
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/segmentation/cnmfe.rst
+++ b/docs/conversion_examples_gallery/segmentation/cnmfe.rst
@@ -24,6 +24,8 @@ Convert CNMFE segmentation data to NWB using :py:class:`~neuroconv.datainterface
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/segmentation/extract.rst
+++ b/docs/conversion_examples_gallery/segmentation/extract.rst
@@ -24,6 +24,8 @@ Convert EXTRACT segmentation data to NWB using :py:class:`~neuroconv.datainterfa
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/segmentation/inscopix.rst
+++ b/docs/conversion_examples_gallery/segmentation/inscopix.rst
@@ -21,6 +21,8 @@ Convert Inscopix segmentation data to NWB using :py:class:`~neuroconv.datainterf
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/segmentation/minian.rst
+++ b/docs/conversion_examples_gallery/segmentation/minian.rst
@@ -46,6 +46,8 @@ Minian does not store sampling frequency information in its native output. For N
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/segmentation/suite2p.rst
+++ b/docs/conversion_examples_gallery/segmentation/suite2p.rst
@@ -34,6 +34,8 @@ When multiple planes and/or channels are present, the name should be unique for 
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"
@@ -60,6 +62,8 @@ This example shows how to convert multiple planes from the same dataset.
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{output_folder}/file2.nwb"

--- a/docs/conversion_examples_gallery/sorting/blackrock.rst
+++ b/docs/conversion_examples_gallery/sorting/blackrock.rst
@@ -27,6 +27,8 @@ Convert Blackrock sorting data to NWB using
     >>> session_start_time = datetime.fromisoformat(metadata["NWBFile"]["session_start_time"])
     >>> session_start_time = session_start_time.replace(tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> nwbfile_path = f"{path_to_save_nwbfile}" # This should be something like: "./saved_file.nwb"
     >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)

--- a/docs/conversion_examples_gallery/sorting/cellexplorer.rst
+++ b/docs/conversion_examples_gallery/sorting/cellexplorer.rst
@@ -27,6 +27,8 @@ Convert CellExplorer sorting data to NWB using :py:class:`~neuroconv.datainterfa
     >>> tzinfo = ZoneInfo("US/Pacific")
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific")).isoformat()
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/sorting/kilosort.rst
+++ b/docs/conversion_examples_gallery/sorting/kilosort.rst
@@ -25,5 +25,8 @@ Convert KiloSort data to NWB using
     >>> metadata = interface.get_metadata()
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
+    >>>
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./saved_file.nwb"
     >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)

--- a/docs/conversion_examples_gallery/sorting/neuralynx.rst
+++ b/docs/conversion_examples_gallery/sorting/neuralynx.rst
@@ -26,5 +26,8 @@ Convert Neuralynx data to NWB using
     >>> metadata = interface.get_metadata()
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific")).isoformat()
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
+    >>>
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./neuralynx_conversion.nwb"
     >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)

--- a/docs/conversion_examples_gallery/sorting/neuroscope.rst
+++ b/docs/conversion_examples_gallery/sorting/neuroscope.rst
@@ -28,6 +28,8 @@ Convert NeuroScope sorting data to NWB using
     >>> # automatically from the source files you must supply one.
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>>  # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./saved_file.nwb"

--- a/docs/conversion_examples_gallery/sorting/phy.rst
+++ b/docs/conversion_examples_gallery/sorting/phy.rst
@@ -24,5 +24,8 @@ Convert Phy data to NWB using :py:class:`~.neuroconv.datainterfaces.ecephys.phy.
     >>> metadata = interface.get_metadata()
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
+    >>>
     >>> nwbfile_path = f"{path_to_save_nwbfile}"  # This should be something like: "./saved_file.nwb"
     >>> interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)

--- a/docs/conversion_examples_gallery/sorting/plexon.rst
+++ b/docs/conversion_examples_gallery/sorting/plexon.rst
@@ -26,6 +26,8 @@ Convert Plexon spiking data (.plx) to NWB using :py:class:`~.neuroconv.datainter
     >>> tzinfo = ZoneInfo("US/Pacific")
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
     >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion
     >>> nwbfile_path = f"{path_to_save_nwbfile}"

--- a/docs/conversion_examples_gallery/text/csv.rst
+++ b/docs/conversion_examples_gallery/text/csv.rst
@@ -70,6 +70,8 @@ The following example demonstrates basic conversion of a CSV file containing int
     >>> # Add the required time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"] = dict(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Run the conversion to create an NWB file
     >>> nwbfile_path = path_to_save_nwbfile  # This should be something like: "./saved_file.nwb"
@@ -152,6 +154,8 @@ CSVs with non-standard column names (e.g., ``start`` instead of ``start_time``):
     >>> metadata = interface.get_metadata()
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"] = dict(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> # Rename columns during conversion (e.g., 'condition' to 'trial_type')
     >>> nwbfile_path = path_to_save_nwbfile

--- a/docs/conversion_examples_gallery/text/excel.rst
+++ b/docs/conversion_examples_gallery/text/excel.rst
@@ -29,6 +29,8 @@ The Excel data will be saved as trials in the NWB file.
     >>> # Add the time zone information to the conversion
     >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
     >>> metadata["NWBFile"] = dict(session_start_time=session_start_time)
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
     >>> nwbfile_path = f"{path_to_save_nwbfile}" # This should be something like: "./saved_file.nwb"
     >>> nwbfile = interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata)


### PR DESCRIPTION
fix #1606 

- Updated multiple conversion examples to include subject metadata (subject_id, species, sex, age) required for DANDI uploads.
- Ensured consistency across various data formats including AlphaOmega, Axon, Biocam, Blackrock, EDF, Intan, and others.