### PR TITLE
Improve units table write performance with column-first strategy for new tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Features
 
 ## Improvements
+* Added column-first fast path for writing Units tables when the table is new (no append/merge). Uses `id.extend()` + `add_column()` instead of per-row `add_unit()` calls, reducing Python overhead for large sortings. [PR #1669](https://github.com/catalystneuro/neuroconv/pull/1669)
 
 # v0.9.3 (February 19, 2026)
 

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -2679,7 +2679,9 @@ def add_sorting_analyzer_to_nwbfile(
         recording, nwbfile=nwbfile, metadata=metadata, null_values_for_properties=null_values_for_properties
     )
     electrode_group_indices = _get_electrode_group_indices(recording, nwbfile=nwbfile)
-    unit_electrode_indices = [electrode_group_indices] * len(sorting.unit_ids)
+    unit_electrode_indices = (
+        [electrode_group_indices] * len(sorting.unit_ids) if electrode_group_indices is not None else None
+    )
 
     _add_units_table_to_nwbfile(
         sorting=sorting_copy,

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -1958,6 +1958,74 @@ def _add_units_table_to_nwbfile(
     module (for intermediate/historical data). It handles unit selection, property customization,
     waveform data, and electrode mapping.
 
+    Storage strategy
+    ----------------
+    Data that is not previously in the table is added as columns. Pre-existing columns
+    require rows to be appended. This means that on first write, everything is added as
+    columns. When appending to an existing table, rows are added first (for pre-existing
+    columns, using null values where data is missing), then new properties are added as
+    columns (which may require null values for previously existing rows).
+
+    **First write (new table):**
+    All data is added as columns. No row-by-row insertion needed.
+
+    ::
+
+        +-----------+-----------+-----------+
+        | col_A     | col_B     | col_C     |
+        |  (column) |  (column) |  (column) |
+        +===========+===========+===========+
+        |     .     |     .     |     .     |
+        |     .     |     .     |     .     |
+        |     .     |     .     |     .     |
+        +-----------+-----------+-----------+
+
+    **Second write (appending to existing table):**
+    Pre-existing columns need values for each new row, so rows are appended
+    via ``add_unit()``. Null values fill columns where data is missing. Then
+    new properties are added as columns, with null values backfilled for
+    previously existing rows.
+
+    ::
+
+        Existing table           data_to_add = {col_A, col_B, col_D}
+        has: col_A, col_B, col_C     col_C missing, col_D is new
+
+        Step 1: append rows for pre-existing columns
+        +-----------+-----------+-----------+
+        | col_A     | col_B     | col_C     |
+        +===========+===========+===========+
+        |  (old)    |  (old)    |  (old)    |   <- existing rows
+        |     .     |     .     |     .     |
+        +-----------+-----------+-----------+
+        |  (new)    |  (new)    |   null    |   <- new rows added
+        |     .     |     .     |   null    |      col_C has no data
+        +-----------+-----------+-----------+
+
+        Step 2: add new columns
+        +-----------+-----------+-----------+-----------+
+        | col_A     | col_B     | col_C     | col_D     |
+        +===========+===========+===========+===========+
+        |  (old)    |  (old)    |  (old)    |   null    |  <- old rows
+        |     .     |     .     |     .     |   null    |     col_D backfilled
+        +-----------+-----------+-----------+-----------+
+        |  (new)    |  (new)    |   null    |  (new)    |  <- new rows
+        |     .     |     .     |   null    |     .     |
+        +-----------+-----------+-----------+-----------+
+
+    In step 1, col_C is a pre-existing column whose data is not present in the new
+    sorting's units, so null values are used (see ``_get_null_value_for_property``
+    for how defaults are determined by data type). In step 2, col_D is a new property
+    only present in the new units, so previously existing rows are backfilled with
+    null values.
+
+    Deduplication is handled by ``unit_name``: units whose name already exists in
+    the table are skipped. When the table has an ``electrodes`` column and a unit's
+    electrode indices differ from the previously stored ones, the unit is re-added
+    as a new row (resulting in duplicate unit names with different electrode
+    mappings). See ``add_electrodes_to_nwbfile`` for how the electrode table itself
+    handles deduplication via ``(group_name, electrode_name, channel_name)``.
+
     Parameters
     ----------
     sorting : spikeinterface.BaseSorting
@@ -2092,62 +2160,59 @@ def _add_units_table_to_nwbfile(
         unit_name_array = unit_ids.astype("str", copy=False)
         data_to_add["unit_name"].update(description="Unique reference for each unit.", data=unit_name_array)
 
-    # Add rows: two strategies depending on whether the table is new or existing.
-    # Both branches populate the table with rows (ids + spike_times + waveforms + electrodes).
-    # Properties from data_to_add are added as columns afterwards in shared code below.
-    if write_table_first_time:
-        # Fast path: column-first bulk write for brand-new tables.
-        # Skip all append/merge logic (row filtering, null backfilling, electrode mismatch checks)
-        # and add rows via id.extend() + add_column() instead of per-row add_unit() calls.
-        num_units = sorting.get_num_units()
-        num_segments = sorting.get_num_segments()
+    # Precompute spike times for all units and add to data_to_add alongside waveforms and electrodes.
+    # This lets the shared column-adding loop below handle all data uniformly.
+    num_units = sorting.get_num_units()
+    num_segments = sorting.get_num_segments()
+    all_spike_times = []
+    for row_index in range(num_units):
+        spike_times = np.concatenate(
+            [
+                sorting.get_unit_spike_train(
+                    unit_id=unit_ids[row_index],
+                    segment_index=segment_index,
+                    return_times=True,
+                )
+                for segment_index in range(num_segments)
+            ]
+        )
+        all_spike_times.append(spike_times)
+    data_to_add["spike_times"].update(
+        description="the spike times for each unit in seconds",
+        data=all_spike_times,
+        index=True,
+    )
 
-        units_table.id.extend(list(range(num_units)))
-
-        all_spike_times = []
-        for row_index in range(num_units):
-            spike_times = np.concatenate(
-                [
-                    sorting.get_unit_spike_train(
-                        unit_id=unit_ids[row_index],
-                        segment_index=segment_index,
-                        return_times=True,
-                    )
-                    for segment_index in range(num_segments)
-                ]
+    if waveform_means is not None:
+        data_to_add["waveform_mean"].update(
+            description="the spike waveform mean for each spike unit",
+            data=waveform_means,
+            index=False,
+        )
+        if waveform_sds is not None:
+            data_to_add["waveform_sd"].update(
+                description="the spike waveform standard deviation for each spike unit",
+                data=waveform_sds,
+                index=False,
             )
-            all_spike_times.append(spike_times)
 
-        units_table.add_column(
-            name="spike_times",
-            description="the spike times for each unit in seconds",
-            data=all_spike_times,
+    if unit_electrode_indices is not None:
+        data_to_add["electrodes"].update(
+            description="the electrodes that each spike unit came from",
+            data=unit_electrode_indices,
             index=True,
+            table=nwbfile.electrodes,
         )
 
-        if waveform_means is not None:
-            units_table.add_column(
-                name="waveform_mean",
-                description="the spike waveform mean for each spike unit",
-                data=waveform_means,
-            )
-            if waveform_sds is not None:
-                units_table.add_column(
-                    name="waveform_sd",
-                    description="the spike waveform standard deviation for each spike unit",
-                    data=waveform_sds,
-                )
-
-        if unit_electrode_indices is not None:
-            units_table.add_column(
-                name="electrodes",
-                description="the electrodes that each spike unit came from",
-                data=unit_electrode_indices,
-                index=True,
-                table=nwbfile.electrodes,
-            )
+    # Establish rows in the table. The strategy depends on whether columns already exist:
+    # - New table: no existing columns, so we only add IDs here. All data (including
+    #   spike_times, waveforms, electrodes) is added as columns afterwards.
+    # - Existing table: HDMF's add_row() requires values for all existing columns,
+    #   so existing properties must be provided per row via add_unit().
+    #   New properties that don't yet exist as columns are added as columns afterwards.
+    if write_table_first_time:
+        units_table.id.extend(list(range(num_units)))
     else:
-        # General path: row-first append/merge for existing tables.
         units_table_previous_properties = set(units_table.colnames).difference({"spike_times"})
         properties_to_add = set(data_to_add)
         properties_to_add_by_rows = units_table_previous_properties.union({"id"})
@@ -2158,7 +2223,7 @@ def _add_units_table_to_nwbfile(
             unit_names_used_previously = units_table["unit_name"].data
         has_electrodes_column = "electrodes" in units_table.colnames
 
-        rows_in_data = [index for index in range(sorting.get_num_units())]
+        rows_in_data = [index for index in range(num_units)]
         if not has_electrodes_column:
             rows_to_add = [index for index in rows_in_data if unit_name_array[index] not in unit_names_used_previously]
         else:
@@ -2196,15 +2261,8 @@ def _add_units_table_to_nwbfile(
             unit_kwargs = null_values_for_row
             for property in properties_with_data:
                 unit_kwargs[property] = data_to_add[property]["data"][row]
-            spike_times = []
 
-            # Extract and concatenate the spike times from multiple segments
-            for segment_index in range(sorting.get_num_segments()):
-                segment_spike_times = sorting.get_unit_spike_train(
-                    unit_id=unit_ids[row], segment_index=segment_index, return_times=True
-                )
-                spike_times.append(segment_spike_times)
-            spike_times = np.concatenate(spike_times)
+            unit_kwargs["spike_times"] = all_spike_times[row]
             if waveform_means is not None:
                 unit_kwargs["waveform_mean"] = waveform_means[row]
                 if waveform_sds is not None:
@@ -2212,10 +2270,10 @@ def _add_units_table_to_nwbfile(
             if unit_electrode_indices is not None:
                 unit_kwargs["electrodes"] = unit_electrode_indices[row]
 
-            units_table.add_unit(spike_times=spike_times, **unit_kwargs, enforce_unique_id=True)
+            units_table.add_unit(**unit_kwargs, enforce_unique_id=True)
 
-    # Add remaining properties as columns (shared by both fast and general paths).
-    # Determine which properties from data_to_add still need to be added as new columns.
+    # Add properties as columns for any data not yet in the table.
+    # For new tables this is everything; for existing tables this is only new properties.
     existing_columns = set(units_table.colnames)
     properties_with_extracted_data = {key for key, value in data_to_add.items() if "data" in value}
     properties_to_add_by_columns = properties_with_extracted_data - existing_columns


### PR DESCRIPTION
Previously, when writing a units table for the first time, spike times, waveform means, waveform standard deviations, electrode mappings, and all sorting properties were inserted row-by-row via HDMF's `add_unit()`. This is slow because each `add_unit()` call internally flattens and copies ragged array data (like spike times) one row at a time, creating unnecessary intermediate Python objects and memory copies that accumulate for large tables. This was particularly problematic for the IBL conversion pipeline, where a single session could consume more than 32 GB of RAM. This PR changes the first-write path to establish all rows in bulk and then add data as columns, avoiding the per-row overhead entirely.

I profiled peak RSS during units table writing on two sessions with large spike counts (1,366 and 2,185 units across 2 probes). The larger session has 3.3 GiB of per-spike ragged data on disk (spike times, amplitudes, and depths). Before these optimizations, it hit ~29.5 GB RSS and was OOM-killed on a 32 GiB machine. After this and https://github.com/hdmf-dev/hdmf/pull/1403 the peak RSS dropped to 13.8 GiB, a reduction of over 50%. On the smaller session (918 MiB on disk), I saw a similar 49% reduction (7,242 MiB to 4,597 MiB). With `np.concatenate`, each ragged column now costs exactly 1x its raw data size instead of 4.5x.
