### PR TITLE
Add summary images to dict-based segmentation pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ## Features
 * Added dict-based metadata pipeline for imaging in `roiextractors.py`, supporting the new `MicroscopySeries`, `ImagingPlanes`, and `Devices` metadata format keyed by `metadata_key`. Old list-based functions are preserved (renamed with `_old_list_format` suffix) and dispatched automatically when `metadata_key` is not provided. [PR #1677](https://github.com/catalystneuro/neuroconv/pull/1677)
 * Added dict-based metadata pipeline for segmentation in `roiextractors.py` (`_add_plane_segmentation_to_nwbfile`, `_add_roi_response_traces_to_nwbfile`) with dual routing in `add_segmentation_to_nwbfile`. Masks are written in the extractor's native format and all traces go into a single `Fluorescence` container. [PR #1692](https://github.com/catalystneuro/neuroconv/pull/1692)
+* Added summary images (mean, correlation) to the dict-based segmentation pipeline via `_add_summary_images_to_nwbfile`. Images are written to a shared `SegmentationImages` container in the ophys processing module, with per-image metadata configurable through `metadata["Ophys"]["SegmentationImages"]`. [PR #1695](https://github.com/catalystneuro/neuroconv/pull/1695)
 
 ## Improvements
 * Added array-like protocol methods (`shape`, `ndim`, `__len__`, `__getitem__`) to all data chunk iterators (`SliceableDataChunkIterator`, `SpikeInterfaceRecordingDataChunkIterator`, `ImagingExtractorDataChunkIterator`, `VideoDataChunkIterator`). [PR #1673](https://github.com/catalystneuro/neuroconv/pull/1673)

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -69,7 +69,7 @@ def _is_dict_based_metadata(metadata: dict) -> bool:
 
     ophys = metadata.get("Ophys", {})
 
-    dict_based_keys = {"ImagingPlanes", "MicroscopySeries", "PlaneSegmentations", "RoiResponses", "SegmentationImages"}
+    dict_based_keys = {"ImagingPlanes", "MicroscopySeries", "PlaneSegmentations", "RoiResponses"}
     if dict_based_keys & ophys.keys():
         return True
 

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -6,6 +6,8 @@ import numpy as np
 import psutil
 from pydantic import FilePath
 from pynwb import NWBFile
+from pynwb.base import Images
+from pynwb.image import GrayscaleImage
 from pynwb.ophys import (
     Fluorescence,
     ImageSegmentation,
@@ -67,7 +69,7 @@ def _is_dict_based_metadata(metadata: dict) -> bool:
 
     ophys = metadata.get("Ophys", {})
 
-    dict_based_keys = {"ImagingPlanes", "MicroscopySeries", "PlaneSegmentations", "RoiResponses"}
+    dict_based_keys = {"ImagingPlanes", "MicroscopySeries", "PlaneSegmentations", "RoiResponses", "SegmentationImages"}
     if dict_based_keys & ophys.keys():
         return True
 
@@ -157,6 +159,16 @@ def _get_ophys_metadata_placeholders():
                 },
             },
         },
+        "SegmentationImages": {
+            default_metadata_key: {
+                "correlation": {
+                    "name": "correlation_image",
+                },
+                "mean": {
+                    "name": "mean_image",
+                },
+            },
+        },
     }
 
     return metadata
@@ -233,6 +245,18 @@ def get_full_ophys_metadata():
                     "name": "DfOverF",
                     "description": "Delta F over F",
                     "unit": "n.a.",
+                },
+            },
+        },
+        "SegmentationImages": {
+            "my_segmentation": {
+                "correlation": {
+                    "name": "correlation_image",
+                    "description": "Correlation image.",
+                },
+                "mean": {
+                    "name": "mean_image",
+                    "description": "Mean image.",
                 },
             },
         },
