### PR TITLE
Add backend configuration support to roiextractors write functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # v0.9.2 (Upcoming)
 
 ## Removals, Deprecations and Changes
+* Deprecated using `write_imaging_to_nwbfile` and `write_segmentation_to_nwbfile` without `nwbfile_path`. Use `add_imaging_to_nwbfile` and `add_segmentation_to_nwbfile` instead for adding data to in-memory NWBFile objects. Will be removed on or after March 2026. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)
+* Deprecated returning NWBFile when using `append_on_disk_nwbfile=True` in `write_imaging_to_nwbfile` and `write_segmentation_to_nwbfile`. Will return None on or after March 2026. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)
 
 ## Bug Fixes
+* Fixed bug in `write_imaging_to_nwbfile` where `nwbfile` was incorrectly passed to `add_imaging_to_nwbfile` instead of the created/loaded nwbfile. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)
+* Fixed bug in `write_segmentation_to_nwbfile` where invalid `plane_num` parameter was passed to `add_segmentation_to_nwbfile`. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)
 
 ## Features
 
 ## Improvements
+* Added `backend`, `backend_configuration`, and `append_on_disk_nwbfile` parameters to `write_imaging_to_nwbfile` and `write_segmentation_to_nwbfile` for better control over file writing, matching the pattern from spikeinterface write functions. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)
 
 # v0.9.1 (January 28, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v0.9.2 (Upcoming)
 
 ## Removals, Deprecations and Changes
-* Deprecated using `write_imaging_to_nwbfile` and `write_segmentation_to_nwbfile` without `nwbfile_path`. Use `add_imaging_to_nwbfile` and `add_segmentation_to_nwbfile` instead for adding data to in-memory NWBFile objects. Will be removed on or after March 2026. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)
-* Deprecated returning NWBFile when using `append_on_disk_nwbfile=True` in `write_imaging_to_nwbfile` and `write_segmentation_to_nwbfile`. Will return None on or after March 2026. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)
+* Deprecated using `write_imaging_to_nwbfile` and `write_segmentation_to_nwbfile` without `nwbfile_path`. Use `add_imaging_to_nwbfile` and `add_segmentation_to_nwbfile` instead for adding data to in-memory NWBFile objects. Will be removed on or after June 2026. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)
+* Deprecated returning NWBFile when using `append_on_disk_nwbfile=True` in `write_imaging_to_nwbfile` and `write_segmentation_to_nwbfile`. Will return None on or after June 2026. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)
 
 ## Bug Fixes
 * Fixed bug in `write_imaging_to_nwbfile` where `nwbfile` was incorrectly passed to `add_imaging_to_nwbfile` instead of the created/loaded nwbfile. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -939,13 +939,13 @@ def write_imaging_to_nwbfile(
     NWBFile or None
         The NWBFile object when writing a new file or using an in-memory nwbfile.
         Returns None when appending to an existing file on disk (append_on_disk_nwbfile=True).
-        **Deprecated**: Returning NWBFile in append mode is deprecated and will return None in or after March 2026.
+        **Deprecated**: Returning NWBFile in append mode is deprecated and will return None on or after June 2026.
     """
     # Handle deprecated usage without nwbfile_path
     if nwbfile_path is None:
         warnings.warn(
             "Using 'write_imaging_to_nwbfile' without 'nwbfile_path' to only add data to an in-memory nwbfile "
-            "is deprecated and will be removed in or after March 2026. Use 'add_imaging_to_nwbfile' instead.",
+            "is deprecated and will be removed on or after June 2026. Use 'add_imaging_to_nwbfile' instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -1027,7 +1027,7 @@ def write_imaging_to_nwbfile(
         # Append mode: read existing file, add data, write back
         warnings.warn(
             "Returning an NWBFile object when using append_on_disk_nwbfile=True is deprecated "
-            "and will return None in or after March 2026.",
+            "and will return None on or after June 2026.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -2226,7 +2226,7 @@ def write_segmentation_to_nwbfile(
     NWBFile or None
         The NWBFile object when writing a new file or using an in-memory nwbfile.
         Returns None when appending to an existing file on disk (append_on_disk_nwbfile=True).
-        **Deprecated**: Returning NWBFile in append mode is deprecated and will return None in or after March 2026.
+        **Deprecated**: Returning NWBFile in append mode is deprecated and will return None on or after June 2026.
     """
     iterator_options = iterator_options or dict()
 
@@ -2259,7 +2259,7 @@ def write_segmentation_to_nwbfile(
     if nwbfile_path is None:
         warnings.warn(
             "Using 'write_segmentation_to_nwbfile' without 'nwbfile_path' to only add data to an in-memory nwbfile "
-            "is deprecated and will be removed in or after March 2026. Use 'add_segmentation_to_nwbfile' instead.",
+            "is deprecated and will be removed on or after June 2026. Use 'add_segmentation_to_nwbfile' instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -2342,7 +2342,7 @@ def write_segmentation_to_nwbfile(
         # Append mode: read existing file, add data, write back
         warnings.warn(
             "Returning an NWBFile object when using append_on_disk_nwbfile=True is deprecated "
-            "and will return None in or after March 2026.",
+            "and will return None on or after June 2026.",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
@pauladkisson this moves a bit further your request/comment here:

https://github.com/catalystneuro/neuroconv/pull/1540#issuecomment-3377865703

And unifies the signatures with ecephys/Spikeinterface functions:

https://github.com/catalystneuro/neuroconv/pull/1565