### PR TITLE
Fix compatibility with roiextractors PR #562

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Removed the deprecated `time_series_name` parameter from `add_recording_as_time_series_to_nwbfile`. Use `metadata_key` instead. [PR #1678](https://github.com/catalystneuro/neuroconv/pull/1678)
 
 ## Bug Fixes
+* Fixed compatibility with upcoming roiextractors changes ([roiextractors PR #562](https://github.com/catalystneuro/roiextractors/pull/562)) by removing calls to the deprecated `get_num_channels` and `get_channel_names` methods on imaging extractors, and making the volumetric chunking test dtype-aware. [PR #1696](https://github.com/catalystneuro/neuroconv/pull/1696)
 * Fixed `NotImplementedError` when using `ndx-events>=0.2.2` with `configure_and_write_nwbfile`. The version check for ndx-events `Events` types was too restrictive (`<= 0.2.1`), causing files with `Events` objects to fail during backend configuration. [PR #1682](https://github.com/catalystneuro/neuroconv/pull/1682)
 * Fixed `get_json_schema_from_method_signature` to resolve PEP 563 string annotations (from `from __future__ import annotations`) before passing them to pydantic. This affected any interface defined in a module with deferred annotations (e.g. `MiniscopeConverter`, or external subclasses from SpikeInterface). [PR #1670](https://github.com/catalystneuro/neuroconv/pull/1670)
 

--- a/src/neuroconv/datainterfaces/ophys/femtonics/femtonicsdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/femtonics/femtonicsdatainterface.py
@@ -187,7 +187,7 @@ class FemtonicsImagingInterface(BaseImagingExtractorInterface):
         if pmt_settings:
             imaging_plane = metadata["Ophys"]["ImagingPlane"][0]
             optical_channels = imaging_plane.get("optical_channel", [])
-            channel_names = self.imaging_extractor.get_channel_names()
+            channel_names = [self._channel_name]
             for i, channel_name in enumerate(channel_names):
                 if channel_name in pmt_settings and i < len(optical_channels):
                     settings = pmt_settings[channel_name]

--- a/src/neuroconv/datainterfaces/ophys/femtonics/femtonicsdatainterface.py
+++ b/src/neuroconv/datainterfaces/ophys/femtonics/femtonicsdatainterface.py
@@ -109,10 +109,6 @@ class FemtonicsImagingInterface(BaseImagingExtractorInterface):
             verbose=verbose,
         )
 
-        # Hack till roiextractors removes the get_num_channels method in check_imaging_equal.
-        # TODO: remove this once roiextractors 0.6.1
-        self.imaging_extractor.get_num_channels = lambda: 1  # Override to ensure only one channel is reported
-
     @classmethod
     def get_extractor_class(cls):
         from roiextractors import FemtonicsImagingExtractor

--- a/src/neuroconv/tools/roiextractors/roiextractors_pending_deprecation.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors_pending_deprecation.py
@@ -174,8 +174,7 @@ def get_nwb_imaging_metadata(
     # Get fresh ophys defaults
     metadata = _get_default_ophys_metadata_old_metadata_list()
 
-    # TODO: get_num_channels is deprecated, remove
-    channel_name_list = imgextractor.get_channel_names() or ["OpticalChannel"]
+    channel_name_list = ["OpticalChannel"]
 
     # Update optical channels based on extractor data
     optical_channels = []
@@ -529,8 +528,8 @@ def get_nwb_segmentation_metadata(sgmextractor: SegmentationExtractor) -> dict:
     """
     metadata = _get_default_segmentation_metadata()
     # Optical Channel name:
-    for i in range(sgmextractor.get_num_channels()):
-        ch_name = sgmextractor.get_channel_names()[i]
+    channel_names = sgmextractor._channel_names
+    for i, ch_name in enumerate(channel_names):
         if i == 0:
             metadata["Ophys"]["ImagingPlane"][0]["optical_channel"][i]["name"] = ch_name
         else:

--- a/tests/test_modalities/test_ophys/test_imagingextractordatachunkiterator.py
+++ b/tests/test_modalities/test_ophys/test_imagingextractordatachunkiterator.py
@@ -195,4 +195,7 @@ def test_volumetric_default_chunking():
     volumetric_imaging_extractor = VolumetricImagingExtractor(imaging_extractors=imaging_extractors)
     iterator = ImagingExtractorDataChunkIterator(imaging_extractor=volumetric_imaging_extractor)
 
-    assert iterator.chunk_shape == (4, width, height, 1)
+    dtype = volumetric_imaging_extractor.get_dtype()
+    frame_size_bytes = width * height * dtype.itemsize
+    expected_num_samples = int(10e6 / frame_size_bytes)
+    assert iterator.chunk_shape == (expected_num_samples, width, height, 1)

--- a/tests/test_on_data/ophys/test_imaging_interfaces.py
+++ b/tests/test_on_data/ophys/test_imaging_interfaces.py
@@ -328,7 +328,7 @@ class TestBrukerTiffImagingInterface(ImagingExtractorInterfaceTestMixin):
 
         cls.device_metadata = dict(name="BrukerFluorescenceMicroscope", description="Version 5.6.64.400")
         cls.optical_channel_metadata = dict(
-            name="Ch2",
+            name="OpticalChannel",
             emission_lambda=np.nan,
             description="An optical channel of the microscope.",
         )
@@ -408,7 +408,7 @@ class TestBrukerTiffImagingInterfaceDualPlaneCase(ImagingExtractorInterfaceTestM
         cls.device_metadata = dict(name="BrukerFluorescenceMicroscope", description="Version 5.6.64.400")
         cls.available_streams = dict(channel_streams=["Ch2"], plane_streams=dict(Ch2=["Ch2_000001"]))
         cls.optical_channel_metadata = dict(
-            name="Ch2",
+            name="OpticalChannel",
             emission_lambda=np.nan,
             description="An optical channel of the microscope.",
         )
@@ -483,7 +483,7 @@ class TestBrukerTiffImagingInterfaceDualPlaneDisjointCase(ImagingExtractorInterf
         cls.device_metadata = dict(name="BrukerFluorescenceMicroscope", description="Version 5.6.64.400")
         cls.available_streams = dict(channel_streams=["Ch2"], plane_streams=dict(Ch2=["Ch2_000001", "Ch2_000002"]))
         cls.optical_channel_metadata = dict(
-            name="Ch2",
+            name="OpticalChannel",
             emission_lambda=np.nan,
             description="An optical channel of the microscope.",
         )
@@ -573,7 +573,7 @@ class TestBrukerTiffImagingInterfaceDualColorCase(ImagingExtractorInterfaceTestM
         cls.device_metadata = dict(name="BrukerFluorescenceMicroscope", description="Version 5.8.64.200")
         cls.available_streams = dict(channel_streams=["Ch1", "Ch2"], plane_streams=dict())
         cls.optical_channel_metadata = dict(
-            name="Ch2",
+            name="OpticalChannel",
             emission_lambda=np.nan,
             description="An optical channel of the microscope.",
         )
@@ -655,7 +655,7 @@ class TestMicroManagerTiffImagingInterface(ImagingExtractorInterfaceTestMixin):
         cls = request.cls
         cls.device_metadata = dict(name="Microscope")
         cls.optical_channel_metadata = dict(
-            name="OpticalChannelDefault",
+            name="OpticalChannel",
             emission_lambda=np.nan,
             description="An optical channel of the microscope.",
         )
@@ -1004,7 +1004,7 @@ class TestInscopixImagingInterfaceMovie128x128x100Part1(ImagingExtractorInterfac
         # Optical channel checks
         optical_channel = imaging_plane["optical_channel"][0]
         assert (
-            optical_channel["name"] == "channel_0"
+            optical_channel["name"] == "OpticalChannel"
         )  # Default metadata because this was not included in the source metadata
         assert (
             optical_channel["description"] == "An optical channel of the microscope."
@@ -1150,7 +1150,7 @@ class TestInscopixImagingInterfaceMovieU8(ImagingExtractorInterfaceTestMixin):
         # Optical channel checks
         optical_channel = imaging_plane["optical_channel"][0]
         assert (
-            optical_channel["name"] == "channel_0"
+            optical_channel["name"] == "OpticalChannel"
         )  # Default metadata because this was not included in the source metadata
         assert (
             optical_channel["description"] == "An optical channel of the microscope."
@@ -1214,7 +1214,7 @@ class TestFemtonicsImagingInterfaceP29(ImagingExtractorInterfaceTestMixin):
 
         # Check optical channel metadata
         optical_channel = imaging_plane["optical_channel"][0]
-        assert optical_channel["name"] == "UG"
+        assert optical_channel["name"] == "OpticalChannel"
         assert (
             optical_channel["description"]
             == "An optical channel of the microscope. PMT voltage: 65.0V, Warmup time: -0.2s"
@@ -1283,7 +1283,7 @@ class TestFemtonicsImagingInterfaceP30(ImagingExtractorInterfaceTestMixin):
 
         # Check optical channel metadata
         optical_channel = imaging_plane["optical_channel"][0]
-        assert optical_channel["name"] == "UG"
+        assert optical_channel["name"] == "OpticalChannel"
         assert (
             optical_channel["description"]
             == "An optical channel of the microscope. PMT voltage: 65.0V, Warmup time: -0.2s"


### PR DESCRIPTION
The `get_channel_names()` method on imaging extractors internally calls `get_num_channels()`, which is removed in [roiextractors PR #562](https://github.com/catalystneuro/roiextractors/pull/562). This PR replaces those calls with a hardcoded `["OpticalChannel"]` default (imaging extractors are single-channel), switches the segmentation metadata path to use `_channel_names` directly, and removes the `get_num_channels` monkey-patch hack in `FemtonicsDataInterface`. The volumetric chunking test is also updated to compute the expected chunk shape from the extractor's dtype rather than hardcoding a value that assumed `uint16`.
