### PR TITLE
Added support for stream_name to TDT recording interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ## Features
 * Added `waveform_data_dict` keyword-only parameter to `add_sorting_to_nwbfile` and `BaseSortingExtractorInterface.add_to_nwbfile` for passing waveform data with associated metadata (`means`, `sds`, `sampling_rate`, `unit`). The Units table now properly sets `waveform_rate`, `waveform_unit`, and `resolution` attributes, enabling proper HDF5 attribute propagation for downstream tools like MatNWB. [PR #1628](https://github.com/catalystneuro/neuroconv/pull/1628)
+* Added support for stream_name to TDT recording interface [#1645](https://github.com/catalystneuro/neuroconv/pull/1645)
 
 ## Improvements
 * Improved warning message in `get_module` to show both existing and new (ignored) descriptions when there's a mismatch, making it easier to debug processing module conflicts. [PR #1620](https://github.com/catalystneuro/neuroconv/pull/1620)

--- a/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposeconverter.py
+++ b/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposeconverter.py
@@ -73,9 +73,23 @@ class LightningPoseConverter(NWBConverter):
             self.labeled_video_name = image_series_labeled_video_name or "ImageSeriesLabeledVideo"
             self.data_interface_objects.update(dict(LabeledVideo=_VideoInterface(file_paths=[labeled_video_file_path])))
 
+    def _deprecated_add_to_nwbfile(
+        self,
+        nwbfile: NWBFile,
+        metadata: dict,
+        reference_frame: str | None = None,
+        confidence_definition: str | None = None,
+        external_mode: bool = True,
+        starting_frames_original_videos: list[int] | None = None,
+        starting_frames_labeled_videos: list[int] | None = None,
+        stub_test: bool = False,
+    ):
+        pass  # Placeholder method to get the appropriate signature for get_conversion_options_schema
+        # TODO: Remove this method after deprecation period is over
+
     def get_conversion_options_schema(self) -> dict:
         conversion_options_schema = get_json_schema_from_method_signature(
-            method=self.add_to_nwbfile, exclude=["nwbfile", "metadata"]
+            method=self._deprecated_add_to_nwbfile, exclude=["nwbfile", "metadata"]
         )
 
         return conversion_options_schema

--- a/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposeconverter.py
+++ b/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposeconverter.py
@@ -73,23 +73,9 @@ class LightningPoseConverter(NWBConverter):
             self.labeled_video_name = image_series_labeled_video_name or "ImageSeriesLabeledVideo"
             self.data_interface_objects.update(dict(LabeledVideo=_VideoInterface(file_paths=[labeled_video_file_path])))
 
-    def _deprecated_add_to_nwbfile(
-        self,
-        nwbfile: NWBFile,
-        metadata: dict,
-        reference_frame: str | None = None,
-        confidence_definition: str | None = None,
-        external_mode: bool = True,
-        starting_frames_original_videos: list[int] | None = None,
-        starting_frames_labeled_videos: list[int] | None = None,
-        stub_test: bool = False,
-    ):
-        pass  # Placeholder method to get the appropriate signature for get_conversion_options_schema
-        # TODO: Remove this method after deprecation period is over
-
     def get_conversion_options_schema(self) -> dict:
         conversion_options_schema = get_json_schema_from_method_signature(
-            method=self._deprecated_add_to_nwbfile, exclude=["nwbfile", "metadata"]
+            method=self.add_to_nwbfile, exclude=["nwbfile", "metadata"]
         )
 
         return conversion_options_schema

--- a/src/neuroconv/datainterfaces/ecephys/tdt/tdtdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/tdt/tdtdatainterface.py
@@ -33,6 +33,7 @@ class TdtRecordingInterface(BaseRecordingExtractorInterface):
         stream_id: str = "0",
         verbose: bool = False,
         es_key: str = "ElectricalSeries",
+        stream_name: str | None = None,
     ):
         """
         Initialize reading of a TDT recording.
@@ -48,15 +49,21 @@ class TdtRecordingInterface(BaseRecordingExtractorInterface):
         verbose : bool, default: False
             Allows verbose.
         es_key : str, optional
+        stream_name : str or None, optional
+            Name of the stream to select. If None, stream_id is used.
 
 
         Notes
         -----
         Stream "0" corresponds to LFP for gin data. Other streams seem non-electrical.
+        Either stream_id or stream_name can be used to select the desired stream, but not both.
         """
+        if stream_name is not None:
+            stream_id = None
         super().__init__(
             folder_path=folder_path,
             stream_id=stream_id,
+            stream_name=stream_name,
             verbose=verbose,
             es_key=es_key,
             gain=gain,

--- a/src/neuroconv/datainterfaces/ecephys/tdt/tdtdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/tdt/tdtdatainterface.py
@@ -1,8 +1,6 @@
 import warnings
 from typing import Any
 
-from pydantic import validate_call
-
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 
 
@@ -28,7 +26,7 @@ class TdtRecordingInterface(BaseRecordingExtractorInterface):
 
         return self.get_extractor_class()(**self.extractor_kwargs)
 
-    @validate_call
+    # @validate_call # Uncomment when deprecation period is over
     def __init__(
         self,
         *args: Any,

--- a/src/neuroconv/datainterfaces/ecephys/tdt/tdtdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/tdt/tdtdatainterface.py
@@ -1,4 +1,7 @@
-from pydantic import DirectoryPath, validate_call
+import warnings
+from typing import Any
+
+from pydantic import validate_call
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
 
@@ -28,12 +31,14 @@ class TdtRecordingInterface(BaseRecordingExtractorInterface):
     @validate_call
     def __init__(
         self,
-        folder_path: DirectoryPath,
-        gain: float,
-        stream_id: str = "0",
-        verbose: bool = False,
-        es_key: str = "ElectricalSeries",
-        stream_name: str | None = None,
+        *args: Any,
+        **kwargs: Any,
+        # folder_path: DirectoryPath,
+        # gain: float,
+        # stream_id: str = "0",
+        # verbose: bool = False,
+        # es_key: str = "ElectricalSeries",
+        # stream_name: str | None = None,
     ):
         """
         Initialize reading of a TDT recording.
@@ -58,6 +63,38 @@ class TdtRecordingInterface(BaseRecordingExtractorInterface):
         Stream "0" corresponds to LFP for gin data. Other streams seem non-electrical.
         Either stream_id or stream_name can be used to select the desired stream, but not both.
         """
+        parameter_names = [
+            "folder_path",
+            "gain",
+            "stream_id",
+            "verbose",
+            "es_key",
+            "stream_name",
+        ]
+        if args:
+            warnings.warn(
+                "Passing arguments positionally is deprecated and will be removed in June 2026. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes {len(parameter_names)} positional arguments but "
+                    f"{len(args)} were given."
+                )
+            # Bind positional args to their parameter names
+            for i, value in enumerate(args):
+                kwargs[parameter_names[i]] = value
+
+        # Extract the actual parameters
+        folder_path = kwargs.get("folder_path", None)
+        gain = kwargs.get("gain", None)
+        stream_id = kwargs.get("stream_id", "0")
+        verbose = kwargs.get("verbose", False)
+        es_key = kwargs.get("es_key", "ElectricalSeries")
+        stream_name = kwargs.get("stream_name", None)
+
         if stream_name is not None:
             stream_id = None
         super().__init__(

--- a/src/neuroconv/datainterfaces/ecephys/tdt/tdtdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/tdt/tdtdatainterface.py
@@ -35,7 +35,7 @@ class TdtRecordingInterface(BaseRecordingExtractorInterface):
         **kwargs: Any,
         # folder_path: DirectoryPath,
         # gain: float,
-        # stream_id: str = "0",
+        # stream_id: str = "0", # Stream "0" corresponds to LFP for gin data. Other streams seem non-electrical.
         # verbose: bool = False,
         # es_key: str = "ElectricalSeries",
         # stream_name: str | None = None,
@@ -60,8 +60,9 @@ class TdtRecordingInterface(BaseRecordingExtractorInterface):
 
         Notes
         -----
-        Stream "0" corresponds to LFP for gin data. Other streams seem non-electrical.
-        Either stream_id or stream_name can be used to select the desired stream, but not both.
+        Either stream_id or stream_name can be used to select the desired stream.
+        If neither are specified, this interface defaults to the first stream, with stream_id "0".
+        If both are specified, stream_name takes precedence.
         """
         parameter_names = [
             "folder_path",

--- a/tests/test_on_data/ecephys/test_recording_interfaces.py
+++ b/tests/test_on_data/ecephys/test_recording_interfaces.py
@@ -749,8 +749,22 @@ class TestSpikeGLXRecordingInterfaceLongNHP(RecordingExtractorInterfaceTestMixin
 class TestTdtRecordingInterface(RecordingExtractorInterfaceTestMixin):
     data_interface_cls = TdtRecordingInterface
     test_gain_value = 0.195  # arbitrary value to test gain
-    interface_kwargs = dict(folder_path=str(ECEPHY_DATA_PATH / "tdt" / "aep_05"), gain=test_gain_value)
     save_directory = OUTPUT_PATH
+
+    @pytest.fixture(
+        params=[
+            dict(folder_path=str(ECEPHY_DATA_PATH / "tdt" / "aep_05"), gain=test_gain_value),
+            dict(folder_path=str(ECEPHY_DATA_PATH / "tdt" / "aep_05"), gain=test_gain_value, stream_name="LFPs"),
+        ],
+        ids=["default", "stream_name"],
+    )
+    def setup_interface(self, request):
+        test_id = request.node.callspec.id
+        self.test_name = test_id
+        self.interface_kwargs = request.param
+        self.interface = self.data_interface_cls(**self.interface_kwargs)
+
+        return self.interface, self.test_name
 
     def run_custom_checks(self):
         # Check that the gain is applied


### PR DESCRIPTION
Fixes #1644

I also found myself wanting to rearrange the order of the parameters so that stream ID and stream name would be logically grouped next to each other. But I can't do that without breaking backward compatibility. So I took the liberty of deprecating the positional arguments, just like we did in #1596.