### PR TITLE
Add dict-based segmentation pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ## Features
 * Added dict-based metadata pipeline for imaging in `roiextractors.py`, supporting the new `MicroscopySeries`, `ImagingPlanes`, and `Devices` metadata format keyed by `metadata_key`. Old list-based functions are preserved (renamed with `_old_list_format` suffix) and dispatched automatically when `metadata_key` is not provided. [PR #1677](https://github.com/catalystneuro/neuroconv/pull/1677)
+* Added dict-based metadata pipeline for segmentation in `roiextractors.py` (`_add_plane_segmentation_to_nwbfile`, `_add_roi_response_traces_to_nwbfile`) with dual routing in `add_segmentation_to_nwbfile`. Masks are written in the extractor's native format and all traces go into a single `Fluorescence` container. [PR #1692](https://github.com/catalystneuro/neuroconv/pull/1692)
 
 ## Improvements
 * Added array-like protocol methods (`shape`, `ndim`, `__len__`, `__getitem__`) to all data chunk iterators (`SliceableDataChunkIterator`, `SpikeInterfaceRecordingDataChunkIterator`, `ImagingExtractorDataChunkIterator`, `VideoDataChunkIterator`). [PR #1673](https://github.com/catalystneuro/neuroconv/pull/1673)

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -56,8 +56,8 @@ def _is_dict_based_metadata(metadata: dict) -> bool:
     """Detect whether metadata uses the new dict-based format or old list-based format.
 
     Dict-based format has top-level 'Devices' key and/or plural dict-valued keys under 'Ophys'
-    ('ImagingPlanes', 'MicroscopySeries', 'PlaneSegmentations', 'RoiResponses',
-    'SegmentationImages'). List-based format has 'Device' (list) and 'ImagingPlane'
+    ('ImagingPlanes', 'MicroscopySeries', 'PlaneSegmentations', 'RoiResponses').
+    List-based format has 'Device' (list) and 'ImagingPlane'
     (list, singular) under 'Ophys'.
 
     Returns True for dict-based, False for list-based.
@@ -67,7 +67,7 @@ def _is_dict_based_metadata(metadata: dict) -> bool:
 
     ophys = metadata.get("Ophys", {})
 
-    dict_based_keys = {"ImagingPlanes", "MicroscopySeries", "PlaneSegmentations", "RoiResponses", "SegmentationImages"}
+    dict_based_keys = {"ImagingPlanes", "MicroscopySeries", "PlaneSegmentations", "RoiResponses"}
     if dict_based_keys & ophys.keys():
         return True
 

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -7,9 +7,13 @@ import psutil
 from pydantic import FilePath
 from pynwb import NWBFile
 from pynwb.ophys import (
+    Fluorescence,
+    ImageSegmentation,
     ImagingPlane,
     OnePhotonSeries,
     OpticalChannel,
+    PlaneSegmentation,
+    RoiResponseSeries,
     TwoPhotonSeries,
 )
 from roiextractors import (
@@ -25,6 +29,7 @@ from .roiextractors_pending_deprecation import (
     _add_segmentation_to_nwbfile_old_list_format,
     get_nwb_segmentation_metadata,
 )
+from ..hdmf import SliceableDataChunkIterator
 from ..nwb_helpers import (
     BACKEND_NWB_IO,
     HDF5BackendConfiguration,
@@ -126,6 +131,7 @@ def _get_ophys_metadata_placeholders():
         },
         "RoiResponses": {
             default_metadata_key: {
+                "plane_segmentation_metadata_key": default_metadata_key,
                 "raw": {
                     "name": "RoiResponseSeries",
                     "description": "Array of raw fluorescence traces.",
@@ -151,27 +157,10 @@ def _get_ophys_metadata_placeholders():
                     "description": "Array of baseline traces.",
                     "unit": "n.a.",
                 },
-                "background": {
-                    "name": "Background",
-                    "description": "Array of background traces.",
-                    "unit": "n.a.",
-                },
                 "dff": {
                     "name": "DfOverF",
                     "description": "Array of df/F traces.",
                     "unit": "n.a.",
-                },
-            },
-        },
-        "SegmentationImages": {
-            default_metadata_key: {
-                "correlation": {
-                    "name": "correlation",
-                    "description": "The correlation image.",
-                },
-                "mean": {
-                    "name": "mean",
-                    "description": "The mean image.",
                 },
             },
         },
@@ -233,6 +222,7 @@ def get_full_ophys_metadata():
         },
         "RoiResponses": {
             "my_segmentation": {
+                "plane_segmentation_metadata_key": "my_segmentation",
                 "raw": {
                     "name": "RoiResponseSeries",
                     "description": "Raw fluorescence traces",
@@ -252,18 +242,6 @@ def get_full_ophys_metadata():
                     "name": "DfOverF",
                     "description": "Delta F over F",
                     "unit": "n.a.",
-                },
-            },
-        },
-        "SegmentationImages": {
-            "my_segmentation": {
-                "correlation": {
-                    "name": "correlation_image",
-                    "description": "Correlation image from Suite2p",
-                },
-                "mean": {
-                    "name": "mean_image",
-                    "description": "Mean image from Suite2p",
                 },
             },
         },
@@ -469,6 +447,288 @@ def _add_photon_series_to_nwbfile(
     elif parent_container == "processing/ophys":
         ophys_module = get_module(nwbfile, name="ophys", description="contains optical physiology processed data")
         ophys_module.add(photon_series)
+
+    return nwbfile
+
+
+def _add_plane_segmentation_to_nwbfile(
+    *,
+    segmentation_extractor: SegmentationExtractor,
+    nwbfile: NWBFile,
+    metadata: dict,
+    metadata_key: str,
+) -> NWBFile:
+    """
+    Add a PlaneSegmentation to an NWBFile using dict-based metadata.
+
+    Masks are written in the extractor's native format (image, pixel, or voxel) as
+    determined by ``_roi_masks.mask_tpe``. All extractor properties (including
+    acceptance/rejection status and quality metrics) are written as columns on the
+    PlaneSegmentation table via the roiextractors property system.
+
+    Parameters
+    ----------
+    segmentation_extractor : SegmentationExtractor
+        The segmentation extractor to get the results from.
+    nwbfile : NWBFile
+        The NWB file to add the plane segmentation to.
+    metadata : dict
+        The full metadata dictionary with dict-based format.
+    metadata_key : str
+        The key in ``metadata["Ophys"]["PlaneSegmentations"]`` identifying the segmentation.
+
+    Returns
+    -------
+    NWBFile
+        The NWBFile with the added PlaneSegmentation.
+    """
+    plane_seg_metadata = metadata["Ophys"]["PlaneSegmentations"][metadata_key].copy()
+
+    # Resolve imaging plane
+    imaging_plane_metadata_key = plane_seg_metadata.pop("imaging_plane_metadata_key", None)
+    if imaging_plane_metadata_key is not None:
+        imaging_plane_metadata = metadata["Ophys"]["ImagingPlanes"][imaging_plane_metadata_key]
+    else:
+        default_metadata = _get_ophys_metadata_placeholders()
+        imaging_plane_metadata = default_metadata["Ophys"]["ImagingPlanes"]["default_metadata_key"]
+    imaging_plane = _add_imaging_plane_to_nwbfile(
+        nwbfile=nwbfile,
+        imaging_plane_metadata=imaging_plane_metadata,
+        metadata=metadata,
+    )
+
+    # Get or create ImageSegmentation container
+    ophys_module = get_module(nwbfile, "ophys", description="contains optical physiology processed data")
+    image_segmentation_name = "ImageSegmentation"
+    if image_segmentation_name in ophys_module.data_interfaces:
+        image_segmentation = ophys_module[image_segmentation_name]
+    else:
+        image_segmentation = ImageSegmentation(name=image_segmentation_name)
+        ophys_module.add(image_segmentation)
+
+    plane_segmentation_name = plane_seg_metadata["name"]
+
+    # If PlaneSegmentation already exists, return early
+    if plane_segmentation_name in image_segmentation.plane_segmentations:
+        return nwbfile
+
+    # Extract ROI data
+    roi_ids = segmentation_extractor.get_roi_ids()
+
+    # Detect native mask format from the extractor
+    # TODO: open a discussion on roiextractors to expose mask_tpe as a public API
+    native_mask_type = segmentation_extractor._roi_masks.mask_tpe  # e.g. "nwb-image_mask"
+    mask_type = native_mask_type.replace("nwb-", "").replace("_mask", "")  # "image", "pixel", or "voxel"
+
+    if mask_type == "image":
+        image_or_pixel_masks = segmentation_extractor.get_roi_image_masks()
+    else:
+        image_or_pixel_masks = segmentation_extractor.get_roi_pixel_masks()
+
+    # Build PlaneSegmentation object
+    plane_seg_metadata["imaging_plane"] = imaging_plane
+    plane_segmentation = PlaneSegmentation(**plane_seg_metadata)
+
+    # Add ROIs
+    roi_names = [str(roi_id) for roi_id in roi_ids]
+    roi_indices = list(range(len(roi_ids)))
+    plane_segmentation.add_column(name="roi_name", description="The unique identifier for each ROI.")
+
+    if mask_type == "image":
+        image_mask_array = image_or_pixel_masks.T
+        for roi_index, roi_name in zip(roi_indices, roi_names):
+            image_mask = image_mask_array[roi_index]
+            plane_segmentation.add_roi(id=roi_index, roi_name=roi_name, image_mask=image_mask)
+    else:
+        mask_type_kwarg = f"{mask_type}_mask"
+        pixel_masks = image_or_pixel_masks
+        for roi_index, roi_name in zip(roi_indices, roi_names):
+            pixel_mask = pixel_masks[roi_index]
+            pixel_mask_to_write = [tuple(x) for x in pixel_mask]
+            plane_segmentation.add_roi(id=roi_index, roi_name=roi_name, **{mask_type_kwarg: pixel_mask_to_write})
+
+    # Add all extractor properties as columns (acceptance, quality metrics, etc.)
+    available_properties = segmentation_extractor.get_property_keys()
+    for property_key in available_properties:
+        values = segmentation_extractor.get_property(key=property_key, ids=roi_ids)
+        plane_segmentation.add_column(name=property_key, description="", data=values)
+
+    image_segmentation.add_plane_segmentation(plane_segmentations=[plane_segmentation])
+
+    return nwbfile
+
+
+def _add_roi_response_traces_to_nwbfile(
+    *,
+    segmentation_extractor: SegmentationExtractor,
+    nwbfile: NWBFile,
+    metadata: dict,
+    metadata_key: str,
+    iterator_options: dict | None = None,
+) -> NWBFile:
+    """
+    Add ROI response traces to an NWBFile using dict-based metadata.
+
+    Adds all traces as ``RoiResponseSeries`` inside a single ``Fluorescence`` container,
+    without splitting into ``Fluorescence`` and ``DfOverF``. This follows the direction
+    of nwb-schema#616 and ndx-microscopy's single-container pattern
+    (``MicroscopyResponseSeriesContainer``).
+
+    Resolves the PlaneSegmentation via ``plane_segmentation_metadata_key`` in the
+    RoiResponses metadata entry.
+
+    Parameters
+    ----------
+    segmentation_extractor : SegmentationExtractor
+        The segmentation extractor containing trace data.
+    nwbfile : NWBFile
+        The NWB file to add traces to.
+    metadata : dict
+        The full metadata dictionary with dict-based format.
+    metadata_key : str
+        The key in ``metadata["Ophys"]["RoiResponses"]``. The entry must contain a
+        ``plane_segmentation_metadata_key`` field that references the PlaneSegmentation
+        in ``metadata["Ophys"]["PlaneSegmentations"]``.
+    iterator_options : dict, optional
+        Options for the data chunk iterator.
+
+    Returns
+    -------
+    NWBFile
+        The NWBFile with the added traces.
+    """
+    iterator_options = iterator_options or dict()
+
+    roi_responses_metadata = metadata["Ophys"]["RoiResponses"][metadata_key].copy()
+
+    # Get traces from extractor, filter None/empty
+    traces_dict = segmentation_extractor.get_traces_dict()
+    traces_to_add = {
+        trace_name: trace for trace_name, trace in traces_dict.items() if trace is not None and trace.size != 0
+    }
+
+    if not traces_to_add:
+        return nwbfile
+
+    # Resolve PlaneSegmentation via explicit reference
+    plane_segmentation_metadata_key = roi_responses_metadata.pop("plane_segmentation_metadata_key")
+    plane_segmentation_name = metadata["Ophys"]["PlaneSegmentations"][plane_segmentation_metadata_key]["name"]
+    ophys_module = get_module(nwbfile, "ophys", description="contains optical physiology processed data")
+    image_segmentation = ophys_module["ImageSegmentation"]
+    plane_segmentation = image_segmentation.plane_segmentations[plane_segmentation_name]
+
+    # Create ROI table region
+    roi_ids = segmentation_extractor.get_roi_ids()
+    available_roi_names = list(plane_segmentation["roi_name"][:])
+    roi_names = [str(roi_id) for roi_id in roi_ids]
+    region = [available_roi_names.index(roi_name) for roi_name in roi_names]
+    imaging_plane_name = plane_segmentation.imaging_plane.name
+    roi_table_region = plane_segmentation.create_roi_table_region(
+        region=region,
+        description=f"The ROIs for {imaging_plane_name}.",
+    )
+
+    # Resolve timestamps
+    timestamps_were_set = segmentation_extractor.has_time_vector()
+    if timestamps_were_set:
+        timestamps = segmentation_extractor.get_timestamps()
+    else:
+        timestamps = segmentation_extractor.get_native_timestamps()
+
+    timestamps_are_available = timestamps is not None
+
+    if timestamps_are_available:
+        rate = calculate_regular_series_rate(series=timestamps)
+        timestamps_are_regular = rate is not None
+        starting_time = timestamps[0]
+    else:
+        rate = float(segmentation_extractor.get_sampling_frequency())
+        timestamps_are_regular = True
+        starting_time = 0.0
+
+    # All traces go into a single Fluorescence container, matching the pattern from
+    # ndx-microscopy (single MicroscopyResponseSeriesContainer) and avoiding the
+    # Fluorescence/DfOverF split that nwb-schema#616 proposes to remove.
+    fluorescence_name = "Fluorescence"
+    if fluorescence_name in ophys_module.data_interfaces:
+        fluorescence = ophys_module[fluorescence_name]
+    else:
+        fluorescence = Fluorescence(name=fluorescence_name)
+        ophys_module.add(fluorescence)
+
+    for trace_name, trace_data in traces_to_add.items():
+        # Skip traces not in metadata
+        if trace_name not in roi_responses_metadata:
+            continue
+
+        trace_metadata = roi_responses_metadata[trace_name]
+
+        # Skip if series already exists
+        series_name = trace_metadata["name"]
+        if series_name in fluorescence.roi_response_series:
+            continue
+
+        roi_response_series_kwargs = trace_metadata.copy()
+        roi_response_series_kwargs["data"] = SliceableDataChunkIterator(trace_data, **iterator_options)
+        roi_response_series_kwargs["rois"] = roi_table_region
+
+        if timestamps_are_regular:
+            roi_response_series_kwargs["starting_time"] = starting_time
+            roi_response_series_kwargs["rate"] = rate
+        else:
+            roi_response_series_kwargs["timestamps"] = timestamps
+
+        roi_response_series = RoiResponseSeries(**roi_response_series_kwargs)
+        fluorescence.add_roi_response_series(roi_response_series)
+
+    return nwbfile
+
+
+def _add_segmentation_to_nwbfile(
+    *,
+    segmentation_extractor: SegmentationExtractor,
+    nwbfile: NWBFile,
+    metadata: dict,
+    metadata_key: str,
+    iterator_options: dict | None = None,
+) -> NWBFile:
+    """
+    Add segmentation data to an NWBFile using dict-based metadata.
+
+    Orchestrates adding the PlaneSegmentation and ROI response traces.
+
+    Parameters
+    ----------
+    segmentation_extractor : SegmentationExtractor
+        The segmentation extractor containing all segmentation data.
+    nwbfile : NWBFile
+        The NWB file to add segmentation data to.
+    metadata : dict
+        The full metadata dictionary with dict-based format.
+    metadata_key : str
+        The key used across ``PlaneSegmentations`` and ``RoiResponses``.
+    iterator_options : dict, optional
+        Options for the data chunk iterator.
+
+    Returns
+    -------
+    NWBFile
+        The NWBFile with the added segmentation data.
+    """
+    _add_plane_segmentation_to_nwbfile(
+        segmentation_extractor=segmentation_extractor,
+        nwbfile=nwbfile,
+        metadata=metadata,
+        metadata_key=metadata_key,
+    )
+
+    _add_roi_response_traces_to_nwbfile(
+        segmentation_extractor=segmentation_extractor,
+        nwbfile=nwbfile,
+        metadata=metadata,
+        metadata_key=metadata_key,
+        iterator_options=iterator_options,
+    )
 
     return nwbfile
 
@@ -857,9 +1117,13 @@ def add_segmentation_to_nwbfile(
     include_roi_acceptance: bool = True,
     mask_type: Literal["image", "pixel", "voxel"] = "image",
     iterator_options: dict | None = None,
+    # TODO: move metadata_key after metadata once positional args removed (September 2026)
+    metadata_key: str | None = None,
 ) -> NWBFile:
     """
     Add segmentation data from a SegmentationExtractor object to an NWBFile.
+
+    Supports both old list-based metadata and new dict-based metadata (via ``metadata_key``).
 
     Parameters
     ----------
@@ -871,10 +1135,13 @@ def add_segmentation_to_nwbfile(
         Metadata for the NWBFile, by default None.
     plane_segmentation_name : str, optional
         The name of the PlaneSegmentation object to be added, by default None.
+        Used with the old list-based metadata format.
     background_plane_segmentation_name : str, optional
         The name of the background PlaneSegmentation, if any, by default None.
+        Used with the old list-based metadata format.
     include_background_segmentation : bool, optional
         If True, includes background plane segmentation, by default False.
+        Used with the old list-based metadata format.
     include_roi_centroids : bool, optional
         If True, includes the centroids of the regions of interest (ROIs), by default True.
     include_roi_acceptance : bool, optional
@@ -883,6 +1150,9 @@ def add_segmentation_to_nwbfile(
         Type of mask to use for segmentation; can be either "image" or "pixel", by default "image".
     iterator_options : dict, optional
         Options for iterating over the data, by default None.
+    metadata_key : str, optional
+        The key in ``metadata["Ophys"]["PlaneSegmentations"]`` identifying the segmentation.
+        When provided, uses the new dict-based metadata format.
 
     Returns
     -------
@@ -929,18 +1199,31 @@ def add_segmentation_to_nwbfile(
         mask_type = positional_values.get("mask_type", mask_type)
         iterator_options = positional_values.get("iterator_options", iterator_options)
 
-    nwbfile = _add_segmentation_to_nwbfile_old_list_format(
-        segmentation_extractor=segmentation_extractor,
-        nwbfile=nwbfile,
-        metadata=metadata,
-        plane_segmentation_name=plane_segmentation_name,
-        background_plane_segmentation_name=background_plane_segmentation_name,
-        include_background_segmentation=include_background_segmentation,
-        include_roi_centroids=include_roi_centroids,
-        include_roi_acceptance=include_roi_acceptance,
-        mask_type=mask_type,
-        iterator_options=iterator_options,
-    )
+    if metadata is None:
+        metadata = _get_ophys_metadata_placeholders()
+
+    if _is_dict_based_metadata(metadata):
+        metadata_key = metadata_key or "default_metadata_key"
+        nwbfile = _add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            metadata_key=metadata_key,
+            iterator_options=iterator_options,
+        )
+    else:
+        nwbfile = _add_segmentation_to_nwbfile_old_list_format(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            plane_segmentation_name=plane_segmentation_name,
+            background_plane_segmentation_name=background_plane_segmentation_name,
+            include_background_segmentation=include_background_segmentation,
+            include_roi_centroids=include_roi_centroids,
+            include_roi_acceptance=include_roi_acceptance,
+            mask_type=mask_type,
+            iterator_options=iterator_options,
+        )
 
     return nwbfile
 

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -134,32 +134,26 @@ def _get_ophys_metadata_placeholders():
                 "plane_segmentation_metadata_key": default_metadata_key,
                 "raw": {
                     "name": "RoiResponseSeries",
-                    "description": "Array of raw fluorescence traces.",
                     "unit": "n.a.",
                 },
                 "deconvolved": {
                     "name": "Deconvolved",
-                    "description": "Array of deconvolved traces.",
                     "unit": "n.a.",
                 },
                 "neuropil": {
                     "name": "Neuropil",
-                    "description": "Array of neuropil traces.",
                     "unit": "n.a.",
                 },
                 "denoised": {
                     "name": "Denoised",
-                    "description": "Array of denoised traces.",
                     "unit": "n.a.",
                 },
                 "baseline": {
                     "name": "Baseline",
-                    "description": "Array of baseline traces.",
                     "unit": "n.a.",
                 },
                 "dff": {
                     "name": "DfOverF",
-                    "description": "Array of df/F traces.",
                     "unit": "n.a.",
                 },
             },
@@ -183,7 +177,6 @@ def get_full_ophys_metadata():
         "my_microscope": {
             "name": "Microscope",
             "description": "Two-photon microscope",
-            "manufacturer": "Thorlabs",
         },
     }
 
@@ -483,6 +476,18 @@ def _add_plane_segmentation_to_nwbfile(
         The NWBFile with the added PlaneSegmentation.
     """
     plane_seg_metadata = metadata["Ophys"]["PlaneSegmentations"][metadata_key].copy()
+
+    # Validate required fields
+    required_fields = ["description"]
+    missing_fields = [field for field in required_fields if field not in plane_seg_metadata]
+    if missing_fields:
+        default_plane_seg = _get_ophys_metadata_placeholders()["Ophys"]["PlaneSegmentations"]["default_metadata_key"]
+        placeholder_hint = "\n".join(f"  {field}: {default_plane_seg[field]!r}" for field in missing_fields)
+        raise ValueError(
+            f"Plane segmentation metadata is missing required fields.\n"
+            f"For a complete NWB file, the following fields should be provided. "
+            f"If missing, a placeholder can be used instead:\n{placeholder_hint}"
+        )
 
     # Resolve imaging plane
     imaging_plane_metadata_key = plane_seg_metadata.pop("imaging_plane_metadata_key", None)

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -50,9 +50,10 @@ from ...utils.str_utils import human_readable_size
 def _is_dict_based_metadata(metadata: dict) -> bool:
     """Detect whether metadata uses the new dict-based format or old list-based format.
 
-    Dict-based format has top-level 'Devices' key and/or 'ImagingPlanes'/'MicroscopySeries'
-    (plural, dict-valued) under 'Ophys'. List-based format has 'Device' (list) and
-    'ImagingPlane' (list, singular) under 'Ophys'.
+    Dict-based format has top-level 'Devices' key and/or plural dict-valued keys under 'Ophys'
+    ('ImagingPlanes', 'MicroscopySeries', 'PlaneSegmentations', 'RoiResponses',
+    'SegmentationImages'). List-based format has 'Device' (list) and 'ImagingPlane'
+    (list, singular) under 'Ophys'.
 
     Returns True for dict-based, False for list-based.
     """
@@ -61,7 +62,8 @@ def _is_dict_based_metadata(metadata: dict) -> bool:
 
     ophys = metadata.get("Ophys", {})
 
-    if "ImagingPlanes" in ophys or "MicroscopySeries" in ophys:
+    dict_based_keys = {"ImagingPlanes", "MicroscopySeries", "PlaneSegmentations", "RoiResponses", "SegmentationImages"}
+    if dict_based_keys & ophys.keys():
         return True
 
     if "ImagingPlane" in ophys or "Device" in ophys:
@@ -115,6 +117,64 @@ def _get_ophys_metadata_placeholders():
                 "imaging_plane_metadata_key": default_metadata_key,
             },
         },
+        "PlaneSegmentations": {
+            default_metadata_key: {
+                "name": "PlaneSegmentation",
+                "description": "Segmented ROIs",
+                "imaging_plane_metadata_key": default_metadata_key,
+            },
+        },
+        "RoiResponses": {
+            default_metadata_key: {
+                "raw": {
+                    "name": "RoiResponseSeries",
+                    "description": "Array of raw fluorescence traces.",
+                    "unit": "n.a.",
+                },
+                "deconvolved": {
+                    "name": "Deconvolved",
+                    "description": "Array of deconvolved traces.",
+                    "unit": "n.a.",
+                },
+                "neuropil": {
+                    "name": "Neuropil",
+                    "description": "Array of neuropil traces.",
+                    "unit": "n.a.",
+                },
+                "denoised": {
+                    "name": "Denoised",
+                    "description": "Array of denoised traces.",
+                    "unit": "n.a.",
+                },
+                "baseline": {
+                    "name": "Baseline",
+                    "description": "Array of baseline traces.",
+                    "unit": "n.a.",
+                },
+                "background": {
+                    "name": "Background",
+                    "description": "Array of background traces.",
+                    "unit": "n.a.",
+                },
+                "dff": {
+                    "name": "DfOverF",
+                    "description": "Array of df/F traces.",
+                    "unit": "n.a.",
+                },
+            },
+        },
+        "SegmentationImages": {
+            default_metadata_key: {
+                "correlation": {
+                    "name": "correlation",
+                    "description": "The correlation image.",
+                },
+                "mean": {
+                    "name": "mean",
+                    "description": "The mean image.",
+                },
+            },
+        },
     }
 
     return metadata
@@ -127,8 +187,6 @@ def get_full_ophys_metadata():
     Users can call this to get a complete example of what the metadata structure looks like,
     edit only the fields they need, and discard the rest. Each call returns an independent
     copy so callers can modify it freely without affecting other calls.
-
-    # TODO: expand with segmentation metadata once we get to that PR
     """
     metadata = get_default_nwbfile_metadata()
 
@@ -164,6 +222,49 @@ def get_full_ophys_metadata():
                 "description": "Two-photon calcium imaging",
                 "unit": "n.a.",
                 "imaging_plane_metadata_key": "my_plane",
+            },
+        },
+        "PlaneSegmentations": {
+            "my_segmentation": {
+                "name": "PlaneSegmentation",
+                "description": "ROIs detected by Suite2p",
+                "imaging_plane_metadata_key": "my_plane",
+            },
+        },
+        "RoiResponses": {
+            "my_segmentation": {
+                "raw": {
+                    "name": "RoiResponseSeries",
+                    "description": "Raw fluorescence traces",
+                    "unit": "n.a.",
+                },
+                "neuropil": {
+                    "name": "Neuropil",
+                    "description": "Neuropil fluorescence",
+                    "unit": "n.a.",
+                },
+                "deconvolved": {
+                    "name": "Deconvolved",
+                    "description": "Deconvolved activity",
+                    "unit": "n.a.",
+                },
+                "dff": {
+                    "name": "DfOverF",
+                    "description": "Delta F over F",
+                    "unit": "n.a.",
+                },
+            },
+        },
+        "SegmentationImages": {
+            "my_segmentation": {
+                "correlation": {
+                    "name": "correlation_image",
+                    "description": "Correlation image from Suite2p",
+                },
+                "mean": {
+                    "name": "mean_image",
+                    "description": "Mean image from Suite2p",
+                },
             },
         },
     }

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -722,13 +722,15 @@ def _add_segmentation_to_nwbfile(
         metadata_key=metadata_key,
     )
 
