### PR TITLE
Remove invalid channel comparison on roiextractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Updated DANDI instance names to fix Ember DANDI upload. [#1631](https://github.com/catalystneuro/neuroconv/pull/1631)
 * Added cap on OpenCV version for Mac OS Intel. [#1637](https://github.com/catalystneuro/neuroconv/pull/1637)
 * Replaced pytz with zoneinfo [#1638](https://github.com/catalystneuro/neuroconv/pull/1638)
+* Removed deprecated `exclude_channel_comparison` parameter from `check_imaging_equal` call in imaging interface tests to fix compatibility with updated roiextractors. [#1642](https://github.com/catalystneuro/neuroconv/pull/1642)
 
 ## Features
 * Added `waveform_data_dict` keyword-only parameter to `add_sorting_to_nwbfile` and `BaseSortingExtractorInterface.add_to_nwbfile` for passing waveform data with associated metadata (`means`, `sds`, `sampling_rate`, `unit`). The Units table now properly sets `waveform_rate`, `waveform_unit`, and `resolution` attributes, enabling proper HDF5 attribute propagation for downstream tools like MatNWB. [PR #1628](https://github.com/catalystneuro/neuroconv/pull/1628)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,7 +266,7 @@ fiber_photometry = [
 
 ## Ophys
 ophys_minimal = [  # Keeps the minimal version of ophys dependencies in the repo
-    "roiextractors>=0.7.2",
+    "roiextractors>0.7.2",
 ]
 brukertiff = [
     "neuroconv[ophys_minimal]",

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -347,9 +347,7 @@ class ImagingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
         imaging = self.interface.imaging_extractor
         nwb_imaging = NwbImagingExtractor(file_path=nwbfile_path, optical_series_name=self.optical_series_name)
 
-        # Exclude channel comparison: imaging extractors now effectively have a single channel
-        # and NWB readers may assign a default channel name (e.g., "OpticalChannel").
-        check_imaging_equal(imaging, nwb_imaging, exclude_channel_comparison=True)
+        check_imaging_equal(imaging, nwb_imaging)
 
     def check_nwbfile_temporal_alignment(self):
         nwbfile_path = str(


### PR DESCRIPTION
We are now sticking to single channel imaging extractors. We are removing this from here as it was deprecated in roiextractors and is pending for removal on the next release.

https://github.com/catalystneuro/roiextractors/pull/545