### PR TITLE
Add remaining functional tests for dict-based segmentation pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ## Improvements
 * Added array-like protocol methods (`shape`, `ndim`, `__len__`, `__getitem__`) to all data chunk iterators (`SliceableDataChunkIterator`, `SpikeInterfaceRecordingDataChunkIterator`, `ImagingExtractorDataChunkIterator`, `VideoDataChunkIterator`). [PR #1673](https://github.com/catalystneuro/neuroconv/pull/1673)
 * Added tests for `OnePhotonSeries`, `processing/ophys` container, and non-iterative write to `TestAddImaging` (dict-based metadata pipeline). [PR #1685](https://github.com/catalystneuro/neuroconv/pull/1685)
+* Added functional tests to `TestAddSegmentation` for image masks, ROI properties, timestamp handling (regular, irregular, sampling frequency fallback), trace data values, ROI table regions, and iterator options propagation. [PR #1693](https://github.com/catalystneuro/neuroconv/pull/1693)
 * Added column-first fast path for writing Units tables when the table is new (no append/merge). Uses `id.extend()` + `add_column()` instead of per-row `add_unit()` calls, reducing Python overhead for large sortings. [PR #1669](https://github.com/catalystneuro/neuroconv/pull/1669)
 
 # v0.9.3 (February 19, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 ## Improvements
 * Added array-like protocol methods (`shape`, `ndim`, `__len__`, `__getitem__`) to all data chunk iterators (`SliceableDataChunkIterator`, `SpikeInterfaceRecordingDataChunkIterator`, `ImagingExtractorDataChunkIterator`, `VideoDataChunkIterator`). [PR #1673](https://github.com/catalystneuro/neuroconv/pull/1673)
 * Added tests for `OnePhotonSeries`, `processing/ophys` container, and non-iterative write to `TestAddImaging` (dict-based metadata pipeline). [PR #1685](https://github.com/catalystneuro/neuroconv/pull/1685)
-* Added functional tests to `TestAddSegmentation` for image masks, ROI properties, timestamp handling (regular, irregular, sampling frequency fallback), trace data values, ROI table regions, and iterator options propagation. [PR #1693](https://github.com/catalystneuro/neuroconv/pull/1693)
+* Added functional tests to `TestAddSegmentation` for image masks, ROI properties, timestamp handling (regular, irregular, sampling frequency fallback), trace data values, ROI table regions, and iterator options propagation. Added a warning when user-provided `RoiResponses` metadata references traces the extractor does not have. [PR #1693](https://github.com/catalystneuro/neuroconv/pull/1693)
 * Added column-first fast path for writing Units tables when the table is new (no append/merge). Uses `id.extend()` + `add_column()` instead of per-row `add_unit()` calls, reducing Python overhead for large sortings. [PR #1669](https://github.com/catalystneuro/neuroconv/pull/1669)
 
 # v0.9.3 (February 19, 2026)

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -621,8 +621,19 @@ def _add_roi_response_traces_to_nwbfile(
         return nwbfile
 
     # Use user-provided metadata or fall back to placeholders
+    user_provided_roi_responses_metadata = user_provided_roi_responses and metadata_key != "default_metadata_key"
     if user_provided_roi_responses:
         roi_responses_metadata = roi_responses[metadata_key].copy()
+        if user_provided_roi_responses_metadata:
+            requested_traces = set(roi_responses_metadata.keys())
+            available_traces = set(traces_to_add.keys())
+            missing_traces = requested_traces - available_traces
+            if missing_traces:
+                warnings.warn(
+                    f"RoiResponses metadata specifies traces {missing_traces} "
+                    f"but the segmentation extractor has no data for them. "
+                    f"These traces will be skipped."
+                )
     else:
         roi_responses_metadata = _get_ophys_metadata_placeholders()["Ophys"]["RoiResponses"]["default_metadata_key"]
 

--- a/tests/test_modalities/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_modalities/test_ophys/test_tools_roiextractors.py
@@ -24,6 +24,7 @@ from roiextractors.testing import (
     generate_dummy_segmentation_extractor,
 )
 
+from neuroconv.tools.hdmf import SliceableDataChunkIterator
 from neuroconv.tools.nwb_helpers import get_module
 from neuroconv.tools.roiextractors import (
     _check_if_imaging_fits_into_memory,
@@ -277,6 +278,8 @@ class TestAddImagingPlane(TestCase):
         assert second_imaging_plane.name == second_imaging_plane_name
 
 
+# TODO: Drop this test class once support for list-based metadata is removed (September 2026).
+# The dict-based equivalent is TestAddSegmentation.
 class TestAddImageSegmentation(unittest.TestCase):
     def setUp(self):
         self.session_start_time = datetime.now().astimezone()
@@ -332,6 +335,8 @@ def assert_masks_equal(mask: list[list[tuple[int, int, int]]], expected_mask: li
         assert_array_equal(mask[mask_ind], expected_mask[mask_ind])
 
 
+# TODO: Drop this test class once support for list-based metadata is removed (September 2026).
+# The dict-based equivalent is TestAddSegmentation.
 class TestAddPlaneSegmentation(TestCase):
     @classmethod
     def setUpClass(cls):
@@ -812,6 +817,8 @@ class TestAddPlaneSegmentation(TestCase):
             np.testing.assert_array_equal(plane_segmentation[prop].data, expected)
 
 
+# TODO: Drop this test class once support for list-based metadata is removed (September 2026).
+# The dict-based equivalent is TestAddSegmentation.
 class TestAddFluorescenceTraces(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -1240,6 +1247,8 @@ class TestAddFluorescenceTraces(unittest.TestCase):
         assert plane_segmentation_name in image_segmentation.plane_segmentations
 
 
+# TODO: Drop this test class once support for list-based metadata is removed (September 2026).
+# The dict-based equivalent is TestAddSegmentation.
 class TestAddFluorescenceTracesMultiPlaneCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -3507,3 +3516,172 @@ class TestAddSegmentation:
                 metadata=metadata,
                 metadata_key="my_seg",
             )
+
+    def test_image_masks_written_correctly(self):
+        """Mask data values match the extractor's get_roi_image_masks()."""
+        nwbfile = mock_NWBFile()
+        num_rois = 4
+        segmentation_extractor = generate_dummy_segmentation_extractor(num_rois=num_rois)
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+        image_segmentation = ophys_module["ImageSegmentation"]
+        (plane_seg,) = image_segmentation.plane_segmentations.values()
+
+        image_masks = segmentation_extractor.get_roi_image_masks().T
+        for index in range(num_rois):
+            assert_array_equal(plane_seg["image_mask"][index], image_masks[index])
+
+    def test_roi_properties_written_as_columns(self):
+        """Custom properties added via set_property() appear as PlaneSegmentation columns."""
+        nwbfile = mock_NWBFile()
+        num_rois = 5
+        segmentation_extractor = generate_dummy_segmentation_extractor(num_rois=num_rois)
+
+        roi_ids = segmentation_extractor.get_roi_ids()
+        custom_float = np.arange(num_rois, dtype=np.float32) * 0.5
+        custom_bool = np.array([True, False, True, False, True])
+        custom_label = np.array(["A", "B", "A", "C", "B"], dtype=object)
+
+        segmentation_extractor.set_property("custom_float", custom_float, ids=roi_ids)
+        segmentation_extractor.set_property("custom_bool", custom_bool, ids=roi_ids)
+        segmentation_extractor.set_property("custom_label", custom_label, ids=roi_ids)
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+        image_segmentation = ophys_module["ImageSegmentation"]
+        (plane_seg,) = image_segmentation.plane_segmentations.values()
+
+        for prop, expected in [
+            ("custom_float", custom_float),
+            ("custom_bool", custom_bool),
+            ("custom_label", custom_label),
+        ]:
+            assert prop in plane_seg
+            np.testing.assert_array_equal(plane_seg[prop].data, expected)
+
+    def test_traces_with_regular_timestamps(self):
+        """Regular timestamps produce rate/starting_time, not timestamps."""
+        nwbfile = mock_NWBFile()
+        num_samples = 5
+        times = np.arange(0, num_samples)
+        segmentation_extractor = generate_dummy_segmentation_extractor(num_samples=num_samples)
+        segmentation_extractor.set_times(times)
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+        fluorescence = ophys_module["Fluorescence"]
+        for series in fluorescence.roi_response_series.values():
+            assert series.rate == 1.0
+            assert series.starting_time == 0.0
+            assert series.timestamps is None
+
+    def test_traces_with_irregular_timestamps(self):
+        """Irregular timestamps are stored directly on the series."""
+        nwbfile = mock_NWBFile()
+        num_samples = 5
+        times = [0.0, 0.12, 0.15, 0.19, 0.1]
+        segmentation_extractor = generate_dummy_segmentation_extractor(num_samples=num_samples)
+        segmentation_extractor.set_times(times)
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+        fluorescence = ophys_module["Fluorescence"]
+        for series in fluorescence.roi_response_series.values():
+            assert series.rate is None
+            assert series.starting_time is None
+            assert_array_equal(series.timestamps.data, times)
+
+    def test_traces_without_timestamps_uses_sampling_frequency(self):
+        """When no timestamps are set, sampling frequency from the extractor is used."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor()
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+        fluorescence = ophys_module["Fluorescence"]
+        expected_rate = segmentation_extractor.get_sampling_frequency()
+        for series in fluorescence.roi_response_series.values():
+            assert series.rate == expected_rate
+            assert series.starting_time == 0.0
+            assert series.timestamps is None
+
+    def test_trace_data_values_match_extractor(self):
+        """Trace data written to NWB matches the extractor's get_traces_dict()."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor()
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+        fluorescence = ophys_module["Fluorescence"]
+        traces_dict = segmentation_extractor.get_traces_dict()
+        available_traces = [data for data in traces_dict.values() if data is not None]
+
+        assert len(fluorescence.roi_response_series) == len(available_traces)
+        for series in fluorescence.roi_response_series.values():
+            written_data = series.data.data.data
+            assert any(np.array_equal(written_data, trace) for trace in available_traces)
+
+    def test_roi_table_region_covers_all_rois(self):
+        """Each RoiResponseSeries references all ROIs and the correct PlaneSegmentation."""
+        nwbfile = mock_NWBFile()
+        num_rois = 7
+        segmentation_extractor = generate_dummy_segmentation_extractor(num_rois=num_rois)
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+        image_segmentation = ophys_module["ImageSegmentation"]
+        (plane_seg,) = image_segmentation.plane_segmentations.values()
+        fluorescence = ophys_module["Fluorescence"]
+
+        for series in fluorescence.roi_response_series.values():
+            assert len(series.rois) == num_rois
+            assert series.rois.table is plane_seg
+
+    def test_iterator_options_propagation(self):
+        """Iterator options are passed through to the SliceableDataChunkIterator."""
+        nwbfile = mock_NWBFile()
+        num_rois = 3
+        num_samples = 10
+        segmentation_extractor = generate_dummy_segmentation_extractor(num_rois=num_rois, num_samples=num_samples)
+
+        chunk_shape = (num_samples // 2, num_rois)
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+            iterator_options=dict(chunk_shape=chunk_shape),
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+        fluorescence = ophys_module["Fluorescence"]
+        for series in fluorescence.roi_response_series.values():
+            assert isinstance(series.data, SliceableDataChunkIterator)
+            assert series.data.chunk_shape == chunk_shape

--- a/tests/test_modalities/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_modalities/test_ophys/test_tools_roiextractors.py
@@ -3517,6 +3517,40 @@ class TestAddSegmentation:
                 metadata_key="my_seg",
             )
 
+    def test_warns_when_metadata_specifies_missing_traces(self):
+        """Warning is emitted when RoiResponses metadata references traces the extractor doesn't have."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            has_neuropil_signal=False,
+            has_deconvolved_signal=False,
+        )
+
+        metadata = {
+            "Ophys": {
+                "PlaneSegmentations": {
+                    "my_seg": {
+                        "name": "PlaneSegmentation",
+                        "description": "Segmented ROIs",
+                    },
+                },
+                "RoiResponses": {
+                    "my_seg": {
+                        "raw": {"name": "RoiResponseSeries", "unit": "n.a."},
+                        "neuropil": {"name": "Neuropil", "unit": "n.a."},
+                        "deconvolved": {"name": "Deconvolved", "unit": "n.a."},
+                    },
+                },
+            },
+        }
+
+        with pytest.warns(UserWarning, match="RoiResponses metadata specifies traces"):
+            add_segmentation_to_nwbfile(
+                segmentation_extractor=segmentation_extractor,
+                nwbfile=nwbfile,
+                metadata=metadata,
+                metadata_key="my_seg",
+            )
+
     def test_image_masks_written_correctly(self):
         """Mask data values match the extractor's get_roi_image_masks()."""
         nwbfile = mock_NWBFile()


### PR DESCRIPTION
Following the pattern from the imaging pipeline (PR #1677 for functionality, PR #1685 for remaining tests), this PR adds functional tests to `TestAddSegmentation` for the dict-based segmentation pipeline introduced in PR #1692. Tests cover image mask correctness, ROI properties as columns, timestamp handling (regular, irregular, sampling frequency fallback), trace data values, ROI table regions, and iterator options propagation. Also adds a warning when user-provided `RoiResponses` metadata references traces the extractor does not have, and marks the four old list-based test classes (`TestAddImageSegmentation`, `TestAddPlaneSegmentation`, `TestAddFluorescenceTraces`, `TestAddFluorescenceTracesMultiPlaneCase`) with TODO comments for removal once list-based metadata support is dropped.