-    _add_roi_response_traces_to_nwbfile(
-        segmentation_extractor=segmentation_extractor,
-        nwbfile=nwbfile,
-        metadata=metadata,
-        metadata_key=metadata_key,
-        iterator_options=iterator_options,
-    )
+    roi_responses = metadata.get("Ophys", {}).get("RoiResponses", {})
+    if metadata_key in roi_responses:
+        _add_roi_response_traces_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            metadata_key=metadata_key,
+            iterator_options=iterator_options,
+        )
 
     return nwbfile
 

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -668,6 +668,21 @@ def _add_roi_response_traces_to_nwbfile(
 
         trace_metadata = roi_responses_metadata[trace_name]
 
+        # Validate required fields
+        required_fields = ["unit"]
+        missing_fields = [field for field in required_fields if field not in trace_metadata]
+        if missing_fields:
+            default_roi_responses = _get_ophys_metadata_placeholders()["Ophys"]["RoiResponses"]["default_metadata_key"]
+            default_trace = default_roi_responses.get(
+                trace_name, next(v for v in default_roi_responses.values() if isinstance(v, dict))
+            )
+            placeholder_hint = "\n".join(f"  {field}: {default_trace[field]!r}" for field in missing_fields)
+            raise ValueError(
+                f"ROI response series '{trace_name}' metadata is missing required fields.\n"
+                f"For a complete NWB file, the following fields should be provided. "
+                f"If missing, a placeholder can be used instead:\n{placeholder_hint}"
+            )
+
         # Skip if series already exists
         series_name = trace_metadata["name"]
         if series_name in fluorescence.roi_response_series:

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -131,7 +131,6 @@ def _get_ophys_metadata_placeholders():
         },
         "RoiResponses": {
             default_metadata_key: {
-                "plane_segmentation_metadata_key": default_metadata_key,
                 "raw": {
                     "name": "RoiResponseSeries",
                     "unit": "n.a.",
@@ -215,7 +214,6 @@ def get_full_ophys_metadata():
         },
         "RoiResponses": {
             "my_segmentation": {
-                "plane_segmentation_metadata_key": "my_segmentation",
                 "raw": {
                     "name": "RoiResponseSeries",
                     "description": "Raw fluorescence traces",
@@ -579,8 +577,12 @@ def _add_roi_response_traces_to_nwbfile(
     of nwb-schema#616 and ndx-microscopy's single-container pattern
     (``MicroscopyResponseSeriesContainer``).
 
-    Resolves the PlaneSegmentation via ``plane_segmentation_metadata_key`` in the
-    RoiResponses metadata entry.
+    The same ``metadata_key`` is used to look up both the ``RoiResponses`` entry and the
+    ``PlaneSegmentations`` entry, coupling the two implicitly.
+
+    If ``metadata_key`` is not present in ``metadata["Ophys"]["RoiResponses"]``, placeholder
+    metadata is used for all available traces. If ``metadata_key`` is present but the extractor
+    has no trace data, a ``ValueError`` is raised.
 
     Parameters
     ----------
@@ -589,11 +591,10 @@ def _add_roi_response_traces_to_nwbfile(
     nwbfile : NWBFile
         The NWB file to add traces to.
     metadata : dict
-        The full metadata dictionary with dict-based format.
+        The full metadata dictionary with dict-based format. Not modified by this function.
     metadata_key : str
-        The key in ``metadata["Ophys"]["RoiResponses"]``. The entry must contain a
-        ``plane_segmentation_metadata_key`` field that references the PlaneSegmentation
-        in ``metadata["Ophys"]["PlaneSegmentations"]``.
+        The key used to look up both ``metadata["Ophys"]["RoiResponses"]`` and
+        ``metadata["Ophys"]["PlaneSegmentations"]``.
     iterator_options : dict, optional
         Options for the data chunk iterator.
 
@@ -604,20 +605,29 @@ def _add_roi_response_traces_to_nwbfile(
     """
     iterator_options = iterator_options or dict()
 
-    roi_responses_metadata = metadata["Ophys"]["RoiResponses"][metadata_key].copy()
-
     # Get traces from extractor, filter None/empty
     traces_dict = segmentation_extractor.get_traces_dict()
     traces_to_add = {
         trace_name: trace for trace_name, trace in traces_dict.items() if trace is not None and trace.size != 0
     }
 
+    roi_responses = metadata.get("Ophys", {}).get("RoiResponses", {})
+    user_provided_roi_responses = metadata_key in roi_responses
+
+    if user_provided_roi_responses and not traces_to_add:
+        raise ValueError("RoiResponses metadata was provided but the segmentation extractor has no trace data.")
+
     if not traces_to_add:
         return nwbfile
 
-    # Resolve PlaneSegmentation via explicit reference
-    plane_segmentation_metadata_key = roi_responses_metadata.pop("plane_segmentation_metadata_key")
-    plane_segmentation_name = metadata["Ophys"]["PlaneSegmentations"][plane_segmentation_metadata_key]["name"]
+    # Use user-provided metadata or fall back to placeholders
+    if user_provided_roi_responses:
+        roi_responses_metadata = roi_responses[metadata_key].copy()
+    else:
+        roi_responses_metadata = _get_ophys_metadata_placeholders()["Ophys"]["RoiResponses"]["default_metadata_key"]
+
+    # Resolve PlaneSegmentation via the same metadata_key
+    plane_segmentation_name = metadata["Ophys"]["PlaneSegmentations"][metadata_key]["name"]
     ophys_module = get_module(nwbfile, "ophys", description="contains optical physiology processed data")
     image_segmentation = ophys_module["ImageSegmentation"]
     plane_segmentation = image_segmentation.plane_segmentations[plane_segmentation_name]
@@ -742,15 +752,13 @@ def _add_segmentation_to_nwbfile(
         metadata_key=metadata_key,
     )
 
-    roi_responses = metadata.get("Ophys", {}).get("RoiResponses", {})
-    if metadata_key in roi_responses:
-        _add_roi_response_traces_to_nwbfile(
-            segmentation_extractor=segmentation_extractor,
-            nwbfile=nwbfile,
-            metadata=metadata,
-            metadata_key=metadata_key,
-            iterator_options=iterator_options,
-        )
+    _add_roi_response_traces_to_nwbfile(
+        segmentation_extractor=segmentation_extractor,
+        nwbfile=nwbfile,
+        metadata=metadata,
+        metadata_key=metadata_key,
+        iterator_options=iterator_options,
+    )
 
     return nwbfile
 

--- a/tests/test_modalities/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_modalities/test_ophys/test_tools_roiextractors.py
@@ -2927,6 +2927,64 @@ class TestAddSegmentation:
         default_plane_name = default_metadata["Ophys"]["ImagingPlanes"]["default_metadata_key"]["name"]
         assert default_plane_name in nwbfile.imaging_planes
 
+    def test_no_device_metadata_key(self):
+        """When imaging plane has no device_metadata_key, a default device is created."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_samples=10, num_rois=5, num_rows=15, num_columns=15
+        )
+
+        metadata = {
+            "Devices": {},
+            "Ophys": {
+                "ImagingPlanes": {
+                    "my_plane": {
+                        "name": "ImagingPlane",
+                        "description": "A plane",
+                        "excitation_lambda": 920.0,
+                        "indicator": "GCaMP6s",
+                        "location": "V1",
+                        "optical_channel": [
+                            {
+                                "name": "Green",
+                                "description": "GCaMP emission",
+                                "emission_lambda": 510.0,
+                            }
+                        ],
+                    },
+                },
+                "PlaneSegmentations": {
+                    "my_seg": {
+                        "name": "PlaneSegmentation",
+                        "description": "Segmented ROIs",
+                        "imaging_plane_metadata_key": "my_plane",
+                    },
+                },
+                "RoiResponses": {
+                    "my_seg": {
+                        "plane_segmentation_metadata_key": "my_seg",
+                        "raw": {"name": "RoiResponseSeries", "description": "Raw traces", "unit": "n.a."},
+                    },
+                },
+            },
+        }
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            metadata_key="my_seg",
+        )
+
+        default_metadata = _get_ophys_metadata_placeholders()
+        default_key = "default_metadata_key"
+        default_device_metadata = default_metadata["Devices"][default_key]
+
+        device = nwbfile.devices[default_device_metadata["name"]]
+        assert device.name == default_device_metadata["name"]
+        plane = nwbfile.imaging_planes["ImagingPlane"]
+        assert plane.device is device
+
     def test_shared_imaging_plane_two_segmentations(self):
         """Two segmentations reference same ImagingPlane: 1 plane, 2 PlaneSegmentations."""
         nwbfile = mock_NWBFile()
@@ -3015,94 +3073,44 @@ class TestAddSegmentation:
 
         assert metadata == metadata_before, "Metadata was mutated"
 
-    def test_traces_match_extractor_data(self):
-        """Trace data in NWB matches extractor get_traces_dict()."""
+    def test_no_roi_responses_metadata(self):
+        """Segmentation with no RoiResponses metadata: only PlaneSegmentation written, no traces."""
         nwbfile = mock_NWBFile()
         segmentation_extractor = generate_dummy_segmentation_extractor(
-            num_samples=10, num_rois=5, num_rows=15, num_columns=15
+            num_samples=10,
+            num_rois=5,
+            num_rows=15,
+            num_columns=15,
+            has_raw_signal=False,
+            has_dff_signal=False,
+            has_deconvolved_signal=False,
+            has_neuropil_signal=False,
         )
+
+        metadata = {
+            "Devices": {},
+            "Ophys": {
+                "ImagingPlanes": {},
+                "PlaneSegmentations": {
+                    "my_seg": {
+                        "name": "PlaneSegmentation",
+                        "description": "Cell ROIs",
+                    },
+                },
+            },
+        }
 
         add_segmentation_to_nwbfile(
             segmentation_extractor=segmentation_extractor,
             nwbfile=nwbfile,
+            metadata=metadata,
+            metadata_key="my_seg",
         )
 
+        # PlaneSegmentation exists
         ophys_module = nwbfile.processing["ophys"]
-        fluorescence = ophys_module["Fluorescence"]
-        traces_dict = segmentation_extractor.get_traces_dict()
-        default_metadata = _get_ophys_metadata_placeholders()
-        default_key = "default_metadata_key"
-        roi_responses_metadata = default_metadata["Ophys"]["RoiResponses"][default_key]
+        image_segmentation = ophys_module["ImageSegmentation"]
+        assert "PlaneSegmentation" in image_segmentation.plane_segmentations
 
-        for trace_name, trace_data in traces_dict.items():
-            if trace_data is None or trace_data.size == 0:
-                continue
-            if trace_name not in roi_responses_metadata:
-                continue
-            trace_meta = roi_responses_metadata[trace_name]
-            if isinstance(trace_meta, str):
-                continue
-            series = fluorescence.roi_response_series[trace_meta["name"]]
-            assert_array_equal(np.squeeze(np.array(series.data)), trace_data)
-
-    def test_all_traces_in_single_fluorescence_container(self):
-        """All traces (including dff) go into a single Fluorescence container, no DfOverF split."""
-        nwbfile = mock_NWBFile()
-        segmentation_extractor = generate_dummy_segmentation_extractor(
-            num_samples=10, num_rois=5, num_rows=15, num_columns=15
-        )
-
-        add_segmentation_to_nwbfile(
-            segmentation_extractor=segmentation_extractor,
-            nwbfile=nwbfile,
-        )
-
-        ophys_module = nwbfile.processing["ophys"]
-
-        # Single Fluorescence container, no DfOverF
-        assert "Fluorescence" in ophys_module.data_interfaces
-        assert "DfOverF" not in ophys_module.data_interfaces
-
-        fluorescence = ophys_module["Fluorescence"]
-        traces_dict = segmentation_extractor.get_traces_dict()
-        placeholders = _get_ophys_metadata_placeholders()
-        default_metadata_key = "default_metadata_key"
-        roi_responses = placeholders["Ophys"]["RoiResponses"][default_metadata_key]
-        for trace_name, trace_data in traces_dict.items():
-            if trace_data is None or trace_data.size == 0:
-                continue
-            if trace_name not in roi_responses:
-                continue
-            trace_meta = roi_responses[trace_name]
-            if isinstance(trace_meta, str):
-                continue
-            series_name = trace_meta["name"]
-            assert series_name in fluorescence.roi_response_series
-
-    def test_missing_traces_not_added(self):
-        """Extractor with some traces None: only available traces written."""
-        nwbfile = mock_NWBFile()
-        segmentation_extractor = generate_dummy_segmentation_extractor(
-            num_samples=10, num_rois=5, num_rows=15, num_columns=15
-        )
-
-        # Override some traces to None
-        original_get_traces_dict = segmentation_extractor.get_traces_dict
-
-        def patched_get_traces_dict():
-            d = original_get_traces_dict()
-            d["deconvolved"] = None
-            d["neuropil"] = None
-            return d
-
-        segmentation_extractor.get_traces_dict = patched_get_traces_dict
-
-        add_segmentation_to_nwbfile(
-            segmentation_extractor=segmentation_extractor,
-            nwbfile=nwbfile,
-        )
-
-        ophys_module = nwbfile.processing["ophys"]
-        fluorescence = ophys_module["Fluorescence"]
-        assert "Deconvolved" not in fluorescence.roi_response_series
-        assert "Neuropil" not in fluorescence.roi_response_series
+        # No Fluorescence container
+        assert "Fluorescence" not in ophys_module.data_interfaces

--- a/tests/test_modalities/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_modalities/test_ophys/test_tools_roiextractors.py
@@ -2907,7 +2907,6 @@ class TestAddSegmentation:
                 },
                 "RoiResponses": {
                     "my_seg": {
-                        "plane_segmentation_metadata_key": "my_seg",
                         "raw": {"name": "RoiResponseSeries", "unit": "n.a."},
                     },
                 },
@@ -2971,7 +2970,6 @@ class TestAddSegmentation:
                 },
                 "RoiResponses": {
                     "my_seg": {
-                        "plane_segmentation_metadata_key": "my_seg",
                         "raw": {"name": "RoiResponseSeries", "description": "Raw traces", "unit": "n.a."},
                     },
                 },
@@ -3041,11 +3039,9 @@ class TestAddSegmentation:
                 },
                 "RoiResponses": {
                     "seg_a": {
-                        "plane_segmentation_metadata_key": "seg_a",
                         "raw": {"name": "RoiResponseSeriesA", "description": "Raw A", "unit": "n.a."},
                     },
                     "seg_b": {
-                        "plane_segmentation_metadata_key": "seg_b",
                         "raw": {"name": "RoiResponseSeriesB", "description": "Raw B", "unit": "n.a."},
                     },
                 },
@@ -3108,7 +3104,54 @@ class TestAddSegmentation:
         assert metadata == metadata_before, "Metadata was mutated"
 
     def test_no_roi_responses_metadata(self):
-        """Segmentation with no RoiResponses metadata: only PlaneSegmentation written, no traces."""
+        """When no RoiResponses metadata is provided but extractor has traces, write with placeholder metadata."""
+        nwbfile = mock_NWBFile()
+        num_rois = 5
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_samples=10,
+            num_rois=num_rois,
+            num_rows=15,
+            num_columns=15,
+        )
+
+        metadata = {
+            "Ophys": {
+                "PlaneSegmentations": {
+                    "my_seg": {
+                        "name": "PlaneSegmentation",
+                        "description": "Cell ROIs",
+                    },
+                },
+            },
+        }
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            metadata_key="my_seg",
+        )
+
+        # PlaneSegmentation exists with correct metadata
+        ophys_module = nwbfile.processing["ophys"]
+        image_segmentation = ophys_module["ImageSegmentation"]
+        assert "PlaneSegmentation" in image_segmentation.plane_segmentations
+        plane_seg = image_segmentation.plane_segmentations["PlaneSegmentation"]
+        assert plane_seg.description == "Cell ROIs"
+        assert len(plane_seg.id) == num_rois
+
+        # Fluorescence container created with placeholder trace names
+        fluorescence = ophys_module["Fluorescence"]
+        expected_placeholder_names = {"RoiResponseSeries", "DfOverF", "Neuropil", "Deconvolved"}
+        assert set(fluorescence.roi_response_series.keys()) == expected_placeholder_names
+
+        # Verify traces are linked to the correct PlaneSegmentation
+        for series in fluorescence.roi_response_series.values():
+            roi_table_region = series.rois
+            assert roi_table_region.table is plane_seg
+
+    def test_no_roi_responses_no_traces(self):
+        """When no RoiResponses metadata and no traces, only PlaneSegmentation is written."""
         nwbfile = mock_NWBFile()
         num_rois = 5
         segmentation_extractor = generate_dummy_segmentation_extractor(
@@ -3148,8 +3191,46 @@ class TestAddSegmentation:
         assert plane_seg.description == "Cell ROIs"
         assert len(plane_seg.id) == num_rois
 
-        # No Fluorescence container since no RoiResponses metadata
+        # No Fluorescence container since no traces and no RoiResponses metadata
         assert "Fluorescence" not in ophys_module.data_interfaces
+
+    def test_roi_responses_metadata_but_no_traces_raises(self):
+        """When RoiResponses metadata is provided but extractor has no traces, raise an error."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_samples=10,
+            num_rois=5,
+            num_rows=15,
+            num_columns=15,
+            has_raw_signal=False,
+            has_dff_signal=False,
+            has_deconvolved_signal=False,
+            has_neuropil_signal=False,
+        )
+
+        metadata = {
+            "Ophys": {
+                "PlaneSegmentations": {
+                    "my_seg": {
+                        "name": "PlaneSegmentation",
+                        "description": "Segmented ROIs",
+                    },
+                },
+                "RoiResponses": {
+                    "my_seg": {
+                        "raw": {"name": "RoiResponseSeries", "unit": "n.a."},
+                    },
+                },
+            },
+        }
+
+        with pytest.raises(ValueError, match="no trace data"):
+            add_segmentation_to_nwbfile(
+                segmentation_extractor=segmentation_extractor,
+                nwbfile=nwbfile,
+                metadata=metadata,
+                metadata_key="my_seg",
+            )
 
     def test_shared_device_two_imaging_planes(self):
         """Two segmentations with different imaging planes that share the same device."""
@@ -3199,11 +3280,9 @@ class TestAddSegmentation:
                 },
                 "RoiResponses": {
                     "seg_a": {
-                        "plane_segmentation_metadata_key": "seg_a",
                         "raw": {"name": "RoiResponseSeriesA", "description": "Raw A", "unit": "n.a."},
                     },
                     "seg_b": {
-                        "plane_segmentation_metadata_key": "seg_b",
                         "raw": {"name": "RoiResponseSeriesB", "description": "Raw B", "unit": "n.a."},
                     },
                 },
@@ -3261,11 +3340,9 @@ class TestAddSegmentation:
                 },
                 "RoiResponses": {
                     "first": {
-                        "plane_segmentation_metadata_key": "first",
                         "raw": {"name": "RoiResponseSeriesFirst", "unit": "n.a."},
                     },
                     "second": {
-                        "plane_segmentation_metadata_key": "second",
                         "raw": {"name": "RoiResponseSeriesSecond", "unit": "n.a."},
                     },
                 },
@@ -3344,11 +3421,9 @@ class TestAddSegmentation:
                 },
                 "RoiResponses": {
                     "seg_a": {
-                        "plane_segmentation_metadata_key": "seg_a",
                         "raw": {"name": "RoiResponseSeriesA", "unit": "n.a."},
                     },
                     "seg_b": {
-                        "plane_segmentation_metadata_key": "seg_b",
                         "raw": {"name": "RoiResponseSeriesB", "unit": "n.a."},
                     },
                 },
@@ -3414,7 +3489,6 @@ class TestAddSegmentation:
                 },
                 "RoiResponses": {
                     "my_seg": {
-                        "plane_segmentation_metadata_key": "my_seg",
                         "raw": {"name": "RoiResponseSeries"},
                     },
                 },

--- a/tests/test_modalities/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_modalities/test_ophys/test_tools_roiextractors.py
@@ -2336,9 +2336,7 @@ class TestAddImaging:
         imaging = generate_dummy_imaging_extractor(num_samples=10, num_rows=5, num_columns=5)
 
         metadata = {
-            "Devices": {},
             "Ophys": {
-                "ImagingPlanes": {},
                 "MicroscopySeries": {
                     "my_series": {
                         "name": "TwoPhotonSeries",
@@ -2377,7 +2375,6 @@ class TestAddImaging:
         imaging = generate_dummy_imaging_extractor(num_samples=10, num_rows=5, num_columns=5)
 
         metadata = {
-            "Devices": {},
             "Ophys": {
                 "ImagingPlanes": {
                     "my_plane": {
@@ -2600,9 +2597,7 @@ class TestAddImaging:
         first_metadata_key = "first"
         second_metadata_key = "second"
         metadata = {
-            "Devices": {},
             "Ophys": {
-                "ImagingPlanes": {},
                 "MicroscopySeries": {
                     first_metadata_key: {
                         "name": "TwoPhotonSeriesFirst",
@@ -2669,9 +2664,7 @@ class TestAddImaging:
 
         metadata_key = "my_series"
         metadata = {
-            "Devices": {},
             "Ophys": {
-                "ImagingPlanes": {},
                 "MicroscopySeries": {
                     metadata_key: {
                         "name": "TwoPhotonSeries",
@@ -2952,7 +2945,6 @@ class TestAddSegmentation:
         )
 
         metadata = {
-            "Devices": {},
             "Ophys": {
                 "ImagingPlanes": {
                     "my_plane": {
@@ -3101,9 +3093,7 @@ class TestAddSegmentation:
     def test_metadata_not_mutated(self):
         """deepcopy metadata before call, assert equal after."""
         nwbfile = mock_NWBFile()
-        segmentation_extractor = generate_dummy_segmentation_extractor(
-            num_samples=10, num_rois=5, num_rows=15, num_columns=15
-        )
+        segmentation_extractor = generate_dummy_segmentation_extractor()
 
         metadata = get_full_ophys_metadata()
         metadata_before = deepcopy(metadata)
@@ -3384,9 +3374,7 @@ class TestAddSegmentation:
     def test_missing_required_plane_segmentation_fields_raises(self):
         """When PlaneSegmentation metadata is missing required fields, a clear error is raised."""
         nwbfile = mock_NWBFile()
-        segmentation_extractor = generate_dummy_segmentation_extractor(
-            num_samples=10, num_rois=5, num_rows=15, num_columns=15
-        )
+        segmentation_extractor = generate_dummy_segmentation_extractor()
 
         metadata = {
             "Ophys": {
@@ -3402,6 +3390,41 @@ class TestAddSegmentation:
             "Plane segmentation metadata is missing required fields.\n"
             "For a complete NWB file, the following fields should be provided. If missing, a placeholder can be used instead:\n"
             "  description: 'Segmented ROIs'"
+        )
+        with pytest.raises(ValueError, match=expected_error):
+            add_segmentation_to_nwbfile(
+                segmentation_extractor=segmentation_extractor,
+                nwbfile=nwbfile,
+                metadata=metadata,
+                metadata_key="my_seg",
+            )
+
+    def test_missing_required_roi_response_fields_raises(self):
+        """When ROI response series metadata is missing required fields, a clear error is raised."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor()
+
+        metadata = {
+            "Ophys": {
+                "PlaneSegmentations": {
+                    "my_seg": {
+                        "name": "PlaneSegmentation",
+                        "description": "Segmented ROIs",
+                    },
+                },
+                "RoiResponses": {
+                    "my_seg": {
+                        "plane_segmentation_metadata_key": "my_seg",
+                        "raw": {"name": "RoiResponseSeries"},
+                    },
+                },
+            },
+        }
+
+        expected_error = re.escape(
+            "ROI response series 'raw' metadata is missing required fields.\n"
+            "For a complete NWB file, the following fields should be provided. If missing, a placeholder can be used instead:\n"
+            "  unit: 'n.a.'"
         )
         with pytest.raises(ValueError, match=expected_error):
             add_segmentation_to_nwbfile(

--- a/tests/test_modalities/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_modalities/test_ophys/test_tools_roiextractors.py
@@ -2319,7 +2319,6 @@ class TestAddImaging:
 
         device = nwbfile.devices[device_metadata["name"]]
         assert device.description == device_metadata["description"]
-        assert device.manufacturer == device_metadata["manufacturer"]
 
         plane = nwbfile.imaging_planes[plane_metadata["name"]]
         assert plane.description == plane_metadata["description"]
@@ -2516,7 +2515,6 @@ class TestAddImaging:
                 "shared_device_key": {
                     "name": "SharedMicroscope",
                     "description": "Shared two-photon microscope",
-                    "manufacturer": "Bruker",
                 },
             },
             "Ophys": {
@@ -2583,7 +2581,6 @@ class TestAddImaging:
         unique_device = nwbfile.devices[device_metadata["name"]]
         assert unique_device.name == device_metadata["name"]
         assert unique_device.description == device_metadata["description"]
-        assert unique_device.manufacturer == device_metadata["manufacturer"]
 
         # Both planes share the same device
         assert nwbfile.imaging_planes["ImagingPlaneV1"].device is unique_device
@@ -2811,8 +2808,12 @@ class TestAddSegmentation:
     def test_basic(self):
         """No metadata: defaults created (device, plane, PlaneSegmentation, traces)."""
         nwbfile = mock_NWBFile()
+        num_samples = 20
+        num_rois = 10
+        num_rows = 25
+        num_columns = 20
         segmentation_extractor = generate_dummy_segmentation_extractor(
-            num_samples=20, num_rois=10, num_rows=25, num_columns=20
+            num_samples=num_samples, num_rois=num_rois, num_rows=num_rows, num_columns=num_columns
         )
 
         add_segmentation_to_nwbfile(
@@ -2820,27 +2821,46 @@ class TestAddSegmentation:
             nwbfile=nwbfile,
         )
 
-        # Defaults
+        # When no metadata is passed, _get_ophys_metadata_placeholders() is used internally.
+        # The placeholders are dict-based, so _is_dict_based_metadata() returns True and the
+        # new dict-based code path is used with metadata_key="default_metadata_key".
         placeholders = _get_ophys_metadata_placeholders()
-        default_metadata_key = "default_metadata_key"
-        default_plane_seg_metadata = placeholders["Ophys"]["PlaneSegmentations"][default_metadata_key]
+        default_key = "default_metadata_key"
+        default_device_metadata = placeholders["Devices"][default_key]
+        default_plane_metadata = placeholders["Ophys"]["ImagingPlanes"][default_key]
+        default_plane_seg_metadata = placeholders["Ophys"]["PlaneSegmentations"][default_key]
 
-        # Device and ImagingPlane exist
+        # Default device
         assert len(nwbfile.devices) == 1
+        device = nwbfile.devices[default_device_metadata["name"]]
+        assert device.name == default_device_metadata["name"]
+
+        # Default imaging plane
         assert len(nwbfile.imaging_planes) == 1
+        plane = nwbfile.imaging_planes[default_plane_metadata["name"]]
+        assert plane.name == default_plane_metadata["name"]
+        assert np.isnan(plane.excitation_lambda)
+        assert plane.indicator == default_plane_metadata["indicator"]
+        assert plane.location == default_plane_metadata["location"]
+        assert plane.device is device
 
         # PlaneSegmentation
         ophys_module = nwbfile.processing["ophys"]
         image_segmentation = ophys_module["ImageSegmentation"]
         assert default_plane_seg_metadata["name"] in image_segmentation.plane_segmentations
         plane_seg = image_segmentation.plane_segmentations[default_plane_seg_metadata["name"]]
-        assert len(plane_seg.id) == 10
+        assert plane_seg.name == default_plane_seg_metadata["name"]
+        assert plane_seg.description == default_plane_seg_metadata["description"]
+        assert plane_seg.imaging_plane is plane
+        assert len(plane_seg.id) == num_rois
 
-        # Traces exist in Fluorescence container
+        # All traces are added to a single Fluorescence container (no DfOverF split),
+        # mirroring ndx-microscopy's single-container approach.
         assert "Fluorescence" in ophys_module.data_interfaces
+        assert "DfOverF" not in ophys_module.data_interfaces
 
     def test_full_metadata_specification(self):
-        """Full metadata specification: all names/descriptions match user metadata."""
+        """Full metadata specification: device, imaging plane, and segmentation are created from user metadata."""
         nwbfile = mock_NWBFile()
         segmentation_extractor = generate_dummy_segmentation_extractor(
             num_samples=10, num_rois=5, num_rows=15, num_columns=15
@@ -2856,37 +2876,26 @@ class TestAddSegmentation:
             metadata_key=metadata_key,
         )
 
-        # Device
-        device_metadata = metadata["Devices"]["my_microscope"]
-        assert device_metadata["name"] in nwbfile.devices
-        device = nwbfile.devices[device_metadata["name"]]
+        plane_seg_metadata = metadata["Ophys"]["PlaneSegmentations"][metadata_key]
+        plane_key = plane_seg_metadata["imaging_plane_metadata_key"]
+        plane_metadata = metadata["Ophys"]["ImagingPlanes"][plane_key]
+        device_key = plane_metadata["device_metadata_key"]
+        device_metadata = metadata["Devices"][device_key]
 
-        # ImagingPlane
-        plane_metadata = metadata["Ophys"]["ImagingPlanes"]["my_plane"]
-        assert plane_metadata["name"] in nwbfile.imaging_planes
+        device = nwbfile.devices[device_metadata["name"]]
+        assert device.description == device_metadata["description"]
+
         plane = nwbfile.imaging_planes[plane_metadata["name"]]
         assert plane.description == plane_metadata["description"]
         assert plane.indicator == plane_metadata["indicator"]
         assert plane.location == plane_metadata["location"]
         assert plane.device is device
 
-        # PlaneSegmentation
         ophys_module = nwbfile.processing["ophys"]
         image_segmentation = ophys_module["ImageSegmentation"]
-        plane_seg_metadata = metadata["Ophys"]["PlaneSegmentations"][metadata_key]
         plane_seg = image_segmentation.plane_segmentations[plane_seg_metadata["name"]]
         assert plane_seg.description == plane_seg_metadata["description"]
         assert plane_seg.imaging_plane is plane
-
-        # Traces in single Fluorescence container with names from metadata
-        roi_responses_metadata = metadata["Ophys"]["RoiResponses"][metadata_key]
-        fluorescence = ophys_module["Fluorescence"]
-        traces_dict = segmentation_extractor.get_traces_dict()
-        for trace_name, trace_meta in roi_responses_metadata.items():
-            if trace_name == "plane_segmentation_metadata_key":
-                continue
-            if traces_dict.get(trace_name) is not None and traces_dict[trace_name].size != 0:
-                assert trace_meta["name"] in fluorescence.roi_response_series
 
     def test_no_imaging_plane_metadata_key(self):
         """PlaneSegmentation without imaging_plane_metadata_key: default plane created."""
@@ -2896,9 +2905,7 @@ class TestAddSegmentation:
         )
 
         metadata = {
-            "Devices": {},
             "Ophys": {
-                "ImagingPlanes": {},
                 "PlaneSegmentations": {
                     "my_seg": {
                         "name": "PlaneSegmentation",
@@ -2908,7 +2915,7 @@ class TestAddSegmentation:
                 "RoiResponses": {
                     "my_seg": {
                         "plane_segmentation_metadata_key": "my_seg",
-                        "raw": {"name": "RoiResponseSeries", "description": "Raw traces", "unit": "n.a."},
+                        "raw": {"name": "RoiResponseSeries", "unit": "n.a."},
                     },
                 },
             },
@@ -2921,11 +2928,21 @@ class TestAddSegmentation:
             metadata_key="my_seg",
         )
 
-        # Default imaging plane created
-        assert len(nwbfile.imaging_planes) == 1
         default_metadata = _get_ophys_metadata_placeholders()
-        default_plane_name = default_metadata["Ophys"]["ImagingPlanes"]["default_metadata_key"]["name"]
-        assert default_plane_name in nwbfile.imaging_planes
+        default_key = "default_metadata_key"
+        default_plane_metadata = default_metadata["Ophys"]["ImagingPlanes"][default_key]
+        default_device_metadata = default_metadata["Devices"][default_key]
+
+        # Default imaging plane
+        assert len(nwbfile.imaging_planes) == 1
+        plane = nwbfile.imaging_planes[default_plane_metadata["name"]]
+        assert plane.name == default_plane_metadata["name"]
+
+        # Default device
+        assert len(nwbfile.devices) == 1
+        device = nwbfile.devices[default_device_metadata["name"]]
+        assert device.name == default_device_metadata["name"]
+        assert plane.device is device
 
     def test_no_device_metadata_key(self):
         """When imaging plane has no device_metadata_key, a default device is created."""
@@ -2980,9 +2997,18 @@ class TestAddSegmentation:
         default_key = "default_metadata_key"
         default_device_metadata = default_metadata["Devices"][default_key]
 
+        # Default device created and linked
+        assert len(nwbfile.devices) == 1
         device = nwbfile.devices[default_device_metadata["name"]]
         assert device.name == default_device_metadata["name"]
-        plane = nwbfile.imaging_planes["ImagingPlane"]
+
+        # User-specified imaging plane uses the default device
+        plane_metadata = metadata["Ophys"]["ImagingPlanes"]["my_plane"]
+        plane = nwbfile.imaging_planes[plane_metadata["name"]]
+        assert plane.description == plane_metadata["description"]
+        assert plane.excitation_lambda == plane_metadata["excitation_lambda"]
+        assert plane.indicator == plane_metadata["indicator"]
+        assert plane.location == plane_metadata["location"]
         assert plane.device is device
 
     def test_shared_imaging_plane_two_segmentations(self):
@@ -3041,18 +3067,36 @@ class TestAddSegmentation:
             segmentation_extractor=seg_b, nwbfile=nwbfile, metadata=metadata, metadata_key="seg_b"
         )
 
-        # 1 imaging plane, 2 plane segmentations
+        device_metadata = metadata["Devices"]["dev"]
+        plane_metadata = metadata["Ophys"]["ImagingPlanes"][shared_plane_key]
+        seg_a_metadata = metadata["Ophys"]["PlaneSegmentations"]["seg_a"]
+        seg_b_metadata = metadata["Ophys"]["PlaneSegmentations"]["seg_b"]
+
+        # 1 device, 1 imaging plane, 2 plane segmentations
+        assert len(nwbfile.devices) == 1
         assert len(nwbfile.imaging_planes) == 1
+
+        device = nwbfile.devices[device_metadata["name"]]
+        assert device.name == device_metadata["name"]
+
+        plane = nwbfile.imaging_planes[plane_metadata["name"]]
+        assert plane.name == plane_metadata["name"]
+        assert plane.excitation_lambda == plane_metadata["excitation_lambda"]
+        assert plane.indicator == plane_metadata["indicator"]
+        assert plane.location == plane_metadata["location"]
+        assert plane.device is device
+
         ophys_module = nwbfile.processing["ophys"]
         image_segmentation = ophys_module["ImageSegmentation"]
         assert len(image_segmentation.plane_segmentations) == 2
-        assert "PlaneSegmentationA" in image_segmentation.plane_segmentations
-        assert "PlaneSegmentationB" in image_segmentation.plane_segmentations
 
-        # Both reference same imaging plane
-        ps_a = image_segmentation.plane_segmentations["PlaneSegmentationA"]
-        ps_b = image_segmentation.plane_segmentations["PlaneSegmentationB"]
-        assert ps_a.imaging_plane is ps_b.imaging_plane
+        ps_a = image_segmentation.plane_segmentations[seg_a_metadata["name"]]
+        assert ps_a.description == seg_a_metadata["description"]
+        assert ps_a.imaging_plane is plane
+
+        ps_b = image_segmentation.plane_segmentations[seg_b_metadata["name"]]
+        assert ps_b.description == seg_b_metadata["description"]
+        assert ps_b.imaging_plane is plane
 
     def test_metadata_not_mutated(self):
         """deepcopy metadata before call, assert equal after."""
@@ -3076,9 +3120,10 @@ class TestAddSegmentation:
     def test_no_roi_responses_metadata(self):
         """Segmentation with no RoiResponses metadata: only PlaneSegmentation written, no traces."""
         nwbfile = mock_NWBFile()
+        num_rois = 5
         segmentation_extractor = generate_dummy_segmentation_extractor(
             num_samples=10,
-            num_rois=5,
+            num_rois=num_rois,
             num_rows=15,
             num_columns=15,
             has_raw_signal=False,
@@ -3088,9 +3133,7 @@ class TestAddSegmentation:
         )
 
         metadata = {
-            "Devices": {},
             "Ophys": {
-                "ImagingPlanes": {},
                 "PlaneSegmentations": {
                     "my_seg": {
                         "name": "PlaneSegmentation",
@@ -3107,10 +3150,263 @@ class TestAddSegmentation:
             metadata_key="my_seg",
         )
 
-        # PlaneSegmentation exists
+        # PlaneSegmentation exists with correct metadata
         ophys_module = nwbfile.processing["ophys"]
         image_segmentation = ophys_module["ImageSegmentation"]
         assert "PlaneSegmentation" in image_segmentation.plane_segmentations
+        plane_seg = image_segmentation.plane_segmentations["PlaneSegmentation"]
+        assert plane_seg.description == "Cell ROIs"
+        assert len(plane_seg.id) == num_rois
 
-        # No Fluorescence container
+        # No Fluorescence container since no RoiResponses metadata
         assert "Fluorescence" not in ophys_module.data_interfaces
+
+    def test_shared_device_two_imaging_planes(self):
+        """Two segmentations with different imaging planes that share the same device."""
+        nwbfile = mock_NWBFile()
+        seg_a = generate_dummy_segmentation_extractor(num_samples=10, num_rois=5, num_rows=15, num_columns=15)
+        seg_b = generate_dummy_segmentation_extractor(num_samples=10, num_rois=3, num_rows=15, num_columns=15)
+
+        metadata = {
+            "Devices": {
+                "shared_device_key": {
+                    "name": "SharedMicroscope",
+                    "description": "Shared two-photon microscope",
+                },
+            },
+            "Ophys": {
+                "ImagingPlanes": {
+                    "plane_v1": {
+                        "name": "ImagingPlaneV1",
+                        "description": "Visual cortex V1",
+                        "excitation_lambda": 920.0,
+                        "indicator": "GCaMP6s",
+                        "location": "V1",
+                        "device_metadata_key": "shared_device_key",
+                        "optical_channel": [{"name": "Green", "description": "GCaMP", "emission_lambda": 510.0}],
+                    },
+                    "plane_v2": {
+                        "name": "ImagingPlaneV2",
+                        "description": "Visual cortex V2",
+                        "excitation_lambda": 920.0,
+                        "indicator": "GCaMP6f",
+                        "location": "V2",
+                        "device_metadata_key": "shared_device_key",
+                        "optical_channel": [{"name": "Green", "description": "GCaMP", "emission_lambda": 510.0}],
+                    },
+                },
+                "PlaneSegmentations": {
+                    "seg_a": {
+                        "name": "PlaneSegmentationA",
+                        "description": "First segmentation",
+                        "imaging_plane_metadata_key": "plane_v1",
+                    },
+                    "seg_b": {
+                        "name": "PlaneSegmentationB",
+                        "description": "Second segmentation",
+                        "imaging_plane_metadata_key": "plane_v2",
+                    },
+                },
+                "RoiResponses": {
+                    "seg_a": {
+                        "plane_segmentation_metadata_key": "seg_a",
+                        "raw": {"name": "RoiResponseSeriesA", "description": "Raw A", "unit": "n.a."},
+                    },
+                    "seg_b": {
+                        "plane_segmentation_metadata_key": "seg_b",
+                        "raw": {"name": "RoiResponseSeriesB", "description": "Raw B", "unit": "n.a."},
+                    },
+                },
+            },
+        }
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=seg_a, nwbfile=nwbfile, metadata=metadata, metadata_key="seg_a"
+        )
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=seg_b, nwbfile=nwbfile, metadata=metadata, metadata_key="seg_b"
+        )
+
+        device_metadata = metadata["Devices"]["shared_device_key"]
+        plane_v1_metadata = metadata["Ophys"]["ImagingPlanes"]["plane_v1"]
+        plane_v2_metadata = metadata["Ophys"]["ImagingPlanes"]["plane_v2"]
+
+        # One device, two planes, two segmentations
+        assert len(nwbfile.devices) == 1
+        assert len(nwbfile.imaging_planes) == 2
+
+        device = nwbfile.devices[device_metadata["name"]]
+        assert device.name == device_metadata["name"]
+        assert device.description == device_metadata["description"]
+
+        plane_v1 = nwbfile.imaging_planes[plane_v1_metadata["name"]]
+        assert plane_v1.description == plane_v1_metadata["description"]
+        assert plane_v1.indicator == plane_v1_metadata["indicator"]
+        assert plane_v1.location == plane_v1_metadata["location"]
+        assert plane_v1.device is device
+
+        plane_v2 = nwbfile.imaging_planes[plane_v2_metadata["name"]]
+        assert plane_v2.description == plane_v2_metadata["description"]
+        assert plane_v2.indicator == plane_v2_metadata["indicator"]
+        assert plane_v2.location == plane_v2_metadata["location"]
+        assert plane_v2.device is device
+
+    def test_repeated_calls_reuse_default_metadata_placeholders(self):
+        """Repeated calls without metadata reuse the same placeholder device and imaging plane."""
+        nwbfile = mock_NWBFile()
+        seg_a = generate_dummy_segmentation_extractor(num_samples=10, num_rois=5, num_rows=15, num_columns=15)
+        seg_b = generate_dummy_segmentation_extractor(num_samples=10, num_rois=3, num_rows=15, num_columns=15)
+
+        metadata = {
+            "Ophys": {
+                "PlaneSegmentations": {
+                    "first": {
+                        "name": "PlaneSegmentationFirst",
+                        "description": "First segmentation",
+                    },
+                    "second": {
+                        "name": "PlaneSegmentationSecond",
+                        "description": "Second segmentation",
+                    },
+                },
+                "RoiResponses": {
+                    "first": {
+                        "plane_segmentation_metadata_key": "first",
+                        "raw": {"name": "RoiResponseSeriesFirst", "unit": "n.a."},
+                    },
+                    "second": {
+                        "plane_segmentation_metadata_key": "second",
+                        "raw": {"name": "RoiResponseSeriesSecond", "unit": "n.a."},
+                    },
+                },
+            },
+        }
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=seg_a, nwbfile=nwbfile, metadata=metadata, metadata_key="first"
+        )
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=seg_b, nwbfile=nwbfile, metadata=metadata, metadata_key="second"
+        )
+
+        default_metadata = _get_ophys_metadata_placeholders()
+        default_key = "default_metadata_key"
+        default_device_metadata = default_metadata["Devices"][default_key]
+        default_plane_metadata = default_metadata["Ophys"]["ImagingPlanes"][default_key]
+
+        # Placeholder device and imaging plane are reused, not duplicated
+        assert len(nwbfile.devices) == 1
+        device = nwbfile.devices[default_device_metadata["name"]]
+        assert device.name == default_device_metadata["name"]
+
+        assert len(nwbfile.imaging_planes) == 1
+        plane = nwbfile.imaging_planes[default_plane_metadata["name"]]
+        assert plane.name == default_plane_metadata["name"]
+        assert plane.device is device
+
+        # Both segmentations created with correct metadata
+        ophys_module = nwbfile.processing["ophys"]
+        image_segmentation = ophys_module["ImageSegmentation"]
+        assert len(image_segmentation.plane_segmentations) == 2
+        assert image_segmentation.plane_segmentations["PlaneSegmentationFirst"].description == "First segmentation"
+        assert image_segmentation.plane_segmentations["PlaneSegmentationSecond"].description == "Second segmentation"
+
+    def test_traces_linked_to_correct_plane_segmentation(self):
+        """Two segmentations with different planes: each trace references the correct PlaneSegmentation."""
+        nwbfile = mock_NWBFile()
+        seg_a = generate_dummy_segmentation_extractor(num_samples=10, num_rois=5, num_rows=15, num_columns=15)
+        seg_b = generate_dummy_segmentation_extractor(num_samples=10, num_rois=3, num_rows=15, num_columns=15)
+
+        metadata = {
+            "Devices": {
+                "dev": {"name": "Microscope"},
+            },
+            "Ophys": {
+                "ImagingPlanes": {
+                    "plane_a": {
+                        "name": "ImagingPlaneA",
+                        "excitation_lambda": 920.0,
+                        "indicator": "GCaMP6s",
+                        "location": "V1",
+                        "device_metadata_key": "dev",
+                        "optical_channel": [{"name": "Green", "description": "GCaMP", "emission_lambda": 510.0}],
+                    },
+                    "plane_b": {
+                        "name": "ImagingPlaneB",
+                        "excitation_lambda": 920.0,
+                        "indicator": "GCaMP6f",
+                        "location": "V2",
+                        "device_metadata_key": "dev",
+                        "optical_channel": [{"name": "Green", "description": "GCaMP", "emission_lambda": 510.0}],
+                    },
+                },
+                "PlaneSegmentations": {
+                    "seg_a": {
+                        "name": "PlaneSegmentationA",
+                        "description": "First segmentation",
+                        "imaging_plane_metadata_key": "plane_a",
+                    },
+                    "seg_b": {
+                        "name": "PlaneSegmentationB",
+                        "description": "Second segmentation",
+                        "imaging_plane_metadata_key": "plane_b",
+                    },
+                },
+                "RoiResponses": {
+                    "seg_a": {
+                        "plane_segmentation_metadata_key": "seg_a",
+                        "raw": {"name": "RoiResponseSeriesA", "unit": "n.a."},
+                    },
+                    "seg_b": {
+                        "plane_segmentation_metadata_key": "seg_b",
+                        "raw": {"name": "RoiResponseSeriesB", "unit": "n.a."},
+                    },
+                },
+            },
+        }
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=seg_a, nwbfile=nwbfile, metadata=metadata, metadata_key="seg_a"
+        )
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=seg_b, nwbfile=nwbfile, metadata=metadata, metadata_key="seg_b"
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+        fluorescence = ophys_module["Fluorescence"]
+
+        series_a = fluorescence.roi_response_series["RoiResponseSeriesA"]
+        series_b = fluorescence.roi_response_series["RoiResponseSeriesB"]
+
+        assert series_a.rois.table.name == "PlaneSegmentationA"
+        assert series_b.rois.table.name == "PlaneSegmentationB"
+
+    def test_missing_required_plane_segmentation_fields_raises(self):
+        """When PlaneSegmentation metadata is missing required fields, a clear error is raised."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_samples=10, num_rois=5, num_rows=15, num_columns=15
+        )
+
+        metadata = {
+            "Ophys": {
+                "PlaneSegmentations": {
+                    "my_seg": {
+                        "name": "PlaneSegmentation",
+                    },
+                },
+            },
+        }
+
+        expected_error = re.escape(
+            "Plane segmentation metadata is missing required fields.\n"
+            "For a complete NWB file, the following fields should be provided. If missing, a placeholder can be used instead:\n"
+            "  description: 'Segmented ROIs'"
+        )
+        with pytest.raises(ValueError, match=expected_error):
+            add_segmentation_to_nwbfile(
+                segmentation_extractor=segmentation_extractor,
+                nwbfile=nwbfile,
+                metadata=metadata,
+                metadata_key="my_seg",
+            )

--- a/tests/test_modalities/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_modalities/test_ophys/test_tools_roiextractors.py
@@ -30,6 +30,7 @@ from neuroconv.tools.roiextractors import (
     add_devices_to_nwbfile,
     add_fluorescence_traces_to_nwbfile,
     add_imaging_to_nwbfile,
+    add_segmentation_to_nwbfile,
 )
 from neuroconv.tools.roiextractors.imagingextractordatachunkiterator import (
     ImagingExtractorDataChunkIterator,
@@ -2802,3 +2803,306 @@ class TestAddImaging:
         )
 
         assert metadata == metadata_before, "Metadata was mutated"
+
+
+class TestAddSegmentation:
+    """Tests for the dict-based metadata segmentation pipeline (add_segmentation_to_nwbfile)."""
+
+    def test_basic(self):
+        """No metadata: defaults created (device, plane, PlaneSegmentation, traces)."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_samples=20, num_rois=10, num_rows=25, num_columns=20
+        )
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+        )
+
+        # Defaults
+        placeholders = _get_ophys_metadata_placeholders()
+        default_metadata_key = "default_metadata_key"
+        default_plane_seg_metadata = placeholders["Ophys"]["PlaneSegmentations"][default_metadata_key]
+
+        # Device and ImagingPlane exist
+        assert len(nwbfile.devices) == 1
+        assert len(nwbfile.imaging_planes) == 1
+
+        # PlaneSegmentation
+        ophys_module = nwbfile.processing["ophys"]
+        image_segmentation = ophys_module["ImageSegmentation"]
+        assert default_plane_seg_metadata["name"] in image_segmentation.plane_segmentations
+        plane_seg = image_segmentation.plane_segmentations[default_plane_seg_metadata["name"]]
+        assert len(plane_seg.id) == 10
+
+        # Traces exist in Fluorescence container
+        assert "Fluorescence" in ophys_module.data_interfaces
+
+    def test_full_metadata_specification(self):
+        """Full metadata specification: all names/descriptions match user metadata."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_samples=10, num_rois=5, num_rows=15, num_columns=15
+        )
+
+        metadata = get_full_ophys_metadata()
+        metadata_key = "my_segmentation"
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            metadata_key=metadata_key,
+        )
+
+        # Device
+        device_metadata = metadata["Devices"]["my_microscope"]
+        assert device_metadata["name"] in nwbfile.devices
+        device = nwbfile.devices[device_metadata["name"]]
+
+        # ImagingPlane
+        plane_metadata = metadata["Ophys"]["ImagingPlanes"]["my_plane"]
+        assert plane_metadata["name"] in nwbfile.imaging_planes
+        plane = nwbfile.imaging_planes[plane_metadata["name"]]
+        assert plane.description == plane_metadata["description"]
+        assert plane.indicator == plane_metadata["indicator"]
+        assert plane.location == plane_metadata["location"]
+        assert plane.device is device
+
+        # PlaneSegmentation
+        ophys_module = nwbfile.processing["ophys"]
+        image_segmentation = ophys_module["ImageSegmentation"]
+        plane_seg_metadata = metadata["Ophys"]["PlaneSegmentations"][metadata_key]
+        plane_seg = image_segmentation.plane_segmentations[plane_seg_metadata["name"]]
+        assert plane_seg.description == plane_seg_metadata["description"]
+        assert plane_seg.imaging_plane is plane
+
+        # Traces in single Fluorescence container with names from metadata
+        roi_responses_metadata = metadata["Ophys"]["RoiResponses"][metadata_key]
+        fluorescence = ophys_module["Fluorescence"]
+        traces_dict = segmentation_extractor.get_traces_dict()
+        for trace_name, trace_meta in roi_responses_metadata.items():
+            if trace_name == "plane_segmentation_metadata_key":
+                continue
+            if traces_dict.get(trace_name) is not None and traces_dict[trace_name].size != 0:
+                assert trace_meta["name"] in fluorescence.roi_response_series
+
+    def test_no_imaging_plane_metadata_key(self):
+        """PlaneSegmentation without imaging_plane_metadata_key: default plane created."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_samples=10, num_rois=5, num_rows=15, num_columns=15
+        )
+
+        metadata = {
+            "Devices": {},
+            "Ophys": {
+                "ImagingPlanes": {},
+                "PlaneSegmentations": {
+                    "my_seg": {
+                        "name": "PlaneSegmentation",
+                        "description": "Segmented ROIs",
+                    },
+                },
+                "RoiResponses": {
+                    "my_seg": {
+                        "plane_segmentation_metadata_key": "my_seg",
+                        "raw": {"name": "RoiResponseSeries", "description": "Raw traces", "unit": "n.a."},
+                    },
+                },
+            },
+        }
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            metadata_key="my_seg",
+        )
+
+        # Default imaging plane created
+        assert len(nwbfile.imaging_planes) == 1
+        default_metadata = _get_ophys_metadata_placeholders()
+        default_plane_name = default_metadata["Ophys"]["ImagingPlanes"]["default_metadata_key"]["name"]
+        assert default_plane_name in nwbfile.imaging_planes
+
+    def test_shared_imaging_plane_two_segmentations(self):
+        """Two segmentations reference same ImagingPlane: 1 plane, 2 PlaneSegmentations."""
+        nwbfile = mock_NWBFile()
+        seg_a = generate_dummy_segmentation_extractor(num_samples=10, num_rois=5, num_rows=15, num_columns=15)
+        seg_b = generate_dummy_segmentation_extractor(num_samples=10, num_rois=3, num_rows=15, num_columns=15)
+
+        shared_plane_key = "shared_plane"
+        metadata = {
+            "Devices": {
+                "dev": {"name": "MyDevice"},
+            },
+            "Ophys": {
+                "ImagingPlanes": {
+                    shared_plane_key: {
+                        "name": "SharedPlane",
+                        "excitation_lambda": 920.0,
+                        "indicator": "GCaMP6f",
+                        "location": "V1",
+                        "device_metadata_key": "dev",
+                        "optical_channel": [
+                            {"name": "Green", "emission_lambda": 525.0, "description": "Green channel"},
+                        ],
+                    },
+                },
+                "PlaneSegmentations": {
+                    "seg_a": {
+                        "name": "PlaneSegmentationA",
+                        "description": "First segmentation",
+                        "imaging_plane_metadata_key": shared_plane_key,
+                    },
+                    "seg_b": {
+                        "name": "PlaneSegmentationB",
+                        "description": "Second segmentation",
+                        "imaging_plane_metadata_key": shared_plane_key,
+                    },
+                },
+                "RoiResponses": {
+                    "seg_a": {
+                        "plane_segmentation_metadata_key": "seg_a",
+                        "raw": {"name": "RoiResponseSeriesA", "description": "Raw A", "unit": "n.a."},
+                    },
+                    "seg_b": {
+                        "plane_segmentation_metadata_key": "seg_b",
+                        "raw": {"name": "RoiResponseSeriesB", "description": "Raw B", "unit": "n.a."},
+                    },
+                },
+            },
+        }
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=seg_a, nwbfile=nwbfile, metadata=metadata, metadata_key="seg_a"
+        )
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=seg_b, nwbfile=nwbfile, metadata=metadata, metadata_key="seg_b"
+        )
+
+        # 1 imaging plane, 2 plane segmentations
+        assert len(nwbfile.imaging_planes) == 1
+        ophys_module = nwbfile.processing["ophys"]
+        image_segmentation = ophys_module["ImageSegmentation"]
+        assert len(image_segmentation.plane_segmentations) == 2
+        assert "PlaneSegmentationA" in image_segmentation.plane_segmentations
+        assert "PlaneSegmentationB" in image_segmentation.plane_segmentations
+
+        # Both reference same imaging plane
+        ps_a = image_segmentation.plane_segmentations["PlaneSegmentationA"]
+        ps_b = image_segmentation.plane_segmentations["PlaneSegmentationB"]
+        assert ps_a.imaging_plane is ps_b.imaging_plane
+
+    def test_metadata_not_mutated(self):
+        """deepcopy metadata before call, assert equal after."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_samples=10, num_rois=5, num_rows=15, num_columns=15
+        )
+
+        metadata = get_full_ophys_metadata()
+        metadata_before = deepcopy(metadata)
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            metadata_key="my_segmentation",
+        )
+
+        assert metadata == metadata_before, "Metadata was mutated"
+
+    def test_traces_match_extractor_data(self):
+        """Trace data in NWB matches extractor get_traces_dict()."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_samples=10, num_rois=5, num_rows=15, num_columns=15
+        )
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+        fluorescence = ophys_module["Fluorescence"]
+        traces_dict = segmentation_extractor.get_traces_dict()
+        default_metadata = _get_ophys_metadata_placeholders()
+        default_key = "default_metadata_key"
+        roi_responses_metadata = default_metadata["Ophys"]["RoiResponses"][default_key]
+
+        for trace_name, trace_data in traces_dict.items():
+            if trace_data is None or trace_data.size == 0:
+                continue
+            if trace_name not in roi_responses_metadata:
+                continue
+            trace_meta = roi_responses_metadata[trace_name]
+            if isinstance(trace_meta, str):
+                continue
+            series = fluorescence.roi_response_series[trace_meta["name"]]
+            assert_array_equal(np.squeeze(np.array(series.data)), trace_data)
+
+    def test_all_traces_in_single_fluorescence_container(self):
+        """All traces (including dff) go into a single Fluorescence container, no DfOverF split."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_samples=10, num_rois=5, num_rows=15, num_columns=15
+        )
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+
+        # Single Fluorescence container, no DfOverF
+        assert "Fluorescence" in ophys_module.data_interfaces
+        assert "DfOverF" not in ophys_module.data_interfaces
+
+        fluorescence = ophys_module["Fluorescence"]
+        traces_dict = segmentation_extractor.get_traces_dict()
+        placeholders = _get_ophys_metadata_placeholders()
+        default_metadata_key = "default_metadata_key"
+        roi_responses = placeholders["Ophys"]["RoiResponses"][default_metadata_key]
+        for trace_name, trace_data in traces_dict.items():
+            if trace_data is None or trace_data.size == 0:
+                continue
+            if trace_name not in roi_responses:
+                continue
+            trace_meta = roi_responses[trace_name]
+            if isinstance(trace_meta, str):
+                continue
+            series_name = trace_meta["name"]
+            assert series_name in fluorescence.roi_response_series
+
+    def test_missing_traces_not_added(self):
+        """Extractor with some traces None: only available traces written."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_samples=10, num_rois=5, num_rows=15, num_columns=15
+        )
+
+        # Override some traces to None
+        original_get_traces_dict = segmentation_extractor.get_traces_dict
+
+        def patched_get_traces_dict():
+            d = original_get_traces_dict()
+            d["deconvolved"] = None
+            d["neuropil"] = None
+            return d
+
+        segmentation_extractor.get_traces_dict = patched_get_traces_dict
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+        fluorescence = ophys_module["Fluorescence"]
+        assert "Deconvolved" not in fluorescence.roi_response_series
+        assert "Neuropil" not in fluorescence.roi_response_series