@@ -725,6 +749,90 @@ def _add_roi_response_traces_to_nwbfile(
     return nwbfile
 
 
+def _add_summary_images_to_nwbfile(
+    *,
+    segmentation_extractor: SegmentationExtractor,
+    nwbfile: NWBFile,
+    metadata: dict,
+    metadata_key: str,
+) -> NWBFile:
+    """
+    Add summary images (e.g. mean and correlation) to an NWBFile.
+
+    Images are added to a single ``Images`` container named ``"SegmentationImages"``
+    in the ``ophys`` processing module. If the extractor has no images, this is a no-op.
+
+    Parameters
+    ----------
+    segmentation_extractor : SegmentationExtractor
+        The segmentation extractor containing image data.
+    nwbfile : NWBFile
+        The NWB file to add images to.
+    metadata : dict
+        The full metadata dictionary. Image metadata is looked up under
+        ``metadata["Ophys"]["SegmentationImages"][metadata_key]``.
+    metadata_key : str
+        The key identifying which segmentation's image metadata to use.
+
+    Returns
+    -------
+    NWBFile
+        The NWBFile with the added summary images.
+    """
+    images_dict = segmentation_extractor.get_images_dict()
+    images_to_add = {img_name: img for img_name, img in images_dict.items() if img is not None}
+    if not images_to_add:
+        return nwbfile
+
+    # Look up per-image metadata for this segmentation
+    segmentation_images_metadata = metadata.get("Ophys", {}).get("SegmentationImages", {})
+    user_provided_images_metadata = (
+        metadata_key in segmentation_images_metadata and metadata_key != "default_metadata_key"
+    )
+    if metadata_key in segmentation_images_metadata:
+        images_metadata = segmentation_images_metadata[metadata_key]
+        if user_provided_images_metadata:
+            requested_images = set(images_metadata.keys())
+            available_images = set(images_to_add.keys())
+            missing_images = requested_images - available_images
+            if missing_images:
+                warnings.warn(
+                    f"SegmentationImages metadata specifies images {missing_images} "
+                    f"but the segmentation extractor has no data for them. "
+                    f"These images will be skipped."
+                )
+    else:
+        placeholders = _get_ophys_metadata_placeholders()
+        images_metadata = placeholders["Ophys"]["SegmentationImages"]["default_metadata_key"]
+
+    # Get or create the single shared Images container
+    container_name = "SegmentationImages"
+    container_description = "Summary images for segmentation."
+    ophys_module = get_module(nwbfile=nwbfile, name="ophys", description="contains optical physiology processed data")
+
+    if container_name not in ophys_module.data_interfaces:
+        ophys_module.add(Images(name=container_name, description=container_description))
+    image_collection = ophys_module.data_interfaces[container_name]
+
+    for img_type, img_data in images_to_add.items():
+        # Skip image types not in metadata (metadata controls what gets written)
+        if img_type not in images_metadata:
+            continue
+
+        image_metadata = images_metadata[img_type]
+        image_name = image_metadata.get("name", img_type)
+        image_description = image_metadata.get("description", f"Summary image: {img_type}.")
+
+        # Skip if an image with this name already exists in the container
+        if image_name in image_collection.images:
+            continue
+
+        # NWB uses width x height (columns, rows); roiextractors uses height x width (rows, columns)
+        image_collection.add_image(GrayscaleImage(name=image_name, data=img_data.T, description=image_description))
+
+    return nwbfile
+
+
 def _add_segmentation_to_nwbfile(
     *,
     segmentation_extractor: SegmentationExtractor,
@@ -769,6 +877,13 @@ def _add_segmentation_to_nwbfile(
         metadata=metadata,
         metadata_key=metadata_key,
         iterator_options=iterator_options,
+    )
+
+    _add_summary_images_to_nwbfile(
+        segmentation_extractor=segmentation_extractor,
+        nwbfile=nwbfile,
+        metadata=metadata,
+        metadata_key=metadata_key,
     )
 
     return nwbfile

--- a/tests/test_modalities/test_ophys/test_tools_roiextractors.py
+++ b/tests/test_modalities/test_ophys/test_tools_roiextractors.py
@@ -1776,6 +1776,7 @@ class TestAddPhotonSeries(TestCase):
         self.assertIn(shared_imaging_plane_name, self.nwbfile.imaging_planes)
 
 
+# TODO: Drop this test class once support for list-based metadata is removed (September 2026).
 class TestAddSummaryImages(TestCase):
     @classmethod
     def setUpClass(cls):
@@ -2861,6 +2862,20 @@ class TestAddSegmentation:
         assert "Fluorescence" in ophys_module.data_interfaces
         assert "DfOverF" not in ophys_module.data_interfaces
 
+        # Summary images
+        default_images_metadata = placeholders["Ophys"]["SegmentationImages"][default_key]
+        assert "SegmentationImages" in ophys_module.data_interfaces
+        image_collection = ophys_module.data_interfaces["SegmentationImages"]
+
+        expected_images = {k: v for k, v in segmentation_extractor.get_images_dict().items() if v is not None}
+        assert len(image_collection.images) == len(expected_images)
+
+        for img_type, img_data in expected_images.items():
+            nwb_name = default_images_metadata[img_type]["name"]
+            nwb_image = image_collection.images[nwb_name]
+            assert nwb_image.name == nwb_name
+            np.testing.assert_array_equal(nwb_image.data, img_data.T)
+
     def test_full_metadata_specification(self):
         """Full metadata specification: device, imaging plane, and segmentation are created from user metadata."""
         nwbfile = mock_NWBFile()
@@ -2898,6 +2913,20 @@ class TestAddSegmentation:
         plane_seg = image_segmentation.plane_segmentations[plane_seg_metadata["name"]]
         assert plane_seg.description == plane_seg_metadata["description"]
         assert plane_seg.imaging_plane is plane
+
+        # Summary images
+        images_metadata = metadata["Ophys"]["SegmentationImages"][metadata_key]
+        image_collection = ophys_module.data_interfaces["SegmentationImages"]
+        images_dict = segmentation_extractor.get_images_dict()
+        expected_images = {k: v for k, v in images_dict.items() if v is not None}
+        assert len(image_collection.images) == len(expected_images)
+
+        for img_type, img_data in expected_images.items():
+            img_meta = images_metadata[img_type]
+            nwb_image = image_collection.images[img_meta["name"]]
+            assert nwb_image.name == img_meta["name"]
+            assert nwb_image.description == img_meta["description"]
+            np.testing.assert_array_equal(nwb_image.data, img_data.T)
 
     def test_no_imaging_plane_metadata_key(self):
         """PlaneSegmentation without imaging_plane_metadata_key: default plane created."""
@@ -3551,6 +3580,45 @@ class TestAddSegmentation:
                 metadata_key="my_seg",
             )
 
+    def test_warns_when_metadata_specifies_missing_images(self):
+        """Warning is emitted when SegmentationImages metadata references image types the extractor doesn't have."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_samples=10, num_rois=5, num_rows=15, num_columns=20, has_summary_images=False
+        )
+        # Add only mean, not correlation
+        segmentation_extractor._summary_images["mean"] = np.random.rand(15, 20)
+
+        metadata = {
+            "Ophys": {
+                "PlaneSegmentations": {
+                    "my_seg": {
+                        "name": "PlaneSegmentation",
+                        "description": "Segmented ROIs",
+                    },
+                },
+                "SegmentationImages": {
+                    "my_seg": {
+                        "correlation": {"name": "corr_img", "description": "Correlation"},
+                        "mean": {"name": "mean_img", "description": "Mean"},
+                    },
+                },
+            },
+        }
+
+        with pytest.warns(UserWarning, match="SegmentationImages metadata specifies images"):
+            add_segmentation_to_nwbfile(
+                segmentation_extractor=segmentation_extractor,
+                nwbfile=nwbfile,
+                metadata=metadata,
+                metadata_key="my_seg",
+            )
+
+        ophys_module = nwbfile.processing["ophys"]
+        image_collection = ophys_module.data_interfaces["SegmentationImages"]
+        assert len(image_collection.images) == 1
+        assert "mean_img" in image_collection.images
+
     def test_image_masks_written_correctly(self):
         """Mask data values match the extractor's get_roi_image_masks()."""
         nwbfile = mock_NWBFile()
@@ -3719,3 +3787,111 @@ class TestAddSegmentation:
         for series in fluorescence.roi_response_series.values():
             assert isinstance(series.data, SliceableDataChunkIterator)
             assert series.data.chunk_shape == chunk_shape
+
+    def test_summary_images_one_suppressed(self):
+        """One image is None in extractor, only the other is written."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_samples=10, num_rois=5, num_rows=15, num_columns=20
+        )
+        segmentation_extractor._summary_images["correlation"] = None
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+        image_collection = ophys_module.data_interfaces["SegmentationImages"]
+        assert len(image_collection.images) == 1
+
+        placeholders = _get_ophys_metadata_placeholders()
+        mean_name = placeholders["Ophys"]["SegmentationImages"]["default_metadata_key"]["mean"]["name"]
+        assert mean_name in image_collection.images
+
+    def test_summary_images_none(self):
+        """Extractor has no summary images: no Images container created."""
+        nwbfile = mock_NWBFile()
+        segmentation_extractor = generate_dummy_segmentation_extractor(
+            num_samples=10, num_rois=5, num_rows=15, num_columns=20, has_summary_images=False
+        )
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=segmentation_extractor,
+            nwbfile=nwbfile,
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+        assert "SegmentationImages" not in ophys_module.data_interfaces
+
+    def test_summary_images_two_segmentations_shared_container(self):
+        """Two segmentation pipelines add images to the same container."""
+        nwbfile = mock_NWBFile()
+        seg_a = generate_dummy_segmentation_extractor(num_samples=10, num_rois=5, num_rows=15, num_columns=20)
+        seg_b = generate_dummy_segmentation_extractor(num_samples=10, num_rois=3, num_rows=15, num_columns=20)
+
+        shared_plane_key = "shared_plane"
+        metadata = {
+            "Devices": {
+                "dev": {"name": "MyDevice"},
+            },
+            "Ophys": {
+                "ImagingPlanes": {
+                    shared_plane_key: {
+                        "name": "SharedPlane",
+                        "excitation_lambda": 920.0,
+                        "indicator": "GCaMP6f",
+                        "location": "V1",
+                        "device_metadata_key": "dev",
+                        "optical_channel": [
+                            {"name": "Green", "emission_lambda": 525.0, "description": "Green channel"},
+                        ],
+                    },
+                },
+                "PlaneSegmentations": {
+                    "seg_a": {
+                        "name": "PlaneSegA",
+                        "description": "First segmentation",
+                        "imaging_plane_metadata_key": shared_plane_key,
+                    },
+                    "seg_b": {
+                        "name": "PlaneSegB",
+                        "description": "Second segmentation",
+                        "imaging_plane_metadata_key": shared_plane_key,
+                    },
+                },
+                "RoiResponses": {
+                    "seg_a": {
+                        "raw": {"name": "RoiResponseSeriesA", "description": "Raw A", "unit": "n.a."},
+                    },
+                    "seg_b": {
+                        "raw": {"name": "RoiResponseSeriesB", "description": "Raw B", "unit": "n.a."},
+                    },
+                },
+                "SegmentationImages": {
+                    "seg_a": {
+                        "correlation": {"name": "corr_a", "description": "Correlation A"},
+                        "mean": {"name": "mean_a", "description": "Mean A"},
+                    },
+                    "seg_b": {
+                        "correlation": {"name": "corr_b", "description": "Correlation B"},
+                        "mean": {"name": "mean_b", "description": "Mean B"},
+                    },
+                },
+            },
+        }
+
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=seg_a, nwbfile=nwbfile, metadata=metadata, metadata_key="seg_a"
+        )
+        add_segmentation_to_nwbfile(
+            segmentation_extractor=seg_b, nwbfile=nwbfile, metadata=metadata, metadata_key="seg_b"
+        )
+
+        ophys_module = nwbfile.processing["ophys"]
+        image_collection = ophys_module.data_interfaces["SegmentationImages"]
+        assert len(image_collection.images) == 4
+        assert "corr_a" in image_collection.images
+        assert "mean_a" in image_collection.images
+        assert "corr_b" in image_collection.images
+        assert "mean_b" in image_collection.images


### PR DESCRIPTION
Closes the summary images gap left open by #1692. The dict-based segmentation pipeline now writes mean and correlation images alongside `PlaneSegmentation` and `RoiResponses`, matching the capability of the old list-based `_add_summary_images_to_nwbfile` in `roiextractors_pending_deprecation.py`.

The implementation follows the design already documented in #1653: a single shared `Images` container (fixed name `"SegmentationImages"`) holds all summary images from all segmentation pipelines. Per-image names and descriptions are configurable through `metadata["Ophys"]["SegmentationImages"][metadata_key]`, using the same `metadata_key` that indexes `PlaneSegmentations` and `RoiResponses`. When no metadata is provided, placeholder names (`correlation_image`, `mean_image`) are used from `_get_ophys_metadata_placeholders()`.

I have left the `Images` container name and description non-configurable to keep this consistent with `ImageSegmentation` and `Fluorescence`, which also use fixed names.

Related: #269, #1511, #1692, #1653, #1693
