### PR TITLE
Replaced pytz with zoneinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added Numba as a dependency of the sorting_analyzer environment. [#1627](https://github.com/catalystneuro/neuroconv/pull/1627), [#1635](https://github.com/catalystneuro/neuroconv/pull/1635)
 * Added cap on NumPy version for all icephys formats. [#1634](https://github.com/catalystneuro/neuroconv/pull/1634)
 * Updated DANDI instance names to fix Ember DANDI upload. [#1631](https://github.com/catalystneuro/neuroconv/pull/1631)
+* Replaced pytz with zoneinfo [#1638](https://github.com/catalystneuro/neuroconv/pull/1638)
 
 ## Features
 * Added `waveform_data_dict` keyword-only parameter to `add_sorting_to_nwbfile` and `BaseSortingExtractorInterface.add_to_nwbfile` for passing waveform data with associated metadata (`means`, `sds`, `sampling_rate`, `unit`). The Units table now properly sets `waveform_rate`, `waveform_unit`, and `resolution` attributes, enabling proper HDF5 attribute propagation for downstream tools like MatNWB. [PR #1628](https://github.com/catalystneuro/neuroconv/pull/1628)

--- a/src/neuroconv/datainterfaces/ophys/tdt_fp/tdtfiberphotometrydatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/tdt_fp/tdtfiberphotometrydatainterface.py
@@ -1,12 +1,11 @@
 import os
 from contextlib import redirect_stdout
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
 import numpy as np
-import pytz
 from pydantic import DirectoryPath, validate_call
 from pynwb.file import NWBFile
 
@@ -60,7 +59,7 @@ class TDTFiberPhotometryInterface(BaseTemporalAlignmentInterface):
         metadata = super().get_metadata()
         tdt_photometry = self.load(evtype=["scalars"])  # This evtype quickly loads info without loading all the data.
         start_timestamp = tdt_photometry.info.start_date.timestamp()
-        session_start_datetime = datetime.fromtimestamp(start_timestamp, tz=pytz.utc)
+        session_start_datetime = datetime.fromtimestamp(start_timestamp, tz=timezone.utc)
         metadata["NWBFile"]["session_start_time"] = session_start_datetime.isoformat()
         return metadata
 

--- a/tests/test_minimal/test_tools/test_nwb_helpers.py
+++ b/tests/test_minimal/test_tools/test_nwb_helpers.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
-import pytz
 from hdmf.testing import TestCase
 from jsonschema.exceptions import ValidationError
 from pynwb import ProcessingModule
@@ -40,7 +40,7 @@ class TestNWBHelpers(TestCase):
 
     def test_metadata_integrity(self):
         """Test that the original metadata is not modified."""
-        session_start_time = datetime(2023, 6, 22, 9, 0, 0, tzinfo=pytz.timezone("America/New_York"))
+        session_start_time = datetime(2023, 6, 22, 9, 0, 0, tzinfo=ZoneInfo("America/New_York"))
         session_description = "Original description"
         identifier = "original_identifier"
         metadata = dict(

--- a/tests/test_on_data/ophys/test_fiber_photometry_interfaces.py
+++ b/tests/test_on_data/ophys/test_fiber_photometry_interfaces.py
@@ -1,12 +1,11 @@
 import re
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
 from hdmf.testing import TestCase
 from pynwb import NWBHDF5IO
-from pytz import utc
 
 from neuroconv.datainterfaces import TDTFiberPhotometryInterface
 from neuroconv.tools.testing.data_interface_mixins import (
@@ -30,7 +29,7 @@ class TestTDTFiberPhotometryInterface(TestCase, TDTFiberPhotometryInterfaceMixin
     )
     conversion_options = dict(t2=1.0)
     save_directory = OUTPUT_PATH
-    expected_session_start_time = datetime(2020, 7, 21, 17, 2, 24, 999999, tzinfo=utc).isoformat()
+    expected_session_start_time = datetime(2020, 7, 21, 17, 2, 24, 999999, tzinfo=timezone.utc).isoformat()
     expected_devices = [
         {
             "name": "optical_fiber",


### PR DESCRIPTION
PyTZ has been essentially deprecated in favor of zoneinfo, which is in the standard library. It was causing some of the daily tests to fail. So in this PR, I have replaced all usages of PyTZ with zoneinfo. 

See daily failures here: https://github.com/catalystneuro/neuroconv/actions/runs/21346697413/job/61435639457

[It’s Time to Say Goodbye to These Obsolete Python Libraries](https://python.plainenglish.io/its-time-to-say-goodbye-to-these-obsolete-python-libraries-7c02aa77d84a)

Note: #1637 fixes the macos intel failures