### PR DESCRIPTION
Continues with the plan of [#1653](https://github.com/catalystneuro/neuroconv/pull/1653). Adds new dict-based metadata functions for writing segmentation objects (`_add_plane_segmentation_to_nwbfile`, `_add_roi_response_traces_to_nwbfile`) with dual routing in `add_segmentation_to_nwbfile`. Note that a lot of related but non-core changes were done in [#1690](https://github.com/catalystneuro/neuroconv/pull/1690) (moving old functionality to new functions without changing behavior) so we can focus on the new functionality here.

This PR implements the most basic functionality, leaving background segmentation and summary images for a future PR so we can focus on the core of the changes. Like the imaging PRs ([#1677](https://github.com/catalystneuro/neuroconv/pull/1677) for implementation, [#1685](https://github.com/catalystneuro/neuroconv/pull/1685) for full tests), the comprehensive tests that are not strictly related to the metadata handling will be added in a follow-up PR.

Some design decisions I would like to highlight:
- **Omitted mask choice functionality**: the current pipeline supports this choice as a conversion option. Here, the minimal functionality of writing the image mask in the native format of the segmentation algorithm is implemented. We can discuss how to add support for format conversion, if desirable, later. Again, so we can focus on the core of the change.
- **Omitted centroids and acceptance**: we have moved to a system of properties that writes the properties of the native format as PlaneSegmentation columns (see [roiextractors#467](https://github.com/catalystneuro/roiextractors/pull/467) and [roiextractors#533](https://github.com/catalystneuro/roiextractors/pull/533)). The accepted list has been deprecated (see [roiextractors#524](https://github.com/catalystneuro/roiextractors/pull/524)) and [I think](https://github.com/catalystneuro/roiextractors/issues/556) we should support centroids as a property (not as a conversion option) but if you don't agree can add that later and focus on the main change here.
- **Single Fluorescence container**: all traces (including dff) go into one `Fluorescence` container instead of splitting between `Fluorescence` and `DfOverF`. This follows the direction of [nwb-schema#616](https://github.com/NeurodataWithoutBorders/nwb-schema/issues/616) and matches ndx-microscopy's single-container pattern (`MicroscopyResponseSeriesContainer`). We can discuss if we want to add support for the split but again, this simplifies the diff. 
