### PR TITLE
Deprecate positional conversion options in `add_to_nwbfile` and interface init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.9.2 (Upcoming)
 
 ## Removals, Deprecations and Changes
+* Enforced keyword-only arguments across all data interfaces: `__init__` methods now only accept `file_path`/`folder_path`/`file_paths` as positional arguments, and `add_to_nwbfile` methods only accept `nwbfile` and `metadata` as positional arguments. Existing positional usage in `add_to_nwbfile` will emit a `FutureWarning` and will be removed on or after August 2026. [PR #1663](https://github.com/catalystneuro/neuroconv/pull/1663)
 * Deprecated using `write_imaging_to_nwbfile` and `write_segmentation_to_nwbfile` without `nwbfile_path`. Use `add_imaging_to_nwbfile` and `add_segmentation_to_nwbfile` instead for adding data to in-memory NWBFile objects. Will be removed on or after June 2026. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)
 * Deprecated returning NWBFile when using `append_on_disk_nwbfile=True` in `write_imaging_to_nwbfile` and `write_segmentation_to_nwbfile`. Will return None on or after June 2026. [PR #1649](https://github.com/catalystneuro/neuroconv/pull/1649)
 

--- a/docs/developer_guide/style_guide.rst
+++ b/docs/developer_guide/style_guide.rst
@@ -31,6 +31,19 @@ DataInterface conventions
 #. Use :code:`file_path` and :code:`folder_path` as arguments for the location of input files and folders/directories respectively.
 #. As an exception to convention to separate words for underscores, we use :code:`nwbfile` to refer to an instance
    of :py:class:`~pynwb.file.NWBFile`.
+#. In :code:`__init__` methods of data interfaces, only :code:`file_path`, :code:`folder_path`, or :code:`file_paths`
+   should be accepted as positional arguments. All other parameters must be keyword-only, enforced with the :code:`*`
+   separator after the path parameter. For example:
+
+   .. code-block:: python
+
+      def __init__(self, file_path: FilePath, *, verbose: bool = False, metadata_key: str = "ElectricalSeries"):
+
+#. In :code:`add_to_nwbfile` methods of leaf interfaces (not converters), only :code:`nwbfile` and :code:`metadata`
+   should be accepted as positional arguments. All other parameters (conversion options) must be keyword-only.
+   When deprecating existing positional usage, use the :code:`*args` pattern with a :code:`FutureWarning` to maintain
+   backward compatibility during the transition period. After the deprecation date, replace :code:`*args` with
+   :code:`*` to enforce keyword-only arguments.
 
 Other conventions
 -----------------

--- a/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/audio/audiointerface.py
@@ -1,5 +1,6 @@
 import json
 import struct
+import warnings
 from pathlib import Path
 from typing import Literal
 
@@ -30,7 +31,9 @@ class AudioInterface(BaseTemporalAlignmentInterface):
     info = "Interface for writing audio recordings to an NWB file."
 
     @validate_call
-    def __init__(self, file_paths: list[FilePath], verbose: bool = False):
+    def __init__(
+        self, file_paths: list[FilePath], *args, verbose: bool = False
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Data interface for writing acoustic recordings to an NWB file.
 
@@ -47,6 +50,31 @@ class AudioInterface(BaseTemporalAlignmentInterface):
 
         verbose : bool, default: False
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_paths
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to AudioInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+
         # This import is to assure that ndx_sound is in the global namespace when an pynwb.io object is created.
         # For more detail, see https://github.com/rly/ndx-pose/issues/36
         import ndx_sound  # noqa: F401
@@ -168,6 +196,7 @@ class AudioInterface(BaseTemporalAlignmentInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stub_test: bool = False,
         stub_frames: int = 1000,
         write_as: Literal["stimulus", "acquisition"] = "stimulus",
@@ -191,6 +220,37 @@ class AudioInterface(BaseTemporalAlignmentInterface):
         -------
         NWBFile
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stub_test",
+                "stub_frames",
+                "write_as",
+                "iterator_options",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to AudioInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stub_test = positional_values.get("stub_test", stub_test)
+            stub_frames = positional_values.get("stub_frames", stub_frames)
+            write_as = positional_values.get("write_as", write_as)
+            iterator_options = positional_values.get("iterator_options", iterator_options)
+
         import scipy
 
         metadata = metadata or self.get_metadata()

--- a/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/deeplabcut/deeplabcutdatainterface.py
@@ -75,6 +75,7 @@ class DeepLabCutInterface(BaseTemporalAlignmentInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         config_file_path: FilePath | None = None,
         subject_name: str = "ind1",
         pose_estimation_metadata_key: str = "PoseEstimationDeepLabCut",
@@ -171,6 +172,39 @@ class DeepLabCutInterface(BaseTemporalAlignmentInterface):
         - When the subject_name matches a subject_id in the NWBFile, the skeleton will be automatically
         linked to that subject.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "config_file_path",
+                "subject_name",
+                "pose_estimation_metadata_key",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to DeepLabCutInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            config_file_path = positional_values.get("config_file_path", config_file_path)
+            subject_name = positional_values.get("subject_name", subject_name)
+            pose_estimation_metadata_key = positional_values.get(
+                "pose_estimation_metadata_key", pose_estimation_metadata_key
+            )
+            verbose = positional_values.get("verbose", verbose)
+
         # This import is to assure that the ndx_pose is in the global namespace when an pynwb.io object is created
         from importlib.metadata import version
 
@@ -525,6 +559,7 @@ class DeepLabCutInterface(BaseTemporalAlignmentInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         container_name: str | None = None,
     ):
         """
@@ -543,6 +578,30 @@ class DeepLabCutInterface(BaseTemporalAlignmentInterface):
             the content of the metadata.
 
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "container_name",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to DeepLabCutInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            container_name = positional_values.get("container_name", container_name)
         from ._dlc_utils import (
             _add_pose_estimation_to_nwbfile,
             _ensure_individuals_in_header,

--- a/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/fictrac/fictracdatainterface.py
@@ -1,5 +1,6 @@
 import json
 import re
+import warnings
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -156,6 +157,7 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         radius: float | None = None,
         configuration_file_path: FilePath | None = None,
         verbose: bool = False,
@@ -175,6 +177,35 @@ class FicTracDataInterface(BaseTemporalAlignmentInterface):
         verbose : bool, default: False
             controls verbosity. ``True`` by default.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "radius",
+                "configuration_file_path",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to FicTracDataInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            radius = positional_values.get("radius", radius)
+            configuration_file_path = positional_values.get("configuration_file_path", configuration_file_path)
+            verbose = positional_values.get("verbose", verbose)
+
         self.file_path = Path(file_path)
         self.verbose = verbose
         self.radius = radius

--- a/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposeconverter.py
+++ b/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposeconverter.py
@@ -93,7 +93,7 @@ class LightningPoseConverter(BaseDataInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict,
-        *args,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         reference_frame: str | None = None,
         confidence_definition: str | None = None,
         external_mode: bool = True,

--- a/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposedatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/lightningpose/lightningposedatainterface.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
@@ -62,6 +63,7 @@ class LightningPoseDataInterface(BaseTemporalAlignmentInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         original_video_file_path: FilePath,
         labeled_video_file_path: FilePath | None = None,
         verbose: bool = False,
@@ -80,6 +82,34 @@ class LightningPoseDataInterface(BaseTemporalAlignmentInterface):
         verbose : bool, default: False
             controls verbosity. ``True`` by default.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "original_video_file_path",
+                "labeled_video_file_path",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to LightningPoseDataInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            original_video_file_path = positional_values.get("original_video_file_path", original_video_file_path)
+            labeled_video_file_path = positional_values.get("labeled_video_file_path", labeled_video_file_path)
+            verbose = positional_values.get("verbose", verbose)
 
         # This import is to assure that the ndx_pose is in the global namespace when an pynwb.io object is created
         # For more detail, see https://github.com/rly/ndx-pose/issues/36
@@ -192,6 +222,7 @@ class LightningPoseDataInterface(BaseTemporalAlignmentInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         reference_frame: str | None = None,
         confidence_definition: str | None = None,
         stub_test: bool | None = False,
@@ -211,6 +242,35 @@ class LightningPoseDataInterface(BaseTemporalAlignmentInterface):
             The description of how the confidence was computed, e.g., 'Softmax output of the deep neural network'.
         stub_test : bool, default: False
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "reference_frame",
+                "confidence_definition",
+                "stub_test",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to LightningPoseDataInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            reference_frame = positional_values.get("reference_frame", reference_frame)
+            confidence_definition = positional_values.get("confidence_definition", confidence_definition)
+            stub_test = positional_values.get("stub_test", stub_test)
+
         from ndx_pose import PoseEstimation, PoseEstimationSeries, Skeleton, Skeletons
 
         metadata_copy = deepcopy(metadata)

--- a/src/neuroconv/datainterfaces/behavior/medpc/medpcdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/medpc/medpcdatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from pydantic import FilePath, validate_call
 from pynwb.behavior import BehavioralEpochs, IntervalSeries
@@ -43,6 +45,7 @@ class MedPCInterface(BaseTemporalAlignmentInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         session_conditions: dict,
         start_variable: str,
         metadata_medpc_name_to_info_dict: dict,
@@ -71,6 +74,41 @@ class MedPCInterface(BaseTemporalAlignmentInterface):
         verbose : bool, optional
             Whether to print verbose output, by default True
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "session_conditions",
+                "start_variable",
+                "metadata_medpc_name_to_info_dict",
+                "aligned_timestamp_names",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to MedPCInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            session_conditions = positional_values.get("session_conditions", session_conditions)
+            start_variable = positional_values.get("start_variable", start_variable)
+            metadata_medpc_name_to_info_dict = positional_values.get(
+                "metadata_medpc_name_to_info_dict", metadata_medpc_name_to_info_dict
+            )
+            aligned_timestamp_names = positional_values.get("aligned_timestamp_names", aligned_timestamp_names)
+            verbose = positional_values.get("verbose", verbose)
+
         # This import is to assure that the ndx_events is in the global namespace when an pynwb.io object is created
         # For more detail, see https://github.com/rly/ndx-pose/issues/36
         import ndx_events  # noqa: F401

--- a/src/neuroconv/datainterfaces/behavior/miniscope/miniscopedatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/miniscope/miniscopedatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 from pydantic import DirectoryPath, validate_call
@@ -25,7 +26,9 @@ class MiniscopeBehaviorInterface(BaseDataInterface):
         return source_schema
 
     @validate_call
-    def __init__(self, folder_path: DirectoryPath, verbose: bool = False):
+    def __init__(
+        self, folder_path: DirectoryPath, *args, verbose: bool = False
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Initialize reading recordings from the Miniscope behavioral camera.
 
@@ -37,6 +40,31 @@ class MiniscopeBehaviorInterface(BaseDataInterface):
         verbose : bool, optional
             If True, enables verbose mode for detailed logging, by default False.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to MiniscopeBehaviorInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+
         from ndx_miniscope.utils import (
             get_recording_start_times,
             get_starting_frames,

--- a/src/neuroconv/datainterfaces/behavior/miniscope/miniscopeheadorientationinterface.py
+++ b/src/neuroconv/datainterfaces/behavior/miniscope/miniscopeheadorientationinterface.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -30,6 +31,7 @@ class MiniscopeHeadOrientationInterface(BaseTemporalAlignmentInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         metadata_key: str = "TimeSeriesMiniscopeHeadOrientation",
         verbose: bool = False,
     ):
@@ -45,6 +47,33 @@ class MiniscopeHeadOrientationInterface(BaseTemporalAlignmentInterface):
         verbose : bool, optional
             If True, enables verbose mode for detailed logging, by default False.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "metadata_key",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to MiniscopeHeadOrientationInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            metadata_key = positional_values.get("metadata_key", metadata_key)
+            verbose = positional_values.get("verbose", verbose)
+
         import pandas as pd
 
         super().__init__(file_path=file_path, verbose=verbose)
@@ -149,6 +178,7 @@ class MiniscopeHeadOrientationInterface(BaseTemporalAlignmentInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         always_write_timestamps: bool = False,
     ):
         """
@@ -178,6 +208,31 @@ class MiniscopeHeadOrientationInterface(BaseTemporalAlignmentInterface):
             using a regular sampling rate instead of explicit timestamps. If set to True, timestamps will be written
             explicitly, regardless of whether the sampling rate is uniform.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "always_write_timestamps",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to MiniscopeHeadOrientationInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            always_write_timestamps = positional_values.get("always_write_timestamps", always_write_timestamps)
+
         # Initialize series_kwargs with data
         series_kwargs = {}
         series_kwargs["data"] = self._quaternion_data

--- a/src/neuroconv/datainterfaces/behavior/neuralynx/neuralynx_nvt_interface.py
+++ b/src/neuroconv/datainterfaces/behavior/neuralynx/neuralynx_nvt_interface.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 import numpy as np
 from pydantic import FilePath, validate_call
@@ -21,7 +22,9 @@ class NeuralynxNvtInterface(BaseTemporalAlignmentInterface):
     info = "Interface for writing Neuralynx position tracking .nvt files to NWB."
 
     @validate_call
-    def __init__(self, file_path: FilePath, verbose: bool = False):
+    def __init__(
+        self, file_path: FilePath, *args, verbose: bool = False
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Interface for writing Neuralynx .nvt files to nwb.
 
@@ -32,6 +35,30 @@ class NeuralynxNvtInterface(BaseTemporalAlignmentInterface):
         verbose : bool, default: False
             controls verbosity.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to NeuralynxNvtInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
 
         self.file_path = file_path
         self.verbose = verbose
@@ -97,6 +124,7 @@ class NeuralynxNvtInterface(BaseTemporalAlignmentInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         add_position: bool = True,
         add_angle: bool | None = None,
     ):
@@ -113,6 +141,32 @@ class NeuralynxNvtInterface(BaseTemporalAlignmentInterface):
         add_angle : bool, optional
             If None, write angle as long as it is not all 0s
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "add_position",
+                "add_angle",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to NeuralynxNVTInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            add_position = positional_values.get("add_position", add_position)
+            add_angle = positional_values.get("add_angle", add_angle)
 
         metadata = metadata or self.get_metadata()
         if isinstance(metadata, DeepDict):

--- a/src/neuroconv/datainterfaces/behavior/sleap/sleapdatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/sleap/sleapdatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -29,6 +30,7 @@ class SLEAPInterface(BaseTemporalAlignmentInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         video_file_path: FilePath | None = None,
         verbose: bool = False,
         frames_per_second: float | None = None,
@@ -47,6 +49,34 @@ class SLEAPInterface(BaseTemporalAlignmentInterface):
         frames_per_second : float, optional
             The frames per second (fps) or sampling rate of the video.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "video_file_path",
+                "verbose",
+                "frames_per_second",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to SLEAPInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            video_file_path = positional_values.get("video_file_path", video_file_path)
+            verbose = positional_values.get("verbose", verbose)
+            frames_per_second = positional_values.get("frames_per_second", frames_per_second)
 
         # This import is to assure that the ndx_pose is in the global namespace when an pynwb.io object is created
         # For more detail, see https://github.com/rly/ndx-pose/issues/36

--- a/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/externalvideointerface.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import deepcopy
 from pathlib import Path
 from typing import Literal
@@ -231,6 +232,7 @@ class ExternalVideoInterface(BaseDataInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         starting_frames: list[int] | None = None,
         parent_container: Literal["acquisition", "processing/behavior"] = "acquisition",
         module_description: str | None = None,
@@ -287,6 +289,36 @@ class ExternalVideoInterface(BaseDataInterface):
             If set to True, timestamps will be written explicitly, regardless of whether they were set directly or need
             to be retrieved from the video file.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "starting_frames",
+                "parent_container",
+                "module_description",
+                "always_write_timestamps",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to ExternalVideoInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            starting_frames = positional_values.get("starting_frames", starting_frames)
+            parent_container = positional_values.get("parent_container", parent_container)
+            module_description = positional_values.get("module_description", module_description)
+            always_write_timestamps = positional_values.get("always_write_timestamps", always_write_timestamps)
         if parent_container not in {"acquisition", "processing/behavior"}:
             raise ValueError(
                 f"parent_container must be either 'acquisition' or 'processing/behavior', not {parent_container}."

--- a/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/internalvideointerface.py
@@ -205,6 +205,7 @@ class InternalVideoInterface(BaseDataInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stub_test: bool = False,
         buffer_data: bool = True,
         iterator_options: dict | None = None,
@@ -291,6 +292,40 @@ class InternalVideoInterface(BaseDataInterface):
             If set to True, timestamps will be written explicitly, regardless of whether they were set directly or need
             to be retrieved from the video file.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stub_test",
+                "buffer_data",
+                "iterator_options",
+                "parent_container",
+                "module_description",
+                "always_write_timestamps",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to InternalVideoInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stub_test = positional_values.get("stub_test", stub_test)
+            buffer_data = positional_values.get("buffer_data", buffer_data)
+            iterator_options = positional_values.get("iterator_options", iterator_options)
+            parent_container = positional_values.get("parent_container", parent_container)
+            module_description = positional_values.get("module_description", module_description)
+            always_write_timestamps = positional_values.get("always_write_timestamps", always_write_timestamps)
         if parent_container not in {"acquisition", "processing/behavior"}:
             raise ValueError(
                 f"parent_container must be either 'acquisition' or 'processing/behavior', not {parent_container}."

--- a/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/video/videodatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import deepcopy
 from pathlib import Path
 from typing import Literal
@@ -266,6 +267,7 @@ class _VideoInterface(BaseDataInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stub_test: bool = False,
         external_mode: bool = True,
         starting_frames: list[int] | None = None,
@@ -327,6 +329,41 @@ class _VideoInterface(BaseDataInterface):
             If the processing module specified by module_name does not exist, it will be created with this description.
             The default description is the same as used by the conversion_tools.get_module function.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stub_test",
+                "external_mode",
+                "starting_frames",
+                "chunk_data",
+                "module_name",
+                "module_description",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to VideoInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stub_test = positional_values.get("stub_test", stub_test)
+            external_mode = positional_values.get("external_mode", external_mode)
+            starting_frames = positional_values.get("starting_frames", starting_frames)
+            chunk_data = positional_values.get("chunk_data", chunk_data)
+            module_name = positional_values.get("module_name", module_name)
+            module_description = positional_values.get("module_description", module_description)
+
         metadata = metadata or dict()
         file_paths = self.source_data["file_paths"]
 

--- a/src/neuroconv/datainterfaces/ecephys/alphaomega/alphaomegadatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/alphaomega/alphaomegadatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pydantic import DirectoryPath
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
@@ -40,7 +42,9 @@ class AlphaOmegaRecordingInterface(BaseRecordingExtractorInterface):
         extractor_instance = extractor_class(**self.extractor_kwargs)
         return extractor_instance
 
-    def __init__(self, folder_path: DirectoryPath, verbose: bool = False, es_key: str = "ElectricalSeries"):
+    def __init__(
+        self, folder_path: DirectoryPath, *args, verbose: bool = False, es_key: str = "ElectricalSeries"
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Load and prepare data for AlphaOmega.
 
@@ -53,6 +57,33 @@ class AlphaOmegaRecordingInterface(BaseRecordingExtractorInterface):
             Default is False.
         es_key: str, default: "ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to AlphaOmegaRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         super().__init__(folder_path=folder_path, verbose=verbose, es_key=es_key)
 
     def get_metadata(self) -> DeepDict:

--- a/src/neuroconv/datainterfaces/ecephys/axon/axondatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/axon/axondatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import datetime, timedelta
 from pathlib import Path
 from warnings import warn
@@ -36,6 +37,7 @@ class AxonRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         verbose: bool = False,
         es_key: str = "ElectricalSeries",
     ):
@@ -51,6 +53,32 @@ class AxonRecordingInterface(BaseRecordingExtractorInterface):
         es_key : str, default: "ElectricalSeries"
             The key for the ElectricalSeries in the metadata
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to AxonRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
 
         self.file_path = Path(file_path)
 

--- a/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/axona/axonadatainterface.py
@@ -1,5 +1,7 @@
 """Collection of Axona interfaces."""
 
+import warnings
+
 from pydantic import FilePath
 from pynwb import NWBFile
 
@@ -38,7 +40,9 @@ class AxonaRecordingInterface(BaseRecordingExtractorInterface):
 
         return AxonaRecordingExtractor
 
-    def __init__(self, file_path: FilePath, verbose: bool = False, es_key: str = "ElectricalSeries"):
+    def __init__(
+        self, file_path: FilePath, *args, verbose: bool = False, es_key: str = "ElectricalSeries"
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
 
         Parameters
@@ -48,6 +52,32 @@ class AxonaRecordingInterface(BaseRecordingExtractorInterface):
         verbose: bool, optional, default: True
         es_key: str, default: "ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to AxonaRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
 
         super().__init__(file_path=file_path, verbose=verbose, es_key=es_key)
         self.metadata_in_set_file = self.recording_extractor.neo_reader.file_parameters["set"]["file_header"]
@@ -133,7 +163,34 @@ class AxonaUnitRecordingInterface(AxonaRecordingInterface):
             type="object",
         )
 
-    def __init__(self, file_path: FilePath, noise_std: float = 3.5):
+    def __init__(
+        self, file_path: FilePath, *args, noise_std: float = 3.5
+    ):  # TODO: change to * (keyword only) on or after August 2026
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "noise_std",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to AxonaUnitRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            noise_std = positional_values.get("noise_std", noise_std)
+
         super().__init__(filename=file_path, noise_std=noise_std)
         self.source_data = dict(file_path=file_path, noise_std=noise_std)
 

--- a/src/neuroconv/datainterfaces/ecephys/baselfpextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baselfpextractorinterface.py
@@ -23,6 +23,7 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
         self,
         nwbfile: NWBFile | None = None,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stub_test: bool = False,
         write_as: Literal["raw", "lfp", "processed"] = "lfp",
         write_electrical_series: bool = True,
@@ -30,6 +31,41 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
         iterator_options: dict | None = None,
         iterator_opts: dict | None = None,
     ):
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stub_test",
+                "write_as",
+                "write_electrical_series",
+                "iterator_type",
+                "iterator_options",
+                "iterator_opts",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to BaseLFPExtractorInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stub_test = positional_values.get("stub_test", stub_test)
+            write_as = positional_values.get("write_as", write_as)
+            write_electrical_series = positional_values.get("write_electrical_series", write_electrical_series)
+            iterator_type = positional_values.get("iterator_type", iterator_type)
+            iterator_options = positional_values.get("iterator_options", iterator_options)
+            iterator_opts = positional_values.get("iterator_opts", iterator_opts)
+
         # Handle deprecated iterator_opts parameter
         if iterator_opts is not None:
             warnings.warn(

--- a/src/neuroconv/datainterfaces/ecephys/biocam/biocamdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/biocam/biocamdatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pydantic import FilePath
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
@@ -26,7 +28,9 @@ class BiocamRecordingInterface(BaseRecordingExtractorInterface):
         schema["properties"]["file_path"]["description"] = "Path to the .bwr file."
         return schema
 
-    def __init__(self, file_path: FilePath, verbose: bool = False, es_key: str = "ElectricalSeries"):
+    def __init__(
+        self, file_path: FilePath, *args, verbose: bool = False, es_key: str = "ElectricalSeries"
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Load and prepare data for Biocam.
 
@@ -38,4 +42,31 @@ class BiocamRecordingInterface(BaseRecordingExtractorInterface):
             Allows verbose.
         es_key: str, default: "ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to BiocamRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         super().__init__(file_path=file_path, verbose=verbose, es_key=es_key)

--- a/src/neuroconv/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/blackrock/blackrockdatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 from typing import Optional
 
@@ -48,6 +49,7 @@ class BlackrockRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         nsx_override: FilePath | None = None,
         verbose: bool = False,
         es_key: str = "ElectricalSeries",
@@ -62,6 +64,34 @@ class BlackrockRecordingInterface(BaseRecordingExtractorInterface):
         verbose: bool, default: True
         es_key : str, default: "ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "nsx_override",
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to BlackrockRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            nsx_override = positional_values.get("nsx_override", nsx_override)
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
 
         file_path = Path(file_path)
         if file_path.suffix == "":
@@ -115,6 +145,7 @@ class BlackrockSortingInterface(BaseSortingExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         sampling_frequency: Optional[float] = None,
         nsx_to_load: Optional[int | list | str] = None,
         verbose: bool = False,
@@ -134,6 +165,35 @@ class BlackrockSortingInterface(BaseSortingExtractorInterface):
         verbose : bool, default: False
             Enables verbosity
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "sampling_frequency",
+                "nsx_to_load",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to BlackrockSortingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            sampling_frequency = positional_values.get("sampling_frequency", sampling_frequency)
+            nsx_to_load = positional_values.get("nsx_to_load", nsx_to_load)
+            verbose = positional_values.get("verbose", verbose)
+
         super().__init__(
             file_path=file_path,
             sampling_frequency=sampling_frequency,

--- a/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/cellexplorer/cellexplorerdatainterface.py
@@ -315,7 +315,9 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
         source_schema["properties"]["folder_path"]["description"] = "Folder containing the .session.mat file"
         return source_schema
 
-    def __init__(self, folder_path: DirectoryPath, verbose: bool = False, es_key: str = "ElectricalSeries"):
+    def __init__(
+        self, folder_path: DirectoryPath, *args, verbose: bool = False, es_key: str = "ElectricalSeries"
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
 
         Parameters
@@ -325,6 +327,33 @@ class CellExplorerRecordingInterface(BaseRecordingExtractorInterface):
         verbose: bool, default=True
         es_key: str, default="ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to CellExplorerRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         self.session_path = Path(folder_path)
 
         # No super here, we need to do everything by hand
@@ -402,13 +431,43 @@ class CellExplorerLFPInterface(CellExplorerRecordingInterface):
     sampling_frequency_key = "srLfp"
     binary_file_extension = "lfp"
 
-    def __init__(self, folder_path: DirectoryPath, verbose: bool = False, es_key: str = "ElectricalSeriesLFP"):
-        super().__init__(folder_path, verbose, es_key)
+    def __init__(
+        self, folder_path: DirectoryPath, *args, verbose: bool = False, es_key: str = "ElectricalSeriesLFP"
+    ):  # TODO: change to * (keyword only) on or after August 2026
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to CellExplorerLFPInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
+        super().__init__(folder_path, verbose=verbose, es_key=es_key)
 
     def add_to_nwbfile(
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stub_test: bool = False,
         starting_time: float | None = None,
         write_as: Literal["raw", "lfp", "processed"] = "lfp",
@@ -419,6 +478,47 @@ class CellExplorerLFPInterface(CellExplorerRecordingInterface):
         iterator_options: dict | None = None,
         iterator_opts: dict | None = None,
     ):
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stub_test",
+                "starting_time",
+                "write_as",
+                "write_electrical_series",
+                "compression",
+                "compression_opts",
+                "iterator_type",
+                "iterator_options",
+                "iterator_opts",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to CellExplorerLFPInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stub_test = positional_values.get("stub_test", stub_test)
+            starting_time = positional_values.get("starting_time", starting_time)
+            write_as = positional_values.get("write_as", write_as)
+            write_electrical_series = positional_values.get("write_electrical_series", write_electrical_series)
+            compression = positional_values.get("compression", compression)
+            compression_opts = positional_values.get("compression_opts", compression_opts)
+            iterator_type = positional_values.get("iterator_type", iterator_type)
+            iterator_options = positional_values.get("iterator_options", iterator_options)
+            iterator_opts = positional_values.get("iterator_opts", iterator_opts)
+
         # Handle deprecated iterator_opts parameter
         if iterator_opts is not None:
             warnings.warn(
@@ -432,16 +532,16 @@ class CellExplorerLFPInterface(CellExplorerRecordingInterface):
             iterator_options = iterator_opts
 
         super().add_to_nwbfile(
-            nwbfile,
-            metadata,
-            stub_test,
-            starting_time,
-            write_as,
-            write_electrical_series,
-            compression,
-            compression_opts,
-            iterator_type,
-            iterator_options,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            stub_test=stub_test,
+            starting_time=starting_time,
+            write_as=write_as,
+            write_electrical_series=write_electrical_series,
+            compression=compression,
+            compression_opts=compression_opts,
+            iterator_type=iterator_type,
+            iterator_options=iterator_options,
         )
 
 
@@ -470,7 +570,9 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
         extractor_instance = extractor_class(**self.extractor_kwargs)
         return extractor_instance
 
-    def __init__(self, file_path: FilePath, verbose: bool = False):
+    def __init__(
+        self, file_path: FilePath, *args, verbose: bool = False
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Initialize read of Cell Explorer file.
 
@@ -480,6 +582,31 @@ class CellExplorerSortingInterface(BaseSortingExtractorInterface):
             Path to .spikes.cellinfo.mat file.
         verbose: bool, default: True
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to CellExplorerSortingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+
         # Triggers import error at initialization
         pymatreader = get_package(
             package_name="pymatreader",

--- a/src/neuroconv/datainterfaces/ecephys/edf/edfanaloginterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/edf/edfanaloginterface.py
@@ -58,8 +58,8 @@ class EDFAnalogInterface(BaseDataInterface):
 
     def __init__(
         self,
-        *,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         channels_to_include: list[str] | None = None,
         verbose: bool = False,
         metadata_key: str = "analog_edf_metadata_key",
@@ -78,6 +78,35 @@ class EDFAnalogInterface(BaseDataInterface):
         metadata_key : str, default: "analog_edf_metadata_key"
             Key for the TimeSeries metadata in the metadata dictionary.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "channels_to_include",
+                "verbose",
+                "metadata_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to EDFAnalogInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            channels_to_include = positional_values.get("channels_to_include", channels_to_include)
+            verbose = positional_values.get("verbose", verbose)
+            metadata_key = positional_values.get("metadata_key", metadata_key)
+
         from spikeinterface.extractors import read_edf
 
         self._file_path = Path(file_path)
@@ -131,6 +160,7 @@ class EDFAnalogInterface(BaseDataInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stub_test: bool = False,
         iterator_type: str | None = "v2",
         iterator_options: dict | None = None,
@@ -161,6 +191,39 @@ class EDFAnalogInterface(BaseDataInterface):
             _stub_recording,
             add_recording_as_time_series_to_nwbfile,
         )
+
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stub_test",
+                "iterator_type",
+                "iterator_options",
+                "iterator_opts",
+                "always_write_timestamps",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to EDFAnalogInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stub_test = positional_values.get("stub_test", stub_test)
+            iterator_type = positional_values.get("iterator_type", iterator_type)
+            iterator_options = positional_values.get("iterator_options", iterator_options)
+            iterator_opts = positional_values.get("iterator_opts", iterator_opts)
+            always_write_timestamps = positional_values.get("always_write_timestamps", always_write_timestamps)
 
         # Handle deprecated iterator_opts parameter
         if iterator_opts is not None:

--- a/src/neuroconv/datainterfaces/ecephys/edf/edfdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/edf/edfdatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pydantic import FilePath
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
@@ -75,6 +77,7 @@ class EDFRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         verbose: bool = False,
         es_key: str = "ElectricalSeries",
         channels_to_skip: list | None = None,
@@ -97,6 +100,35 @@ class EDFRecordingInterface(BaseRecordingExtractorInterface):
             channels that are present in the EDF file.
 
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+                "channels_to_skip",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to EDFRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+            channels_to_skip = positional_values.get("channels_to_skip", channels_to_skip)
+
         get_package(
             package_name="pyedflib",
             excluded_platforms_and_python_versions=dict(darwin=dict(arm=["3.9"])),

--- a/src/neuroconv/datainterfaces/ecephys/intan/intananaloginterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intananaloginterface.py
@@ -33,6 +33,7 @@ class IntanAnalogInterface(BaseDataInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stream_name: str,
         verbose: bool = False,
         metadata_key: str = "TimeSeriesAnalogIntan",
@@ -56,6 +57,35 @@ class IntanAnalogInterface(BaseDataInterface):
         metadata_key : str, default: "TimeSeriesAnalogIntan"
             Key for the TimeSeries metadata in the metadata dictionary.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stream_name",
+                "verbose",
+                "metadata_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to IntanAnalogInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stream_name = positional_values.get("stream_name", stream_name)
+            verbose = positional_values.get("verbose", verbose)
+            metadata_key = positional_values.get("metadata_key", metadata_key)
+
         from spikeinterface.extractors import read_intan
 
         self._file_path = Path(file_path)
@@ -153,6 +183,7 @@ class IntanAnalogInterface(BaseDataInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stub_test: bool = False,
         iterator_type: str | None = "v2",
         iterator_options: dict | None = None,
@@ -179,6 +210,38 @@ class IntanAnalogInterface(BaseDataInterface):
         always_write_timestamps : bool, default: False
             If True, always writes timestamps instead of using sampling rate
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stub_test",
+                "iterator_type",
+                "iterator_options",
+                "iterator_opts",
+                "always_write_timestamps",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to IntanAnalogInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stub_test = positional_values.get("stub_test", stub_test)
+            iterator_type = positional_values.get("iterator_type", iterator_type)
+            iterator_options = positional_values.get("iterator_options", iterator_options)
+            iterator_opts = positional_values.get("iterator_opts", iterator_opts)
+            always_write_timestamps = positional_values.get("always_write_timestamps", always_write_timestamps)
         from ....tools.spikeinterface import (
             _stub_recording,
             add_recording_as_time_series_to_nwbfile,

--- a/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/intan/intandatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 from pydantic import FilePath
@@ -51,6 +52,7 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         verbose: bool = False,
         es_key: str = "ElectricalSeries",
         ignore_integrity_checks: bool = False,
@@ -70,6 +72,34 @@ class IntanRecordingInterface(BaseRecordingExtractorInterface):
             If True, data that violates integrity assumptions will be loaded. At the moment the only integrity
             check performed is that timestamps are continuous. If False, an error will be raised if the check fails.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+                "ignore_integrity_checks",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to IntanRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+            ignore_integrity_checks = positional_values.get("ignore_integrity_checks", ignore_integrity_checks)
 
         self.file_path = Path(file_path)
 

--- a/src/neuroconv/datainterfaces/ecephys/kilosort/kilosortdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/kilosort/kilosortdatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pydantic import DirectoryPath
 
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
@@ -28,6 +30,7 @@ class KiloSortSortingInterface(BaseSortingExtractorInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         keep_good_only: bool = False,
         verbose: bool = False,
     ):
@@ -42,6 +45,33 @@ class KiloSortSortingInterface(BaseSortingExtractorInterface):
             If True, only Kilosort-labeled 'good' units are returned
         verbose: bool, default: True
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "keep_good_only",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to KiloSortSortingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            keep_good_only = positional_values.get("keep_good_only", keep_good_only)
+            verbose = positional_values.get("verbose", verbose)
+
         super().__init__(folder_path=folder_path, keep_good_only=keep_good_only, verbose=verbose)
 
     def get_metadata(self) -> DeepDict:

--- a/src/neuroconv/datainterfaces/ecephys/maxwell/maxonedatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/maxwell/maxonedatainterface.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from pathlib import Path
 from platform import system
 
@@ -51,6 +52,7 @@ class MaxOneRecordingInterface(BaseRecordingExtractorInterface):  # pragma: no c
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         hdf5_plugin_path: DirectoryPath | None = None,
         download_plugin: bool = True,
         verbose: bool = False,
@@ -75,6 +77,37 @@ class MaxOneRecordingInterface(BaseRecordingExtractorInterface):  # pragma: no c
         es_key : str, default: "ElectricalSeries"
             The key of this ElectricalSeries in the metadata dictionary.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "hdf5_plugin_path",
+                "download_plugin",
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to MaxOneRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            hdf5_plugin_path = positional_values.get("hdf5_plugin_path", hdf5_plugin_path)
+            download_plugin = positional_values.get("download_plugin", download_plugin)
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         if system() != "Linux":
             raise NotImplementedError(
                 "The MaxOneRecordingInterface has not yet been implemented for systems other than Linux."

--- a/src/neuroconv/datainterfaces/ecephys/mcsraw/mcsrawdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/mcsraw/mcsrawdatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pydantic import FilePath
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
@@ -26,7 +28,9 @@ class MCSRawRecordingInterface(BaseRecordingExtractorInterface):
         source_schema["properties"]["file_path"]["description"] = "Path to the .raw file."
         return source_schema
 
-    def __init__(self, file_path: FilePath, verbose: bool = False, es_key: str = "ElectricalSeries"):
+    def __init__(
+        self, file_path: FilePath, *args, verbose: bool = False, es_key: str = "ElectricalSeries"
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Load and prepare data for MCSRaw.
 
@@ -38,4 +42,31 @@ class MCSRawRecordingInterface(BaseRecordingExtractorInterface):
             Allows verbose.
         es_key: str, default: "ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to MCSRawRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         super().__init__(file_path=file_path, verbose=verbose, es_key=es_key)

--- a/src/neuroconv/datainterfaces/ecephys/mearec/mearecdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/mearec/mearecdatainterface.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 from pydantic import FilePath
 
@@ -30,7 +31,9 @@ class MEArecRecordingInterface(BaseRecordingExtractorInterface):
         source_schema["properties"]["file_path"]["description"] = "Path to the MEArec .h5 file."
         return source_schema
 
-    def __init__(self, file_path: FilePath, verbose: bool = False, es_key: str = "ElectricalSeries"):
+    def __init__(
+        self, file_path: FilePath, *args, verbose: bool = False, es_key: str = "ElectricalSeries"
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Load and prepare data for MEArec.
 
@@ -42,6 +45,33 @@ class MEArecRecordingInterface(BaseRecordingExtractorInterface):
             Allows verbose.
         es_key : str, default: "ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to MEArecRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         super().__init__(file_path=file_path, verbose=verbose, es_key=es_key)
 
     def get_metadata(self) -> DeepDict:

--- a/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuralynx/neuralynxdatainterface.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 import numpy as np
 from pydantic import DirectoryPath
@@ -47,6 +48,7 @@ class NeuralynxRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stream_name: str | None = None,
         verbose: bool = False,
         es_key: str = "ElectricalSeries",
@@ -64,6 +66,35 @@ class NeuralynxRecordingInterface(BaseRecordingExtractorInterface):
         verbose : bool, default: False
         es_key : str, default: "ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stream_name",
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to NeuralynxRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stream_name = positional_values.get("stream_name", stream_name)
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         super().__init__(
             folder_path=folder_path,
             stream_name=stream_name,
@@ -129,6 +160,7 @@ class NeuralynxSortingInterface(BaseSortingExtractorInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         sampling_frequency: float | None = None,
         verbose: bool = False,
         stream_id: str | None = None,
@@ -147,6 +179,34 @@ class NeuralynxSortingInterface(BaseSortingExtractorInterface):
             Used by Spikeinterface and neo to calculate the t_start, if not provided and the stream is unique
             it will be chosen automatically
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "sampling_frequency",
+                "verbose",
+                "stream_id",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to NeuralynxSortingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            sampling_frequency = positional_values.get("sampling_frequency", sampling_frequency)
+            verbose = positional_values.get("verbose", verbose)
+            stream_id = positional_values.get("stream_id", stream_id)
 
         super().__init__(
             folder_path=folder_path, sampling_frequency=sampling_frequency, stream_id=stream_id, verbose=verbose

--- a/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/neuroscope/neuroscopedatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -157,6 +158,7 @@ class NeuroScopeRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         gain: float | None = None,
         xml_file_path: FilePath | None = None,
         verbose: bool = False,
@@ -179,6 +181,37 @@ class NeuroScopeRecordingInterface(BaseRecordingExtractorInterface):
             The default is None.
         es_key: str, default: "ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "gain",
+                "xml_file_path",
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to NeuroScopeRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            gain = positional_values.get("gain", gain)
+            xml_file_path = positional_values.get("xml_file_path", xml_file_path)
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         get_package(package_name="lxml")
 
         if xml_file_path is None:
@@ -249,9 +282,11 @@ class NeuroScopeLFPInterface(BaseLFPExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         gain: float | None = None,
         xml_file_path: FilePath | None = None,
         verbose: bool = False,
+        es_key: str = "ElectricalSeries",
     ):
         """
         Load and prepare lfp data and corresponding metadata from the Neuroscope format (.eeg or .lfp files).
@@ -270,7 +305,39 @@ class NeuroScopeLFPInterface(BaseLFPExtractorInterface):
             The default is None.
         verbose : bool, default: False
             If True, enables verbose mode for detailed logging.
+        es_key : str, default: "ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "gain",
+                "xml_file_path",
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to NeuroScopeLFPInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            gain = positional_values.get("gain", gain)
+            xml_file_path = positional_values.get("xml_file_path", xml_file_path)
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         get_package(package_name="lxml")
 
         if xml_file_path is None:
@@ -325,6 +392,7 @@ class NeuroScopeSortingInterface(BaseSortingExtractorInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         keep_mua_units: bool = True,
         exclude_shanks: list[int] | None = None,
         xml_file_path: FilePath | None = None,
@@ -347,6 +415,37 @@ class NeuroScopeSortingInterface(BaseSortingExtractorInterface):
             If unspecified, it will be automatically set as the only .xml file in the same folder as the .dat file.
             The default is None.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "keep_mua_units",
+                "exclude_shanks",
+                "xml_file_path",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to NeuroScopeSortingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            keep_mua_units = positional_values.get("keep_mua_units", keep_mua_units)
+            exclude_shanks = positional_values.get("exclude_shanks", exclude_shanks)
+            xml_file_path = positional_values.get("xml_file_path", xml_file_path)
+            verbose = positional_values.get("verbose", verbose)
+
         get_package(package_name="lxml")
 
         super().__init__(

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephybinarysanaloginterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephybinarysanaloginterface.py
@@ -29,6 +29,7 @@ class OpenEphysBinaryAnalogInterface(BaseDataInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stream_name: str | None = None,
         block_index: int | None = None,
         verbose: bool = False,
@@ -52,6 +53,37 @@ class OpenEphysBinaryAnalogInterface(BaseDataInterface):
             The name of the TimeSeries object in the NWBFile and also
             the key of the associated metadata
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stream_name",
+                "block_index",
+                "verbose",
+                "time_series_name",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to OpenEphysBinaryAnalogInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stream_name = positional_values.get("stream_name", stream_name)
+            block_index = positional_values.get("block_index", block_index)
+            verbose = positional_values.get("verbose", verbose)
+            time_series_name = positional_values.get("time_series_name", time_series_name)
+
         from spikeinterface.extractors.extractor_classes import (
             OpenEphysBinaryRecordingExtractor,
         )
@@ -129,6 +161,7 @@ class OpenEphysBinaryAnalogInterface(BaseDataInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stub_test: bool = False,
         iterator_type: str | None = "v2",
         iterator_options: dict | None = None,
@@ -159,6 +192,39 @@ class OpenEphysBinaryAnalogInterface(BaseDataInterface):
             _stub_recording,
             add_recording_as_time_series_to_nwbfile,
         )
+
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stub_test",
+                "iterator_type",
+                "iterator_options",
+                "iterator_opts",
+                "always_write_timestamps",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to OpenEphysBinaryAnalogInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stub_test = positional_values.get("stub_test", stub_test)
+            iterator_type = positional_values.get("iterator_type", iterator_type)
+            iterator_options = positional_values.get("iterator_options", iterator_options)
+            iterator_opts = positional_values.get("iterator_opts", iterator_opts)
+            always_write_timestamps = positional_values.get("always_write_timestamps", always_write_timestamps)
 
         # Handle deprecated iterator_opts parameter
         if iterator_opts is not None:

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinarydatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pydantic import DirectoryPath
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
@@ -79,6 +81,7 @@ class OpenEphysBinaryRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stream_name: str | None = None,
         block_index: int | None = None,
         stub_test: bool = False,
@@ -101,6 +104,39 @@ class OpenEphysBinaryRecordingInterface(BaseRecordingExtractorInterface):
         verbose : bool, default: False
         es_key : str, default: "ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stream_name",
+                "block_index",
+                "stub_test",
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to OpenEphysBinaryRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stream_name = positional_values.get("stream_name", stream_name)
+            block_index = positional_values.get("block_index", block_index)
+            stub_test = positional_values.get("stub_test", stub_test)
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         from ._openephys_utils import _read_settings_xml
 
         self._xml_root = _read_settings_xml(folder_path)

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephyslegacydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephyslegacydatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import datetime
 from warnings import warn
 
@@ -71,6 +72,7 @@ class OpenEphysLegacyRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stream_name: str | None = None,
         block_index: int | None = None,
         verbose: bool = False,
@@ -91,6 +93,37 @@ class OpenEphysLegacyRecordingInterface(BaseRecordingExtractorInterface):
         verbose : bool, default: False
         es_key : str, default: "ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stream_name",
+                "block_index",
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to OpenEphysLegacyRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stream_name = positional_values.get("stream_name", stream_name)
+            block_index = positional_values.get("block_index", block_index)
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         available_streams = self.get_stream_names(folder_path=folder_path)
         if len(available_streams) > 1 and stream_name is None:
             raise ValueError(

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephyssortingdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephyssortingdatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pydantic import DirectoryPath, validate_call
 
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
@@ -40,5 +42,34 @@ class OpenEphysSortingInterface(BaseSortingExtractorInterface):
         return OpenEphysSortingExtractor
 
     @validate_call
-    def __init__(self, folder_path: DirectoryPath, experiment_id: int = 0, recording_id: int = 0):
+    def __init__(
+        self, folder_path: DirectoryPath, *args, experiment_id: int = 0, recording_id: int = 0
+    ):  # TODO: change to * (keyword only) on or after August 2026
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "experiment_id",
+                "recording_id",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to OpenEphysSortingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            experiment_id = positional_values.get("experiment_id", experiment_id)
+            recording_id = positional_values.get("recording_id", recording_id)
+
         super().__init__(folder_path=str(folder_path), experiment_id=experiment_id, recording_id=recording_id)

--- a/src/neuroconv/datainterfaces/ecephys/phy/phydatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/phy/phydatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pydantic import DirectoryPath, validate_call
 
 from ..basesortingextractorinterface import BaseSortingExtractorInterface
@@ -34,6 +36,7 @@ class PhySortingInterface(BaseSortingExtractorInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         exclude_cluster_groups: list[str] | None = None,
         verbose: bool = False,
     ):
@@ -48,6 +51,33 @@ class PhySortingInterface(BaseSortingExtractorInterface):
             Cluster groups to exclude (e.g. "noise" or ["noise", "mua"]).
         verbose : bool, default: False
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "exclude_cluster_groups",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to PhySortingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            exclude_cluster_groups = positional_values.get("exclude_cluster_groups", exclude_cluster_groups)
+            verbose = positional_values.get("verbose", verbose)
+
         super().__init__(folder_path=folder_path, exclude_cluster_groups=exclude_cluster_groups, verbose=verbose)
 
     def get_metadata(self) -> DeepDict:

--- a/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/plexon/plexondatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 from pydantic import FilePath, validate_call
@@ -35,6 +36,7 @@ class PlexonRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         verbose: bool = False,
         es_key: str = "ElectricalSeries",
         stream_name: str = "WB-Wideband",
@@ -53,6 +55,34 @@ class PlexonRecordingInterface(BaseRecordingExtractorInterface):
             Only pass a stream if you modified the channel prefixes in the Plexon file and you know the prefix of
             the wideband data.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+                "stream_name",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to PlexonRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+            stream_name = positional_values.get("stream_name", stream_name)
 
         invalid_stream_names = ["FPl-Low Pass Filtered", "SPKC-High Pass Filtered", "AI-Auxiliary Input"]
         assert stream_name not in invalid_stream_names, f"Invalid stream name: {stream_name}"
@@ -99,6 +129,7 @@ class PlexonLFPInterface(BaseLFPExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         verbose: bool = False,
         es_key: str = "ElectricalSeriesLF",
         stream_name: str = "FPl-Low Pass Filtered",
@@ -117,6 +148,34 @@ class PlexonLFPInterface(BaseLFPExtractorInterface):
             Only pass a stream if you modified the channel prefixes in the Plexon file and you know the prefix of
             the FPllow pass filtered data.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+                "stream_name",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to PlexonLFPInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+            stream_name = positional_values.get("stream_name", stream_name)
 
         # By default, the stream name of Plexon LFP data is "FPl-Low Pass Filter"
         # But the user might modify it. For that case, we exclude the default stream names
@@ -178,7 +237,9 @@ class Plexon2RecordingInterface(BaseRecordingExtractorInterface):
         return extractor_instance
 
     @validate_call
-    def __init__(self, file_path: FilePath, verbose: bool = False, es_key: str = "ElectricalSeries"):
+    def __init__(
+        self, file_path: FilePath, *args, verbose: bool = False, es_key: str = "ElectricalSeries"
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Load and prepare data for Plexon.
 
@@ -190,6 +251,33 @@ class Plexon2RecordingInterface(BaseRecordingExtractorInterface):
             Allows verbosity.
         es_key : str, default: "ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to Plexon2RecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         # TODO: when neo version 0.14.4 is out or higher change this to stream_name for clarify
         import neo
         from packaging.version import Version
@@ -242,7 +330,9 @@ class PlexonSortingInterface(BaseSortingExtractorInterface):
         return PlexonSortingExtractor
 
     @validate_call
-    def __init__(self, file_path: FilePath, verbose: bool = False):
+    def __init__(
+        self, file_path: FilePath, *args, verbose: bool = False
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Load and prepare data for Plexon.
 
@@ -253,6 +343,31 @@ class PlexonSortingInterface(BaseSortingExtractorInterface):
         verbose: bool, default: True
             Allows verbosity.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to PlexonSortingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+
         super().__init__(file_path=file_path, verbose=verbose)
 
     def get_metadata(self) -> DeepDict:

--- a/src/neuroconv/datainterfaces/ecephys/sortedrecordinginterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/sortedrecordinginterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from neuroconv import ConverterPipe
 from neuroconv.datainterfaces.ecephys.baserecordingextractorinterface import (
     BaseRecordingExtractorInterface,
@@ -48,6 +50,7 @@ class SortedRecordingConverter(ConverterPipe):
     def __init__(
         self,
         recording_interface: BaseRecordingExtractorInterface,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         sorting_interface: BaseSortingExtractorInterface,
         unit_ids_to_channel_ids: dict[str | int, list[str | int]],
     ):
@@ -65,6 +68,32 @@ class SortedRecordingConverter(ConverterPipe):
             maps to a list of channel IDs (values) that were used to detect that unit.
             This mapping ensures proper linkage between sorted units and recording electrodes.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "sorting_interface",
+                "unit_ids_to_channel_ids",
+            ]
+            num_positional_args_before_args = 1  # recording_interface
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to SortedRecordingConverter.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            sorting_interface = positional_values.get("sorting_interface", sorting_interface)
+            unit_ids_to_channel_ids = positional_values.get("unit_ids_to_channel_ids", unit_ids_to_channel_ids)
 
         self.recording_interface = recording_interface
         self.sorting_interface = sorting_interface

--- a/src/neuroconv/datainterfaces/ecephys/spike2/spike2datainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spike2/spike2datainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 from pydantic import FilePath, validate_call
@@ -62,7 +63,9 @@ class Spike2RecordingInterface(BaseRecordingExtractorInterface):
         return CedRecordingExtractor.get_all_channels_info(file_path=file_path)
 
     @validate_call
-    def __init__(self, file_path: FilePath, verbose: bool = False, es_key: str = "ElectricalSeries"):
+    def __init__(
+        self, file_path: FilePath, *args, verbose: bool = False, es_key: str = "ElectricalSeries"
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Initialize reading of Spike2 file.
 
@@ -73,6 +76,33 @@ class Spike2RecordingInterface(BaseRecordingExtractorInterface):
         verbose : bool, default: False
         es_key : str, default: "ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to Spike2RecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         _test_sonpy_installation()
 
         stream_id = "1" if Path(file_path).suffix == ".smr" else None

--- a/src/neuroconv/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikegadgets/spikegadgetsdatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pydantic import ConfigDict, FilePath, validate_call
 
 from ..baserecordingextractorinterface import BaseRecordingExtractorInterface
@@ -42,6 +44,7 @@ class SpikeGadgetsRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stream_id: str = "trodes",
         gains: ArrayType | None = None,
         verbose: bool = False,
@@ -60,6 +63,37 @@ class SpikeGadgetsRecordingInterface(BaseRecordingExtractorInterface):
             or an array of values for each channel.
         es_key : str, default: "ElectricalSeries"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stream_id",
+                "gains",
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to SpikeGadgetsRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stream_id = positional_values.get("stream_id", stream_id)
+            gains = positional_values.get("gains", gains)
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         super().__init__(file_path=file_path, stream_id=stream_id, verbose=verbose, es_key=es_key)
 
         if gains is not None:

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxdatainterface.py
@@ -1,5 +1,6 @@
 """DataInterfaces for SpikeGLX."""
 
+import warnings
 from datetime import datetime
 from pathlib import Path
 
@@ -55,7 +56,7 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
-        *,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stream_id: str,
         verbose: bool = False,
         es_key: str | None = None,
@@ -73,6 +74,34 @@ class SpikeGLXRecordingInterface(BaseRecordingExtractorInterface):
         es_key : str, optional
             The key to access the metadata of the ElectricalSeries.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stream_id",
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to SpikeGLXRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stream_id = positional_values.get("stream_id", stream_id)
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
 
         if stream_id == "nidq":
             raise ValueError(

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxnidqinterface.py
@@ -38,7 +38,7 @@ class SpikeGLXNIDQInterface(BaseDataInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
-        *,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         verbose: bool = False,
         es_key: str | None = None,
         metadata_key: str = "SpikeGLXNIDQ",
@@ -122,6 +122,38 @@ class SpikeGLXNIDQInterface(BaseDataInterface):
                 }
 
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+                "es_key",
+                "metadata_key",
+                "analog_channel_groups",
+                "digital_channel_groups",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to SpikeGLXNIDQInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+            metadata_key = positional_values.get("metadata_key", metadata_key)
+            analog_channel_groups = positional_values.get("analog_channel_groups", analog_channel_groups)
+            digital_channel_groups = positional_values.get("digital_channel_groups", digital_channel_groups)
 
         if es_key is not None:
             warnings.warn(
@@ -439,7 +471,7 @@ class SpikeGLXNIDQInterface(BaseDataInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
-        *,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stub_test: bool = False,
         iterator_type: str | None = "v2",
         iterator_options: dict | None = None,
@@ -466,6 +498,39 @@ class SpikeGLXNIDQInterface(BaseDataInterface):
         always_write_timestamps : bool, default: False
             If True, always writes timestamps instead of using sampling rate
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stub_test",
+                "iterator_type",
+                "iterator_options",
+                "iterator_opts",
+                "always_write_timestamps",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to SpikeGLXNIDQInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stub_test = positional_values.get("stub_test", stub_test)
+            iterator_type = positional_values.get("iterator_type", iterator_type)
+            iterator_options = positional_values.get("iterator_options", iterator_options)
+            iterator_opts = positional_values.get("iterator_opts", iterator_opts)
+            always_write_timestamps = positional_values.get("always_write_timestamps", always_write_timestamps)
+
         # Handle deprecated iterator_opts parameter
         if iterator_opts is not None:
             warnings.warn(

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxsyncchannelinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxsyncchannelinterface.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import datetime
 from pathlib import Path
 
@@ -67,6 +68,7 @@ class SpikeGLXSyncChannelInterface(BaseDataInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stream_id: str,
         verbose: bool = False,
         metadata_key: str = "SpikeGLXSync",
@@ -98,6 +100,35 @@ class SpikeGLXSyncChannelInterface(BaseDataInterface):
         NotImplementedError
             If stream_id contains 'obx' (OneBox support not yet implemented).
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stream_id",
+                "verbose",
+                "metadata_key",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to SpikeGLXSyncChannelInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stream_id = positional_values.get("stream_id", stream_id)
+            verbose = positional_values.get("verbose", verbose)
+            metadata_key = positional_values.get("metadata_key", metadata_key)
+
         # Validate stream_id
         if "-SYNC" not in stream_id:
             raise ValueError(
@@ -225,7 +256,7 @@ class SpikeGLXSyncChannelInterface(BaseDataInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
-        *,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stub_test: bool = False,
         iterator_type: str | None = "v2",
         iterator_options: dict | None = None,
@@ -250,6 +281,37 @@ class SpikeGLXSyncChannelInterface(BaseDataInterface):
         always_write_timestamps : bool, default: False
             If True, always writes timestamps instead of using sampling rate.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stub_test",
+                "iterator_type",
+                "iterator_options",
+                "always_write_timestamps",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to SpikeGLXSyncChannelInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stub_test = positional_values.get("stub_test", stub_test)
+            iterator_type = positional_values.get("iterator_type", iterator_type)
+            iterator_options = positional_values.get("iterator_options", iterator_options)
+            always_write_timestamps = positional_values.get("always_write_timestamps", always_write_timestamps)
+
         from ....tools.spikeinterface import (
             _stub_recording,
             add_recording_as_time_series_to_nwbfile,

--- a/src/neuroconv/datainterfaces/ecephys/tdt/tdtdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/tdt/tdtdatainterface.py
@@ -31,7 +31,7 @@ class TdtRecordingInterface(BaseRecordingExtractorInterface):
     @validate_call
     def __init__(
         self,
-        *args: Any,
+        *args: Any,  # TODO: change to * (keyword only) on or after August 2026
         folder_path: DirectoryPath,
         gain: float,
         stream_id: str = "0",  # Stream "0" corresponds to LFP for gin data. Other streams seem non-electrical.

--- a/src/neuroconv/datainterfaces/ecephys/whitematter/whitematterdatainterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/whitematter/whitematterdatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional
 
 from pydantic import FilePath
@@ -38,6 +39,7 @@ class WhiteMatterRecordingInterface(BaseRecordingExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         sampling_frequency: float,
         num_channels: int,
         channel_ids: Optional[list] = None,
@@ -65,6 +67,41 @@ class WhiteMatterRecordingInterface(BaseRecordingExtractorInterface):
         es_key : str, default: "ElectricalSeries"
             The key of this ElectricalSeries in the metadata dictionary.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "sampling_frequency",
+                "num_channels",
+                "channel_ids",
+                "is_filtered",
+                "verbose",
+                "es_key",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to WhiteMatterRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            sampling_frequency = positional_values.get("sampling_frequency", sampling_frequency)
+            num_channels = positional_values.get("num_channels", num_channels)
+            channel_ids = positional_values.get("channel_ids", channel_ids)
+            is_filtered = positional_values.get("is_filtered", is_filtered)
+            verbose = positional_values.get("verbose", verbose)
+            es_key = positional_values.get("es_key", es_key)
+
         super().__init__(
             file_path=file_path,
             sampling_frequency=sampling_frequency,

--- a/src/neuroconv/datainterfaces/icephys/abf/abfdatainterface.py
+++ b/src/neuroconv/datainterfaces/icephys/abf/abfdatainterface.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from datetime import datetime, timedelta
 from pathlib import Path
 from warnings import warn
@@ -82,6 +83,7 @@ class AbfInterface(BaseIcephysInterface):
     def __init__(
         self,
         file_paths: list[FilePath],
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         icephys_metadata: dict | None = None,
         icephys_metadata_file_path: FilePath | None = None,
     ):
@@ -97,6 +99,33 @@ class AbfInterface(BaseIcephysInterface):
         icephys_metadata_file_path : FilePath, optional
             JSON file containing the Icephys-specific metadata.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "icephys_metadata",
+                "icephys_metadata_file_path",
+            ]
+            num_positional_args_before_args = 1  # file_paths
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to AbfInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            icephys_metadata = positional_values.get("icephys_metadata", icephys_metadata)
+            icephys_metadata_file_path = positional_values.get("icephys_metadata_file_path", icephys_metadata_file_path)
+
         super().__init__(file_paths=file_paths)
         self.source_data.update(
             icephys_metadata=icephys_metadata,

--- a/src/neuroconv/datainterfaces/image/imageinterface.py
+++ b/src/neuroconv/datainterfaces/image/imageinterface.py
@@ -158,6 +158,7 @@ class ImageInterface(BaseDataInterface):
         self,
         file_paths: list[str | Path] | None = None,
         folder_path: str | Path | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         images_location: Literal["acquisition", "stimulus"] = "acquisition",
         metadata_key: str = "Images",
         verbose: bool = True,
@@ -178,6 +179,35 @@ class ImageInterface(BaseDataInterface):
         verbose : bool, default: True
             Whether to print status messages
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "images_location",
+                "metadata_key",
+                "verbose",
+            ]
+            num_positional_args_before_args = 2  # file_paths, folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to ImageInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            images_location = positional_values.get("images_location", images_location)
+            metadata_key = positional_values.get("metadata_key", metadata_key)
+            verbose = positional_values.get("verbose", verbose)
+
         if file_paths is None and folder_path is None:
             raise ValueError("Either file_paths or folder_path must be provided")
 
@@ -302,6 +332,7 @@ class ImageInterface(BaseDataInterface):
         self,
         nwbfile: NWBFile,
         metadata: DeepDict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         container_name: str | None = None,
     ) -> None:
         """
@@ -318,6 +349,30 @@ class ImageInterface(BaseDataInterface):
             on or after February 2026. Use metadata_key in __init__ instead.
             If provided, it overrides the name from metadata.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "container_name",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to ImageInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            container_name = positional_values.get("container_name", container_name)
 
         if container_name is not None:
             warnings.warn(

--- a/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/baseimagingextractorinterface.py
@@ -169,7 +169,7 @@ class BaseImagingExtractorInterface(BaseExtractorInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
-        *args,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         photon_series_type: Literal["TwoPhotonSeries", "OnePhotonSeries"] = "TwoPhotonSeries",
         photon_series_index: int = 0,
         parent_container: Literal["acquisition", "processing/ophys"] = "acquisition",

--- a/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
@@ -151,7 +151,7 @@ class BaseSegmentationExtractorInterface(BaseExtractorInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
-        *args,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stub_test: bool = False,
         stub_frames: int | None = None,
         include_background_segmentation: bool = False,

--- a/src/neuroconv/datainterfaces/ophys/brukertiff/brukertiffdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/brukertiff/brukertiffdatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Literal
 
 from dateutil.parser import parse
@@ -72,6 +73,7 @@ class BrukerTiffMultiPlaneImagingInterface(BaseImagingExtractorInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stream_name: str | None = None,
         verbose: bool = False,
     ):
@@ -86,6 +88,33 @@ class BrukerTiffMultiPlaneImagingInterface(BaseImagingExtractorInterface):
             The name of the recording stream (e.g. 'Ch2').
         verbose : bool, default: False
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stream_name",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to BrukerTiffMultiPlaneImagingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stream_name = positional_values.get("stream_name", stream_name)
+            verbose = positional_values.get("verbose", verbose)
+
         self.folder_path = folder_path
         super().__init__(
             folder_path=folder_path,
@@ -265,6 +294,7 @@ class BrukerTiffSinglePlaneImagingInterface(BaseImagingExtractorInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stream_name: str | None = None,
         verbose: bool = False,
     ):
@@ -279,6 +309,33 @@ class BrukerTiffSinglePlaneImagingInterface(BaseImagingExtractorInterface):
             The name of the recording stream (e.g. 'Ch2').
         verbose : bool, default: False
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stream_name",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to BrukerTiffSinglePlaneImagingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stream_name = positional_values.get("stream_name", stream_name)
+            verbose = positional_values.get("verbose", verbose)
+
         super().__init__(
             folder_path=folder_path,
             stream_name=stream_name,

--- a/src/neuroconv/datainterfaces/ophys/caiman/caimandatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/caiman/caimandatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pydantic import FilePath
 
 from ..basesegmentationextractorinterface import BaseSegmentationExtractorInterface
@@ -31,7 +33,9 @@ class CaimanSegmentationInterface(BaseSegmentationExtractorInterface):
 
         return CaimanSegmentationExtractor
 
-    def __init__(self, file_path: FilePath, verbose: bool = False):
+    def __init__(
+        self, file_path: FilePath, *args, verbose: bool = False
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Parameters
         ----------
@@ -40,5 +44,30 @@ class CaimanSegmentationInterface(BaseSegmentationExtractorInterface):
         verbose : bool, default False
             Whether to print progress
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to CaimanSegmentationInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+
         super().__init__(file_path=file_path)
         self.verbose = verbose

--- a/src/neuroconv/datainterfaces/ophys/cnmfe/cnmfedatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/cnmfe/cnmfedatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pydantic import FilePath
 
 from ..basesegmentationextractorinterface import BaseSegmentationExtractorInterface
@@ -16,6 +18,33 @@ class CnmfeSegmentationInterface(BaseSegmentationExtractorInterface):
 
         return CnmfeSegmentationExtractor
 
-    def __init__(self, file_path: FilePath, verbose: bool = False):
+    def __init__(
+        self, file_path: FilePath, *args, verbose: bool = False
+    ):  # TODO: change to * (keyword only) on or after August 2026
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to CnmfeSegmentationInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+
         super().__init__(file_path=file_path)
         self.verbose = verbose

--- a/src/neuroconv/datainterfaces/ophys/extract/extractdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/extract/extractdatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pydantic import FilePath
 
 from ..basesegmentationextractorinterface import BaseSegmentationExtractorInterface
@@ -19,6 +21,7 @@ class ExtractSegmentationInterface(BaseSegmentationExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         sampling_frequency: float,
         output_struct_name: str | None = None,
         verbose: bool = False,
@@ -32,6 +35,35 @@ class ExtractSegmentationInterface(BaseSegmentationExtractorInterface):
         output_struct_name : str, optional
         verbose: bool, default : True
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "sampling_frequency",
+                "output_struct_name",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to ExtractSegmentationInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            sampling_frequency = positional_values.get("sampling_frequency", sampling_frequency)
+            output_struct_name = positional_values.get("output_struct_name", output_struct_name)
+            verbose = positional_values.get("verbose", verbose)
+
         self.verbose = verbose
         super().__init__(
             file_path=file_path,

--- a/src/neuroconv/datainterfaces/ophys/femtonics/femtonicsdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/femtonics/femtonicsdatainterface.py
@@ -1,5 +1,6 @@
 """Femtonics imaging interface for NeuroConv."""
 
+import warnings
 from typing import Optional
 
 from pydantic import FilePath
@@ -24,6 +25,7 @@ class FemtonicsImagingInterface(BaseImagingExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         session_name: Optional[str] = None,
         munit_name: Optional[str] = None,
         channel_name: Optional[str] = None,
@@ -60,6 +62,36 @@ class FemtonicsImagingInterface(BaseImagingExtractorInterface):
         verbose : bool, optional
             Whether to print verbose output. Default is False.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "session_name",
+                "munit_name",
+                "channel_name",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to FemtonicsImagingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            session_name = positional_values.get("session_name", session_name)
+            munit_name = positional_values.get("munit_name", munit_name)
+            channel_name = positional_values.get("channel_name", channel_name)
+            verbose = positional_values.get("verbose", verbose)
 
         # Store parameters for later use
         self._file_path = file_path

--- a/src/neuroconv/datainterfaces/ophys/hdf5/hdf5datainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/hdf5/hdf5datainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Literal
 
 from pydantic import FilePath
@@ -22,6 +23,7 @@ class Hdf5ImagingInterface(BaseImagingExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         mov_field: str = "mov",
         sampling_frequency: float | None = None,
         start_time: float | None = None,
@@ -43,6 +45,43 @@ class Hdf5ImagingInterface(BaseImagingExtractorInterface):
         channel_names : list of str, optional
         verbose : bool, default: False
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "mov_field",
+                "sampling_frequency",
+                "start_time",
+                "metadata",
+                "channel_names",
+                "verbose",
+                "photon_series_type",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to Hdf5ImagingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            mov_field = positional_values.get("mov_field", mov_field)
+            sampling_frequency = positional_values.get("sampling_frequency", sampling_frequency)
+            start_time = positional_values.get("start_time", start_time)
+            metadata = positional_values.get("metadata", metadata)
+            channel_names = positional_values.get("channel_names", channel_names)
+            verbose = positional_values.get("verbose", verbose)
+            photon_series_type = positional_values.get("photon_series_type", photon_series_type)
+
         super().__init__(
             file_path=file_path,
             mov_field=mov_field,

--- a/src/neuroconv/datainterfaces/ophys/inscopix/inscopixsegmentationdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/inscopix/inscopixsegmentationdatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pydantic import FilePath
 
 from ..basesegmentationextractorinterface import BaseSegmentationExtractorInterface
@@ -20,6 +22,7 @@ class InscopixSegmentationInterface(BaseSegmentationExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         verbose: bool = False,
     ):
         """
@@ -30,6 +33,31 @@ class InscopixSegmentationInterface(BaseSegmentationExtractorInterface):
         verbose : bool, optional
             If True, outputs additional information during processing.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to InscopixSegmentationInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+
         super().__init__(file_path=file_path, verbose=verbose)
 
     def get_metadata(self) -> DeepDict:

--- a/src/neuroconv/datainterfaces/ophys/micromanagertiff/micromanagertiffdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/micromanagertiff/micromanagertiffdatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from dateutil.parser import parse
 from pydantic import DirectoryPath, validate_call
 
@@ -35,7 +37,9 @@ class MicroManagerTiffImagingInterface(BaseImagingExtractorInterface):
         return MicroManagerTiffImagingExtractor
 
     @validate_call
-    def __init__(self, folder_path: DirectoryPath, verbose: bool = False):
+    def __init__(
+        self, folder_path: DirectoryPath, *args, verbose: bool = False
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Data Interface for MicroManagerTiffImagingExtractor.
 
@@ -46,6 +50,31 @@ class MicroManagerTiffImagingInterface(BaseImagingExtractorInterface):
            the 'DisplaySettings' JSON file.
         verbose : bool, default: False
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to MicroManagerTiffImagingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+
         super().__init__(folder_path=folder_path)
         self.verbose = verbose
         # Micro-Manager uses "Default" as channel name, for clarity we rename it to  'OpticalChannelDefault'

--- a/src/neuroconv/datainterfaces/ophys/minian/miniandatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/minian/miniandatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import deepcopy
 from typing import Optional
 
@@ -68,6 +69,7 @@ class MinianSegmentationInterface(BaseSegmentationExtractorInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         sampling_frequency: Optional[float] = None,
         timestamps_path: Optional[FilePath] = None,
         verbose: bool = False,
@@ -85,6 +87,35 @@ class MinianSegmentationInterface(BaseSegmentationExtractorInterface):
         verbose : bool, default False
             Whether to print progress
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "sampling_frequency",
+                "timestamps_path",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to MinianSegmentationInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            sampling_frequency = positional_values.get("sampling_frequency", sampling_frequency)
+            timestamps_path = positional_values.get("timestamps_path", timestamps_path)
+            verbose = positional_values.get("verbose", verbose)
+
         super().__init__(
             folder_path=folder_path, sampling_frequency=sampling_frequency, timestamps_path=timestamps_path
         )
@@ -100,6 +131,7 @@ class MinianSegmentationInterface(BaseSegmentationExtractorInterface):
         self,
         nwbfile: NWBFile,
         metadata: Optional[dict] = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stub_test: bool = False,
         stub_frames: int = 100,
         include_background_segmentation: bool = True,
@@ -109,6 +141,47 @@ class MinianSegmentationInterface(BaseSegmentationExtractorInterface):
         plane_segmentation_name: Optional[str] = None,
         iterator_options: Optional[dict] = None,
     ):
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stub_test",
+                "stub_frames",
+                "include_background_segmentation",
+                "include_roi_centroids",
+                "include_roi_acceptance",
+                "mask_type",
+                "plane_segmentation_name",
+                "iterator_options",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to MinianSegmentationInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stub_test = positional_values.get("stub_test", stub_test)
+            stub_frames = positional_values.get("stub_frames", stub_frames)
+            include_background_segmentation = positional_values.get(
+                "include_background_segmentation", include_background_segmentation
+            )
+            include_roi_centroids = positional_values.get("include_roi_centroids", include_roi_centroids)
+            include_roi_acceptance = positional_values.get("include_roi_acceptance", include_roi_acceptance)
+            mask_type = positional_values.get("mask_type", mask_type)
+            plane_segmentation_name = positional_values.get("plane_segmentation_name", plane_segmentation_name)
+            iterator_options = positional_values.get("iterator_options", iterator_options)
+
         super().add_to_nwbfile(
             nwbfile=nwbfile,
             metadata=metadata,

--- a/src/neuroconv/datainterfaces/ophys/miniscope/miniscopeimagingdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/miniscope/miniscopeimagingdatainterface.py
@@ -433,6 +433,7 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         photon_series_type: Literal["TwoPhotonSeries", "OnePhotonSeries"] = "OnePhotonSeries",
         **kwargs,
     ):
@@ -441,6 +442,33 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
 
         This method adds the Miniscope device and then delegates to the parent class.
         """
+        # Handle deprecated positional arguments
+        if args:
+            import warnings
+
+            parameter_names = [
+                "photon_series_type",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                "Passing arguments positionally to MiniscopeImagingInterface.add_to_nwbfile() is deprecated "
+                "and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            photon_series_type = positional_values.get("photon_series_type", photon_series_type)
+
         from ndx_miniscope.utils import add_miniscope_device
 
         # Add Miniscope device - required for proper ndx_miniscope.Miniscope device type

--- a/src/neuroconv/datainterfaces/ophys/miniscope/miniscopeimagingdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/miniscope/miniscopeimagingdatainterface.py
@@ -44,7 +44,9 @@ class _MiniscopeMultiRecordingInterface(BaseImagingExtractorInterface):
         return MiniscopeMultiRecordingImagingExtractor
 
     @validate_call
-    def __init__(self, folder_path: DirectoryPath, verbose: bool = False):
+    def __init__(
+        self, folder_path: DirectoryPath, *args, verbose: bool = False
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Initialize reading the Miniscope imaging data.
 
@@ -56,6 +58,31 @@ class _MiniscopeMultiRecordingInterface(BaseImagingExtractorInterface):
         verbose : bool, optional
             If True, enables verbose mode for detailed logging, by default False.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to _MiniscopeMultiRecordingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+
         from ndx_miniscope.utils import get_recording_start_times, read_miniscope_config
 
         miniscope_folder_paths = list(Path(folder_path).rglob("Miniscope"))
@@ -213,6 +240,7 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
     def __init__(
         self,
         folder_path: DirectoryPath = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         file_paths: list = None,
         configuration_file_path: str = None,
         timeStamps_file_path: str = None,
@@ -257,6 +285,37 @@ class MiniscopeImagingInterface(BaseImagingExtractorInterface):
         verbose : bool, optional
             If True, enables verbose mode for detailed logging, by default False.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "file_paths",
+                "configuration_file_path",
+                "timeStamps_file_path",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to MiniscopeImagingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            file_paths = positional_values.get("file_paths", file_paths)
+            configuration_file_path = positional_values.get("configuration_file_path", configuration_file_path)
+            timeStamps_file_path = positional_values.get("timeStamps_file_path", timeStamps_file_path)
+            verbose = positional_values.get("verbose", verbose)
+
         if folder_path is None and (file_paths is None or configuration_file_path is None):
             raise ValueError(
                 "Either 'folder_path' must be provided, or both 'file_paths' and 'configuration_file_path' must be provided."

--- a/src/neuroconv/datainterfaces/ophys/sbx/sbxdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/sbx/sbxdatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Literal
 
 from pydantic import FilePath, validate_call
@@ -23,6 +24,7 @@ class SbxImagingInterface(BaseImagingExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         sampling_frequency: float | None = None,
         verbose: bool = False,
         photon_series_type: Literal["OnePhotonSeries", "TwoPhotonSeries"] = "TwoPhotonSeries",
@@ -35,6 +37,34 @@ class SbxImagingInterface(BaseImagingExtractorInterface):
         sampling_frequency : float, optional
         verbose : bool, default: False
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "sampling_frequency",
+                "verbose",
+                "photon_series_type",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to SbxImagingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            sampling_frequency = positional_values.get("sampling_frequency", sampling_frequency)
+            verbose = positional_values.get("verbose", verbose)
+            photon_series_type = positional_values.get("photon_series_type", photon_series_type)
 
         super().__init__(
             file_path=file_path,

--- a/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterfaces.py
+++ b/src/neuroconv/datainterfaces/ophys/scanimage/scanimageimaginginterfaces.py
@@ -41,6 +41,7 @@ class ScanImageImagingInterface(BaseImagingExtractorInterface):
     def __init__(
         self,
         file_path: Optional[FilePath] = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         channel_name: Optional[str] = None,
         slice_sample: Optional[int] = None,
         plane_index: Optional[int] = None,
@@ -102,6 +103,47 @@ class ScanImageImagingInterface(BaseImagingExtractorInterface):
         verbose : bool, default: False
             If True, will print detailed information about the interface initialization process.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "channel_name",
+                "slice_sample",
+                "plane_index",
+                "file_paths",
+                "interleave_slice_samples",
+                "plane_name",
+                "fallback_sampling_frequency",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to ScanImageImagingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            channel_name = positional_values.get("channel_name", channel_name)
+            slice_sample = positional_values.get("slice_sample", slice_sample)
+            plane_index = positional_values.get("plane_index", plane_index)
+            file_paths = positional_values.get("file_paths", file_paths)
+            interleave_slice_samples = positional_values.get("interleave_slice_samples", interleave_slice_samples)
+            plane_name = positional_values.get("plane_name", plane_name)
+            fallback_sampling_frequency = positional_values.get(
+                "fallback_sampling_frequency", fallback_sampling_frequency
+            )
+            verbose = positional_values.get("verbose", verbose)
+
         file_paths = [Path(file_path)] if file_path else file_paths
         header_version = self.get_scanimage_version(file_path=file_paths[0])
         if header_version not in [3, 4, 5]:
@@ -426,6 +468,7 @@ class ScanImageLegacyImagingInterface(BaseImagingExtractorInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         fallback_sampling_frequency: float | None = None,
         verbose: bool = False,
     ):
@@ -441,6 +484,35 @@ class ScanImageLegacyImagingInterface(BaseImagingExtractorInterface):
             The sampling frequency can usually be extracted from the scanimage metadata in
             exif:ImageDescription:state.acq.frameRate. If not, use this.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "fallback_sampling_frequency",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to ScanImageLegacyImagingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            fallback_sampling_frequency = positional_values.get(
+                "fallback_sampling_frequency", fallback_sampling_frequency
+            )
+            verbose = positional_values.get("verbose", verbose)
+
         from roiextractors.extractors.tiffimagingextractors.scanimagetiff_utils import (
             extract_extra_metadata,
         )

--- a/src/neuroconv/datainterfaces/ophys/sima/simadatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/sima/simadatainterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pydantic import FilePath
 
 from ..basesegmentationextractorinterface import BaseSegmentationExtractorInterface
@@ -16,7 +18,9 @@ class SimaSegmentationInterface(BaseSegmentationExtractorInterface):
 
         return SimaSegmentationExtractor
 
-    def __init__(self, file_path: FilePath, sima_segmentation_label: str = "auto_ROIs"):
+    def __init__(
+        self, file_path: FilePath, *args, sima_segmentation_label: str = "auto_ROIs"
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
 
         Parameters
@@ -24,4 +28,29 @@ class SimaSegmentationInterface(BaseSegmentationExtractorInterface):
         file_path : FilePath
         sima_segmentation_label : str, default: "auto_ROIs"
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "sima_segmentation_label",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to SimaSegmentationInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            sima_segmentation_label = positional_values.get("sima_segmentation_label", sima_segmentation_label)
+
         super().__init__(file_path=file_path, sima_segmentation_label=sima_segmentation_label)

--- a/src/neuroconv/datainterfaces/ophys/suite2p/suite2pdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/suite2p/suite2pdatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import deepcopy
 
 from pydantic import DirectoryPath, validate_call
@@ -116,6 +117,7 @@ class Suite2pSegmentationInterface(BaseSegmentationExtractorInterface):
     def __init__(
         self,
         folder_path: DirectoryPath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         channel_name: str | None = None,
         plane_name: str | None = None,
         plane_segmentation_name: str | None = None,
@@ -137,6 +139,36 @@ class Suite2pSegmentationInterface(BaseSegmentationExtractorInterface):
         plane_segmentation_name: str, optional
             The name of the plane segmentation to be added.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "channel_name",
+                "plane_name",
+                "plane_segmentation_name",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to Suite2pSegmentationInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            channel_name = positional_values.get("channel_name", channel_name)
+            plane_name = positional_values.get("plane_name", plane_name)
+            plane_segmentation_name = positional_values.get("plane_segmentation_name", plane_segmentation_name)
+            verbose = positional_values.get("verbose", verbose)
 
         super().__init__(folder_path=folder_path, channel_name=channel_name, plane_name=plane_name)
         available_planes = self.get_available_planes(folder_path=self.source_data["folder_path"])
@@ -180,6 +212,7 @@ class Suite2pSegmentationInterface(BaseSegmentationExtractorInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stub_test: bool = False,
         stub_frames: int = 100,
         include_roi_centroids: bool = True,
@@ -222,6 +255,43 @@ class Suite2pSegmentationInterface(BaseSegmentationExtractorInterface):
         iterator_options : dict, optional
             Additional options for iterating over the data, by default None.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stub_test",
+                "stub_frames",
+                "include_roi_centroids",
+                "include_roi_acceptance",
+                "mask_type",
+                "plane_segmentation_name",
+                "iterator_options",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to Suite2pSegmentationInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stub_test = positional_values.get("stub_test", stub_test)
+            stub_frames = positional_values.get("stub_frames", stub_frames)
+            include_roi_centroids = positional_values.get("include_roi_centroids", include_roi_centroids)
+            include_roi_acceptance = positional_values.get("include_roi_acceptance", include_roi_acceptance)
+            mask_type = positional_values.get("mask_type", mask_type)
+            plane_segmentation_name = positional_values.get("plane_segmentation_name", plane_segmentation_name)
+            iterator_options = positional_values.get("iterator_options", iterator_options)
+
         super().add_to_nwbfile(
             nwbfile=nwbfile,
             metadata=metadata,

--- a/src/neuroconv/datainterfaces/ophys/tdt_fp/tdtfiberphotometrydatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/tdt_fp/tdtfiberphotometrydatainterface.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from contextlib import redirect_stdout
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -29,7 +30,9 @@ class TDTFiberPhotometryInterface(BaseTemporalAlignmentInterface):
     associated_suffixes = ("Tbk", "Tdx", "tev", "tin", "tsq")
 
     @validate_call
-    def __init__(self, folder_path: DirectoryPath, verbose: bool = False):
+    def __init__(
+        self, folder_path: DirectoryPath, *args, verbose: bool = False
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """Initialize the TDTFiberPhotometryInterface.
 
         Parameters
@@ -39,6 +42,31 @@ class TDTFiberPhotometryInterface(BaseTemporalAlignmentInterface):
         verbose : bool, optional
             Whether to print status messages, default = True.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # folder_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to TDTFiberPhotometryInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            verbose = positional_values.get("verbose", verbose)
+
         super().__init__(
             folder_path=folder_path,
             verbose=verbose,
@@ -274,7 +302,7 @@ class TDTFiberPhotometryInterface(BaseTemporalAlignmentInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict,
-        *,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         stub_test: bool = False,
         t1: float = 0.0,
         t2: float = 0.0,
@@ -303,6 +331,37 @@ class TDTFiberPhotometryInterface(BaseTemporalAlignmentInterface):
         AssertionError
             If the timing_source is not one of "original", "aligned_timestamps", or "aligned_starting_time_and_rate".
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "stub_test",
+                "t1",
+                "t2",
+                "timing_source",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to TDTFiberPhotometryInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            stub_test = positional_values.get("stub_test", stub_test)
+            t1 = positional_values.get("t1", t1)
+            t2 = positional_values.get("t2", t2)
+            timing_source = positional_values.get("timing_source", timing_source)
+
         from ndx_fiber_photometry import (
             CommandedVoltageSeries,
             FiberPhotometry,

--- a/src/neuroconv/datainterfaces/ophys/thor/thordatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/thor/thordatainterface.py
@@ -1,5 +1,6 @@
 """Interface for Thor TIFF files with OME metadata."""
 
+import warnings
 from datetime import datetime, timezone
 
 import numpy as np
@@ -42,7 +43,9 @@ class ThorImagingInterface(BaseImagingExtractorInterface):
         return source_schema
 
     @validate_call
-    def __init__(self, file_path: FilePath, channel_name: str | None = None, verbose: bool = False):
+    def __init__(
+        self, file_path: FilePath, *args, channel_name: str | None = None, verbose: bool = False
+    ):  # TODO: change to * (keyword only) on or after August 2026
         """
         Initialize reading of a TIFF file.
 
@@ -55,6 +58,32 @@ class ThorImagingInterface(BaseImagingExtractorInterface):
         verbose : bool, default: False
             If True, print verbose output
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "channel_name",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to ThorImagingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            channel_name = positional_values.get("channel_name", channel_name)
+            verbose = positional_values.get("verbose", verbose)
 
         super().__init__(file_path=file_path, channel_name=channel_name, verbose=verbose)
         self.channel_name = channel_name

--- a/src/neuroconv/datainterfaces/ophys/tiff/tiffdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/tiff/tiffdatainterface.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Literal, Optional
 
 from pydantic import FilePath, validate_call
@@ -47,7 +48,7 @@ class TiffImagingInterface(BaseImagingExtractorInterface):
         file_path: Optional[FilePath] = None,
         file_paths: Optional[list[FilePath]] = None,
         sampling_frequency: float = None,
-        *,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         dimension_order: str = "ZCT",
         num_channels: int = 1,
         channel_name: Optional[str] = None,
@@ -181,7 +182,40 @@ class TiffImagingInterface(BaseImagingExtractorInterface):
 
             All dimension orders → T: Simple planar time series (all orderings equivalent)
         """
-        import warnings
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "dimension_order",
+                "num_channels",
+                "channel_name",
+                "num_planes",
+                "verbose",
+                "photon_series_type",
+            ]
+            num_positional_args_before_args = 3  # file_path, file_paths, sampling_frequency
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to TiffImagingInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            dimension_order = positional_values.get("dimension_order", dimension_order)
+            num_channels = positional_values.get("num_channels", num_channels)
+            channel_name = positional_values.get("channel_name", channel_name)
+            num_planes = positional_values.get("num_planes", num_planes)
+            verbose = positional_values.get("verbose", verbose)
+            photon_series_type = positional_values.get("photon_series_type", photon_series_type)
 
         # Handle both file_path and file_paths
         if file_path is not None and file_paths is not None:

--- a/src/neuroconv/datainterfaces/text/excel/exceltimeintervalsinterface.py
+++ b/src/neuroconv/datainterfaces/text/excel/exceltimeintervalsinterface.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pandas as pd
 from pydantic import FilePath, validate_call
 
@@ -15,6 +17,7 @@ class ExcelTimeIntervalsInterface(TimeIntervalsInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         read_kwargs: dict | None = None,
         verbose: bool = False,
     ):
@@ -26,6 +29,33 @@ class ExcelTimeIntervalsInterface(TimeIntervalsInterface):
             Passed to pandas.read_excel()
         verbose : bool, default: False
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "read_kwargs",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to ExcelTimeIntervalsInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            read_kwargs = positional_values.get("read_kwargs", read_kwargs)
+            verbose = positional_values.get("verbose", verbose)
+
         super().__init__(file_path=file_path, read_kwargs=read_kwargs, verbose=verbose)
 
     def _read_file(self, file_path: FilePath, **read_kwargs):

--- a/src/neuroconv/datainterfaces/text/timeintervalsinterface.py
+++ b/src/neuroconv/datainterfaces/text/timeintervalsinterface.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import abstractmethod
 from pathlib import Path
 
@@ -19,6 +20,7 @@ class TimeIntervalsInterface(BaseDataInterface):
     def __init__(
         self,
         file_path: FilePath,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         read_kwargs: dict | None = None,
         verbose: bool = False,
     ):
@@ -38,6 +40,33 @@ class TimeIntervalsInterface(BaseDataInterface):
         verbose : bool, default: False
             Controls verbosity of the interface output.
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "read_kwargs",
+                "verbose",
+            ]
+            num_positional_args_before_args = 1  # file_path
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"__init__() takes at most {len(parameter_names) + num_positional_args_before_args + 1} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args + 1} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to TimeIntervalsInterface.__init__() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            read_kwargs = positional_values.get("read_kwargs", read_kwargs)
+            verbose = positional_values.get("verbose", verbose)
+
         read_kwargs = read_kwargs or dict()
         super().__init__(file_path=file_path)
         self.verbose = verbose
@@ -212,6 +241,7 @@ class TimeIntervalsInterface(BaseDataInterface):
         self,
         nwbfile: NWBFile,
         metadata: dict | None = None,
+        *args,  # TODO: change to * (keyword only) on or after August 2026
         tag: str = "trials",
         column_name_mapping: dict[str, str] = None,
         column_descriptions: dict[str, str] = None,
@@ -276,6 +306,34 @@ class TimeIntervalsInterface(BaseDataInterface):
         - The 'start_time' column is required; 'stop_time' is auto-generated if missing.
 
         """
+        # Handle deprecated positional arguments
+        if args:
+            parameter_names = [
+                "tag",
+                "column_name_mapping",
+                "column_descriptions",
+            ]
+            num_positional_args_before_args = 2  # nwbfile, metadata
+            if len(args) > len(parameter_names):
+                raise TypeError(
+                    f"add_to_nwbfile() takes at most {len(parameter_names) + num_positional_args_before_args} positional arguments but "
+                    f"{len(args) + num_positional_args_before_args} were given. "
+                    "Note: Positional arguments are deprecated and will be removed on or after August 2026. "
+                    "Please use keyword arguments."
+                )
+            positional_values = dict(zip(parameter_names, args))
+            passed_as_positional = list(positional_values.keys())
+            warnings.warn(
+                f"Passing arguments positionally to TimeIntervalsInterface.add_to_nwbfile() is deprecated "
+                f"and will be removed on or after August 2026. "
+                f"The following arguments were passed positionally: {passed_as_positional}. "
+                "Please use keyword arguments instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            tag = positional_values.get("tag", tag)
+            column_name_mapping = positional_values.get("column_name_mapping", column_name_mapping)
+            column_descriptions = positional_values.get("column_descriptions", column_descriptions)
         metadata = metadata or self.get_metadata()
         self.time_intervals = convert_df_to_time_intervals(
             self.dataframe,

--- a/tests/test_minimal/test_keyword_only_arguments.py
+++ b/tests/test_minimal/test_keyword_only_arguments.py
@@ -1,0 +1,41 @@
+"""Tests to enforce keyword-only argument conventions for add_to_nwbfile methods.
+
+These tests ensure that all interface add_to_nwbfile methods enforce keyword-only arguments
+after nwbfile and metadata. Only nwbfile and metadata should be positional.
+
+During the deprecation period (before August 2026), methods use *args with FutureWarning.
+After the deprecation period, methods should use bare * for keyword-only enforcement.
+
+See the developer style guide for details on the convention.
+"""
+
+import inspect
+
+import pytest
+
+from neuroconv.datainterfaces import interface_list
+
+
+@pytest.mark.parametrize(
+    "interface_class",
+    interface_list,
+    ids=lambda cls: cls.__name__,
+)
+def test_add_to_nwbfile_only_nwbfile_metadata_positional(interface_class):
+    """Only nwbfile and metadata should be positional in add_to_nwbfile."""
+    if "add_to_nwbfile" not in interface_class.__dict__:
+        pytest.skip(f"{interface_class.__name__} does not override add_to_nwbfile")
+
+    add_to_nwbfile_method = getattr(interface_class, "add_to_nwbfile")
+    sig = inspect.signature(add_to_nwbfile_method)
+
+    # No add_to_nwbfile uses POSITIONAL_ONLY (/), so POSITIONAL_OR_KEYWORD means "can be passed positionally"
+    can_be_passed_positionally = lambda param: param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+    positional_params = {name for name, param in sig.parameters.items() if can_be_passed_positionally(param)}
+
+    allowed_positional_params = {"self", "nwbfile", "metadata"}
+    assert positional_params == allowed_positional_params, (
+        f"{interface_class.__name__}.add_to_nwbfile() positional parameters are {positional_params}, "
+        f"expected {allowed_positional_params}. "
+        f"All other parameters should be keyword-only (use * or *args)."
+    )


### PR DESCRIPTION
Allows only nwbfile and metadata for `add_to_nwbfile`
Allows file_path, file_paths and folder_path for `__init__`

