### PR TITLE
Pinned opencv version for mac-os intel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added Numba as a dependency of the sorting_analyzer environment. [#1627](https://github.com/catalystneuro/neuroconv/pull/1627), [#1635](https://github.com/catalystneuro/neuroconv/pull/1635)
 * Added cap on NumPy version for all icephys formats. [#1634](https://github.com/catalystneuro/neuroconv/pull/1634)
 * Updated DANDI instance names to fix Ember DANDI upload. [#1631](https://github.com/catalystneuro/neuroconv/pull/1631)
+* Added cap on OpenCV version for Mac OS Intel. [#1637](https://github.com/catalystneuro/neuroconv/pull/1637)
 
 ## Features
 * Added `waveform_data_dict` keyword-only parameter to `add_sorting_to_nwbfile` and `BaseSortingExtractorInterface.add_to_nwbfile` for passing waveform data with associated metadata (`means`, `sds`, `sampling_rate`, `unit`). The Units table now properly sets `waveform_rate`, `waveform_unit`, and `resolution` attributes, enabling proper HDF5 attribute propagation for downstream tools like MatNWB. [PR #1628](https://github.com/catalystneuro/neuroconv/pull/1628)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,9 @@ deeplabcut = [
 fictrac = [
 ]
 video = [
-    "opencv-python-headless>=4.8.1.78",
+    # Remove this pin when the following issue is resolved: https://github.com/opencv/opencv-python/issues/1192
+    "opencv-python-headless>=4.8.1.78,<4.13; platform_system == 'Darwin' and platform_machine == 'x86_64'",
+    "opencv-python-headless>=4.8.1.78; platform_system != 'Darwin' or platform_machine != 'x86_64'",
 ]
 lightningpose = [
     "ndx-pose>=0.2",


### PR DESCRIPTION
This PR fixes a bug with the OpenCV video writer that was causing the daily tests to fail. 

See here for failing tests: https://github.com/catalystneuro/neuroconv/actions/runs/21346697413/job/61435636499

And see here for more details: https://github.com/opencv/opencv-python/issues/1192

Note: #1638 fixes the rest of the tests