### PR TITLE
Add backend support to `LightningPoseConverter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Improvements
 * Added `backend`, `backend_configuration`, and `append_on_disk_nwbfile` parameters to `write_imaging_to_nwbfile` and `write_segmentation_to_nwbfile` for better control over file writing, matching the pattern from spikeinterface write functions. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)
+* Added `backend`, `backend_configuration`, and `append_on_disk_nwbfile` support to `LightningPoseConverter`. [PR #1652](https://github.com/catalystneuro/neuroconv/pull/1652)
 
 # v0.9.1 (January 28, 2026)
 


### PR DESCRIPTION
This PR adds backend support (`backend`, `backend_configuration`, `append_on_disk_nwbfile`) to `LightningPoseConverter`.

I wanted to add backend support and remove the outdated `make_or_load_nwbfile` context manager, making the `run_conversion` signature of `LightningPoseConverter` consistent with our other classes. I discovered that these features weren't automatically available because `LightningPoseConverter` inherits from `NWBConverter`. The `NWBConverter.run_conversion` method expects conversion options to be passed as a nested dictionary keyed by interface name (e.g., `conversion_options={"InterfaceA": {...}, "InterfaceB": {...}}`), but `LightningPoseConverter` was designed with a flat `conversion_options` pattern like a regular interface. This is useful because it avoids repeating `conversion_options` that are essentially the same for all the internal interfaces:

```python
# Flat pattern (what LightningPoseConverter uses)
stub_test=True

# vs nested pattern (what NWBConverter expects)
conversion_options={
    "OriginalVideo": {"stub_test": True},
    "LabeledVideo": {"stub_test": True},
    "PoseEstimation": {"stub_test": True}
}
```

While the flat pattern is more user friendly and avoids the cumbersome nesting, it forces the class to override `run_conversion` entirely, duplicating logic and missing out on parent class improvements while creating more code to maintain.

Fortunately, there is a simple fix: change the parent class from `NWBConverter` to `BaseDataInterface`. This eliminates the need to override `run_conversion` and automatically provides backend support. We lose nothing because none of the actual converter machinery was being used here: no automatic iteration over interfaces, no aggregated schemas, just the semantic idea that this class bundles multiple data streams together and some internal conventions (e.g. using data_interface_objects to hold the internal interfaces).
