### PR TITLE
Add how to for filtering ROIs in segmentation extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fixed `get_json_schema_from_method_signature` to skip `*args` (VAR_POSITIONAL) parameters, which was causing schema validation errors when methods used the `*args` pattern for deprecating positional arguments. [PR #1647](https://github.com/catalystneuro/neuroconv/pull/1647)
 
 ## Features
+* Added `roi_ids_to_add` parameter to `BaseSegmentationExtractorInterface.add_to_nwbfile()` to select a subset of ROIs during conversion, reducing file size by excluding rejected or unwanted ROIs. Also added `roi_ids` property to inspect available ROI IDs. Requires roiextractors >= 0.8.0. [PR #1658](https://github.com/catalystneuro/neuroconv/pull/1658)
 * Added `backend`, `backend_configuration`, and `append_on_disk_nwbfile` parameters to `write_imaging_to_nwbfile` and `write_segmentation_to_nwbfile` for better control over file writing, matching the pattern from spikeinterface write functions. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)
 * Added support for stream_name to TDT recording interface [#1645](https://github.com/catalystneuro/neuroconv/pull/1645)
 * Added `backend`, `backend_configuration`, and `append_on_disk_nwbfile` parameters to `write_imaging_to_nwbfile` and `write_segmentation_to_nwbfile` for better control over file writing, matching the pattern from spikeinterface write functions. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)

--- a/docs/how_to/index.rst
+++ b/docs/how_to/index.rst
@@ -14,5 +14,6 @@ This section contains practical guides for using NeuroConv effectively.
    linking_sorted_data
    convert_video_formats_with_ffmpeg
    adding_multiple_sorting_interfaces
+   selecting_rois_for_conversion
    add_behavioral_and_sensor_data
    repacking_nwb_files

--- a/docs/how_to/selecting_rois_for_conversion.rst
+++ b/docs/how_to/selecting_rois_for_conversion.rst
@@ -12,8 +12,7 @@ Inspecting Available ROI IDs
 -----------------------------
 
 Before filtering, you can inspect the available ROI IDs using the ``roi_ids``
-property on any segmentation interface. This property returns all ROI IDs in the
-source data, including both cell and background ROIs:
+property on any segmentation interface:
 
 .. code-block:: python
 
@@ -21,7 +20,7 @@ source data, including both cell and background ROIs:
 
     interface = MockSegmentationInterface(num_rois=20)
 
-    # Inspect all available ROI IDs (cell + background)
+    # Inspect all available ROI IDs
     print("All ROI IDs:", interface.roi_ids)
 
 

--- a/docs/how_to/selecting_rois_for_conversion.rst
+++ b/docs/how_to/selecting_rois_for_conversion.rst
@@ -1,0 +1,45 @@
+Selecting ROIs for Conversion
+==============================
+
+By default, segmentation interfaces write all ROIs from the source data to the
+NWB file. In some cases, for example after curating the segmentation output,
+you may want to include only a subset of the ROIs in the source data. To support this, segmentation
+interfaces accept the ``roi_ids_to_add`` parameter in ``add_to_nwbfile()``
+(and ``create_nwbfile()``) to specify which ROIs to write.
+
+
+Inspecting Available ROI IDs
+-----------------------------
+
+Before filtering, you can inspect the available ROI IDs using the ``roi_ids``
+property on any segmentation interface. This property returns all ROI IDs in the
+source data, including both cell and background ROIs:
+
+.. code-block:: python
+
+    from neuroconv.tools.testing.mock_interfaces import MockSegmentationInterface
+
+    interface = MockSegmentationInterface(num_rois=20)
+
+    # Inspect all available ROI IDs (cell + background)
+    print("All ROI IDs:", interface.roi_ids)
+
+
+Filtering ROIs During Conversion
+---------------------------------
+
+Pass the ``roi_ids_to_add`` parameter to ``create_nwbfile()`` or ``add_to_nwbfile()``
+to include only a subset of ROIs:
+
+.. code-block:: python
+
+    from neuroconv.tools.testing.mock_interfaces import MockSegmentationInterface
+
+    interface = MockSegmentationInterface(num_rois=20)
+
+    # Convert with only specific ROIs
+    nwbfile = interface.create_nwbfile(roi_ids_to_add=["roi_00", "roi_03", "roi_10"])
+
+    # Verify only selected ROIs are in the file
+    plane_segmentation = nwbfile.processing["ophys"]["ImageSegmentation"]["PlaneSegmentation"]
+    print("Number of ROIs in NWB:", len(plane_segmentation))  # 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,7 +264,7 @@ fiber_photometry = [
 
 ## Ophys
 ophys_minimal = [  # Keeps the minimal version of ophys dependencies in the repo
-    "roiextractors>0.7.2",
+    "roiextractors>=0.8.0",
 ]
 brukertiff = [
     "neuroconv[ophys_minimal]",

--- a/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
@@ -169,6 +169,7 @@ class BaseImagingExtractorInterface(BaseExtractorInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,
         photon_series_type: Literal["TwoPhotonSeries", "OnePhotonSeries"] = "TwoPhotonSeries",
         photon_series_index: int = 0,
         parent_container: Literal["acquisition", "processing/ophys"] = "acquisition",
@@ -220,6 +221,46 @@ class BaseImagingExtractorInterface(BaseExtractorInterface):
         """
 
         from ...tools.roiextractors import add_imaging_to_nwbfile
+
+        # TODO: Remove this block in August 2026 or after when positional arguments are no longer supported.
+        if args:
+            parameter_names = [
+                "photon_series_type",
+                "photon_series_index",
+                "parent_container",
+                "stub_test",
+                "stub_frames",
+                "always_write_timestamps",
+                "iterator_type",
+                "iterator_options",
+                "stub_samples",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed in August 2026 or after. Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to add_to_nwbfile is deprecated "
+                f"and will be removed in August 2026 or after. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            photon_series_type = positional_values.get("photon_series_type", photon_series_type)
+            photon_series_index = positional_values.get("photon_series_index", photon_series_index)
+            parent_container = positional_values.get("parent_container", parent_container)
+            stub_test = positional_values.get("stub_test", stub_test)
+            stub_frames = positional_values.get("stub_frames", stub_frames)
+            always_write_timestamps = positional_values.get("always_write_timestamps", always_write_timestamps)
+            iterator_type = positional_values.get("iterator_type", iterator_type)
+            iterator_options = positional_values.get("iterator_options", iterator_options)
+            stub_samples = positional_values.get("stub_samples", stub_samples)
 
         # Handle deprecation of stub_frames in favor of stub_samples
         if stub_frames is not None and stub_samples != 100:

--- a/tests/test_modalities/test_ophys/test_ophys_interfaces.py
+++ b/tests/test_modalities/test_ophys/test_ophys_interfaces.py
@@ -40,14 +40,12 @@ class TestMockSegmentationInterface(SegmentationExtractorInterfaceTestMixin):
     interface_kwargs = dict()
 
     def test_roi_ids_property(self):
-        """Test that roi_ids property returns all ROI IDs (cell + background)."""
+        """Test that roi_ids property returns cell ROI IDs."""
         interface = MockSegmentationInterface(num_rois=10)
         roi_ids = interface.roi_ids
 
         expected_cell_ids = interface.segmentation_extractor.get_roi_ids()
-        expected_background_ids = interface.segmentation_extractor.get_background_ids()
-        expected_all_ids = expected_cell_ids + expected_background_ids
-        assert roi_ids == expected_all_ids
+        assert roi_ids == expected_cell_ids
 
     def test_add_to_nwbfile_with_roi_ids_to_add(self):
         """Test that passing roi_ids_to_add filters the ROIs in the output."""

--- a/tests/test_modalities/test_ophys/test_ophys_interfaces.py
+++ b/tests/test_modalities/test_ophys/test_ophys_interfaces.py
@@ -39,6 +39,28 @@ class TestMockSegmentationInterface(SegmentationExtractorInterfaceTestMixin):
     data_interface_cls = MockSegmentationInterface
     interface_kwargs = dict()
 
+    def test_roi_ids_property(self):
+        """Test that roi_ids property returns all ROI IDs (cell + background)."""
+        interface = MockSegmentationInterface(num_rois=10)
+        roi_ids = interface.roi_ids
+
+        expected_cell_ids = interface.segmentation_extractor.get_roi_ids()
+        expected_background_ids = interface.segmentation_extractor.get_background_ids()
+        expected_all_ids = expected_cell_ids + expected_background_ids
+        assert roi_ids == expected_all_ids
+
+    def test_add_to_nwbfile_with_roi_ids_to_add(self):
+        """Test that passing roi_ids_to_add filters the ROIs in the output."""
+        interface = MockSegmentationInterface(num_rois=10)
+        selected_ids = ["roi_0", "roi_2", "roi_5"]
+
+        nwbfile = interface.create_nwbfile(roi_ids_to_add=selected_ids)
+
+        plane_segmentation = nwbfile.processing["ophys"]["ImageSegmentation"]["PlaneSegmentation"]
+        assert len(plane_segmentation) == 3
+        written_roi_names = list(plane_segmentation["roi_name"].data)
+        assert written_roi_names == selected_ids
+
 
 # This is a temporary test class to show that the migration path to kwargs only works as intended.
 # TODO: Remove this test class in June 2026 or after when positional arguments are no longer supported.


### PR DESCRIPTION
Add roi_ids_to_add parameter to segmentation interfaces to select which ROIs to include when writing to NWB, along with a roi_ids property and a how-to guide.



Closes #1459