### PR TITLE
Fix: wrong default device added by `add_electrodes_to_nwbfile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.9.4 (Upcoming)
 
 ## Removals, Deprecations and Changes
+* Fix creation of ghost Device in `add_electrodes_to_nwbfile` [PR #1697](https://github.com/catalystneuro/neuroconv/pull/1718)
 * Bumped minimum spikeinterface version to `>=0.104.0`. Updated template metric names in unit property descriptions (`halfwidth` to `trough_half_width`/`peak_half_width`, `peak_to_valley` to `peak_to_trough_duration`). [PR #1697](https://github.com/catalystneuro/neuroconv/pull/1697)
 * Made `nwbfile_path` a required parameter in `write_recording_to_nwbfile`, `write_sorting_to_nwbfile`, and `write_sorting_analyzer_to_nwbfile`. To add data to an in-memory NWBFile, use `add_recording_to_nwbfile`, `add_sorting_to_nwbfile`, or `add_sorting_analyzer_to_nwbfile` instead. [PR #1689](https://github.com/catalystneuro/neuroconv/pull/1689)
 * `write_recording_to_nwbfile`, `write_sorting_to_nwbfile`, and `write_sorting_analyzer_to_nwbfile` now return `None` in append mode (`append_on_disk_nwbfile=True`) instead of the NWBFile object. [PR #1689](https://github.com/catalystneuro/neuroconv/pull/1689)

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -946,11 +946,25 @@ def add_electrodes_to_nwbfile(
         data = np.full(recording.get_num_channels(), fill_value=default_location)
         data_to_add["location"] = dict(description="location", data=data, index=False)
 
-    # Add missing groups to the nwb file
-    groupless_names = [group_name for group_name in group_names if group_name not in nwbfile.electrode_groups]
-    if len(groupless_names) > 0:
-        electrode_group_list = [dict(name=group_name) for group_name in groupless_names]
-        missing_group_metadata = dict(Ecephys=dict(ElectrodeGroup=electrode_group_list))
+    # Add missing ElectrodeGroups to nwbfile if group names from the recording are not present in the nwbfile already,
+    # and update metadata with missing groups if necessary.
+    # Keep other metadata fields (e.g., Device) if user passes metadata
+    group_names_to_add = [group_name for group_name in group_names if group_name not in nwbfile.electrode_groups]
+    if len(group_names_to_add) > 0:
+        electrode_group_list = [dict(name=group_name) for group_name in group_names_to_add]
+        if metadata is not None:
+            electrodes_group_metadata = metadata.get("Ecephys", dict()).get("ElectrodeGroup", list())
+            missing_group_metadata = metadata.copy()
+            missing_group_metadata["Ecephys"]["ElectrodeGroup"] = electrodes_group_metadata
+        else:
+            missing_group_metadata = dict()
+            electrodes_group_metadata = list()
+            missing_group_metadata["Ecephys"] = dict()
+            missing_group_metadata["Ecephys"]["ElectrodeGroup"] = electrodes_group_metadata
+        # Fill in missing groups
+        for group in electrode_group_list:
+            if group["name"] not in [g["name"] for g in electrodes_group_metadata]:
+                electrodes_group_metadata.append(group)
         _add_electrode_groups_to_nwbfile(recording=recording, nwbfile=nwbfile, metadata=missing_group_metadata)
 
     group_list = [nwbfile.electrode_groups[group_name] for group_name in group_names]

--- a/tests/test_modalities/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_modalities/test_ecephys/test_tools_spikeinterface.py
@@ -1118,6 +1118,62 @@ class TestAddElectrodes(TestCase):
         self.assertListEqual(channel_names[-2:], ["probe2_ch0", "probe2_ch1"])
         self.assertListEqual(group_names[-2:], ["ProbeB", "ProbeB"])  # Different group
 
+    def test_no_new_electrode_groups_added_when_all_groups_already_present(self):
+        """When all recording group names are already in nwbfile, no new ElectrodeGroups should be created."""
+        # setUp already creates device "extra_device" and electrode group "0"
+        num_electrode_groups_before = len(self.nwbfile.electrode_groups)
+
+        # Recording whose only group ("0") is already present in the nwbfile
+        recording = generate_recording(num_channels=2, durations=[1], set_probe=False)
+        recording.set_property(key="group_name", values=["0", "0"])
+
+        metadata = dict(
+            Ecephys=dict(
+                Device=[dict(name="extra_device", description="user-supplied device")],
+                ElectrodeGroup=[
+                    dict(name="0", description="user-supplied group", location="CA1", device="extra_device")
+                ],
+            )
+        )
+
+        add_electrodes_to_nwbfile(recording=recording, nwbfile=self.nwbfile, metadata=metadata)
+
+        # No new electrode groups should have been created
+        self.assertEqual(len(self.nwbfile.electrode_groups), num_electrode_groups_before)
+
+    def test_only_missing_electrode_groups_added_with_user_metadata_preserved(self):
+        """When metadata with Device/ElectrodeGroup is passed, only missing groups are added using that metadata."""
+        # setUp already creates device "extra_device" and electrode group "0"
+        # "0" is already in the nwbfile; "new_group" is not
+        recording = generate_recording(num_channels=4, durations=[1], set_probe=False)
+        recording.set_property(key="group_name", values=["0", "0", "new_group", "new_group"])
+
+        metadata = dict(
+            Ecephys=dict(
+                Device=[dict(name="extra_device", description="user-supplied device")],
+                ElectrodeGroup=[
+                    dict(name="0", description="existing group", location="CA1", device="extra_device"),
+                    dict(
+                        name="new_group", description="new group from metadata", location="CA2", device="extra_device"
+                    ),
+                ],
+            )
+        )
+
+        add_electrodes_to_nwbfile(recording=recording, nwbfile=self.nwbfile, metadata=metadata)
+
+        # "new_group" should have been added
+        self.assertIn("new_group", self.nwbfile.electrode_groups)
+
+        # "0" should not be duplicated
+        self.assertEqual(list(self.nwbfile.electrode_groups.keys()).count("0"), 1)
+
+        # "new_group" should carry the user-supplied metadata
+        new_group = self.nwbfile.electrode_groups["new_group"]
+        self.assertEqual(new_group.description, "new group from metadata")
+        self.assertEqual(new_group.location, "CA2")
+        self.assertEqual(new_group.device.name, "extra_device")
+
 
 class TestAddTimeSeries:
     def test_default_values(self):


### PR DESCRIPTION
This PR fixes a weird bug that creates a "ghost" default `Device` when adding electrodes.

If the user provides `metadata` with `Device` and `ElectrodeGroup` to the `add_electrodes_to_nwbfile`, these are completely ignored [here](https://github.com/catalystneuro/neuroconv/blob/main/src/neuroconv/tools/spikeinterface/spikeinterface.py#L949-L954), which results in the creation of a `Device` and `ElectrodeGroups` addociated to that device.

The fix takes in consideration existing metadata and adds only groups which are in the recording and not in the provided metadata

### TODO:

- [x] Add test