### PR TITLE
Split output files by heterogeneous offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.9.4 (Upcoming)
 
 ## Features
+* Added `BaseRecordingExtractorInterface.split_by_offset`, which partitions a recording's channels by their offset value (using only the offsets present in the recording, independent of any external metadata) and returns one sub-interface per distinct offset, each with a distinct `es_key`. A single NWB `ElectricalSeries` can only carry one scalar `offset`, so recordings with heterogeneous offsets cannot be written to one series; the returned sub-interfaces can be combined in a `ConverterPipe` to write one `ElectricalSeries` per offset into a single NWB file (or converted individually). Recordings with a single offset return the interface unchanged. [PR #1752](https://github.com/catalystneuro/neuroconv/pull/1752)
 * Added `DoricFiberPhotometryInterface` for converting fiber photometry data from Doric Neuroscience Studio `.doric` HDF5 files. [PR #1727](https://github.com/catalystneuro/neuroconv/pull/1727)
 
 ## Removals, Deprecations and Changes

--- a/docs/conversion_examples_gallery/recording/edf.rst
+++ b/docs/conversion_examples_gallery/recording/edf.rst
@@ -48,8 +48,55 @@ Other auxiliary signal channels should be excluded using the ``channels_to_skip`
     nwbfile_path = f"{path_to_save_nwbfile}"
     interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata, overwrite=True)
 
+Handling Channels with Heterogeneous Offsets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The NWB ``ElectricalSeries`` stores a single scalar ``offset`` that is shared by all of its channels.
+Some EDF files contain electrode channels whose physical-to-digital offsets differ from one another,
+which cannot be represented in a single ``ElectricalSeries``. In that case a normal ``run_conversion`` call
+raises ``ValueError: Recording extractors with heterogeneous offsets are not supported.``
+
+To convert such a file, use :py:meth:`~neuroconv.datainterfaces.ecephys.baserecordingextractorinterface.BaseRecordingExtractorInterface.run_conversion_split_by_offset`.
+It partitions the channels by their offset value and writes one NWB file per distinct offset. The output
+paths are derived from the given ``nwbfile_path`` by inserting an ``_offset{index}`` suffix
+(e.g. ``recording.nwb`` becomes ``recording_offset0.nwb``, ``recording_offset1.nwb``, ...). When all channels
+share the same offset, a single file is written to ``nwbfile_path`` unchanged.
+
+.. code-block:: python
+
+    from zoneinfo import ZoneInfo
+    from neuroconv.datainterfaces import EDFRecordingInterface
+
+    file_path = f"{ECEPHY_DATA_PATH}/edf/heterogeneous_offsets.edf"
+
+    interface = EDFRecordingInterface(file_path=file_path)
+
+    metadata = interface.get_metadata()
+    session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    metadata["NWBFile"].update(session_start_time=session_start_time)
+    metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
+
+    # Writes one NWB file per distinct channel offset and returns the written paths
+    nwbfile_path = f"{path_to_save_nwbfile}"
+    written_paths = interface.run_conversion_split_by_offset(
+        nwbfile_path=nwbfile_path, metadata=metadata, overwrite=True
+    )
+    print(f"Wrote: {written_paths}")
+
+If you need finer control over the per-file naming or metadata, call
+:py:meth:`~neuroconv.datainterfaces.ecephys.baserecordingextractorinterface.BaseRecordingExtractorInterface.split_by_offset`
+directly to obtain one sub-interface per offset and run the conversion on each yourself:
+
+.. code-block:: python
+
+    sub_interfaces = interface.split_by_offset()
+    for index, sub_interface in enumerate(sub_interfaces):
+        sub_interface.run_conversion(
+            nwbfile_path=f"recording_offset{index}.nwb", metadata=metadata, overwrite=True
+        )
+
 Converting Auxiliary EDF Channels as TimeSeries
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Auxiliary signals such as physiological monitoring signals, triggers, or auxiliary data should be stored as generic TimeSeries objects
 rather than ElectricalSeries. Use the dedicated :py:class:`~neuroconv.datainterfaces.ecephys.edf.edfanaloginterface.EDFAnalogInterface`

--- a/docs/conversion_examples_gallery/recording/edf.rst
+++ b/docs/conversion_examples_gallery/recording/edf.rst
@@ -51,49 +51,42 @@ Other auxiliary signal channels should be excluded using the ``channels_to_skip`
 Handling Channels with Heterogeneous Offsets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The NWB ``ElectricalSeries`` stores a single scalar ``offset`` that is shared by all of its channels.
-Some EDF files contain electrode channels whose physical-to-digital offsets differ from one another,
-which cannot be represented in a single ``ElectricalSeries``. In that case a normal ``run_conversion`` call
-raises ``ValueError: Recording extractors with heterogeneous offsets are not supported.``
+A single NWB ``ElectricalSeries`` stores one scalar ``offset`` shared by all of its channels.
+Some EDF files contain channels whose physical-to-digital offsets differ from one another (for example
+different electrode types digitized over different physical ranges), which cannot be represented in a
+single ``ElectricalSeries``. A normal ``run_conversion`` on such a file raises
+``ValueError: Recording extractors with heterogeneous offsets are not supported.``
 
-To convert such a file, use :py:meth:`~neuroconv.datainterfaces.ecephys.baserecordingextractorinterface.BaseRecordingExtractorInterface.run_conversion_split_by_offset`.
-It partitions the channels by their offset value and writes one NWB file per distinct offset. The output
-paths are derived from the given ``nwbfile_path`` by inserting an ``_offset{index}`` suffix
-(e.g. ``recording.nwb`` becomes ``recording_offset0.nwb``, ``recording_offset1.nwb``, ...). When all channels
-share the same offset, a single file is written to ``nwbfile_path`` unchanged.
+Use :py:meth:`~neuroconv.datainterfaces.ecephys.baserecordingextractorinterface.BaseRecordingExtractorInterface.split_by_offset`
+to partition the channels by offset. It returns one sub-interface per distinct offset (each restricted to
+the channels sharing that offset, and each with a distinct ``es_key``), using only the offsets in the file
+itself — no BIDS or other external metadata required. Combining the sub-interfaces in a ``ConverterPipe``
+then writes one ``ElectricalSeries`` per offset into a **single** NWB file, sharing one electrodes table
+and without rescaling the data. If the recording has a single offset, ``split_by_offset`` returns just the
+original interface.
 
 .. code-block:: python
 
     from zoneinfo import ZoneInfo
+    from neuroconv import ConverterPipe
     from neuroconv.datainterfaces import EDFRecordingInterface
 
     file_path = f"{ECEPHY_DATA_PATH}/edf/heterogeneous_offsets.edf"
 
     interface = EDFRecordingInterface(file_path=file_path)
 
-    metadata = interface.get_metadata()
+    # One sub-interface per distinct channel offset (each with a distinct es_key)
+    sub_interfaces = interface.split_by_offset()
+    converter = ConverterPipe(data_interfaces={sub.es_key: sub for sub in sub_interfaces})
+
+    metadata = converter.get_metadata()
     session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
     metadata["NWBFile"].update(session_start_time=session_start_time)
     metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 
-    # Writes one NWB file per distinct channel offset and returns the written paths
+    # Writes one NWB file with one ElectricalSeries per distinct offset
     nwbfile_path = f"{path_to_save_nwbfile}"
-    written_paths = interface.run_conversion_split_by_offset(
-        nwbfile_path=nwbfile_path, metadata=metadata, overwrite=True
-    )
-    print(f"Wrote: {written_paths}")
-
-If you need finer control over the per-file naming or metadata, call
-:py:meth:`~neuroconv.datainterfaces.ecephys.baserecordingextractorinterface.BaseRecordingExtractorInterface.split_by_offset`
-directly to obtain one sub-interface per offset and run the conversion on each yourself:
-
-.. code-block:: python
-
-    sub_interfaces = interface.split_by_offset()
-    for index, sub_interface in enumerate(sub_interfaces):
-        sub_interface.run_conversion(
-            nwbfile_path=f"recording_offset{index}.nwb", metadata=metadata, overwrite=True
-        )
+    converter.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata, overwrite=True)
 
 Converting Auxiliary EDF Channels as TimeSeries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -1,9 +1,7 @@
 import copy
-from pathlib import Path
 from typing import Literal
 
 import numpy as np
-from pydantic import FilePath
 from pynwb import NWBFile
 from pynwb.device import Device
 from pynwb.ecephys import ElectricalSeries, ElectrodeGroup
@@ -451,19 +449,24 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
         """
         Split this interface into one sub-interface per distinct channel offset.
 
-        NWB's ``ElectricalSeries`` stores a single scalar ``offset`` shared by all channels, so a
-        recording whose channels have heterogeneous offsets cannot be written to a single
-        ``ElectricalSeries``. This method partitions the channels by their offset value and returns
-        one interface per distinct offset, each restricted (via
-        :py:meth:`~spikeinterface.core.BaseRecording.select_channels`) to the channels that share
-        that offset. Each returned interface can therefore be written to its own NWB file.
+        A single NWB ``ElectricalSeries`` stores one scalar ``offset`` shared by all of its channels,
+        so a recording whose channels have heterogeneous offsets cannot be written to a single
+        ``ElectricalSeries`` (``add_to_nwbfile`` raises in that case). This method partitions the
+        channels by their offset value — using only the offsets present in the recording, independent
+        of any external (e.g. BIDS) metadata — and returns one interface per distinct offset, each
+        restricted (via :py:meth:`~spikeinterface.core.BaseRecording.select_channels`) to the channels
+        that share that offset.
+
+        Each sub-interface is given a distinct ``es_key`` (``{es_key}0``, ``{es_key}1``, ...), so the
+        returned interfaces can be combined in a :py:class:`~neuroconv.nwbconverter.ConverterPipe` to
+        write one ``ElectricalSeries`` per offset into a single NWB file, or converted individually.
 
         Returns
         -------
         list of BaseRecordingExtractorInterface
-            One interface per distinct offset, ordered by offset value. If the recording has a
-            single (or no) distinct offset, a single-element list containing this interface is
-            returned unchanged.
+            One interface per distinct offset, ordered by offset value. If the recording has a single
+            (or no) distinct offset, a single-element list containing this interface is returned
+            unchanged.
         """
         from ...tools.spikeinterface import _group_channel_ids_by_offset
 
@@ -472,79 +475,16 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
         if len(offset_to_channel_ids) <= 1:
             return [self]
 
+        width = int(np.ceil(np.log10(len(offset_to_channel_ids))))
         sub_interfaces = []
-        for offset in sorted(offset_to_channel_ids):
-            channel_ids = offset_to_channel_ids[offset]
+        for index, offset in enumerate(sorted(offset_to_channel_ids)):
             sub_interface = copy.copy(self)
-            sub_interface.recording_extractor = self.recording_extractor.select_channels(channel_ids=channel_ids)
+            sub_interface.recording_extractor = self.recording_extractor.select_channels(
+                channel_ids=offset_to_channel_ids[offset]
+            )
             sub_interface._number_of_segments = sub_interface.recording_extractor.get_num_segments()
+            sub_interface.es_key = f"{self.es_key}{index:0{width}}"
             sub_interfaces.append(sub_interface)
 
         return sub_interfaces
 
-    def run_conversion_split_by_offset(
-        self,
-        nwbfile_path: FilePath,
-        metadata: dict | None = None,
-        overwrite: bool = False,
-        backend: Literal["hdf5", "zarr"] | None = None,
-        **conversion_options,
-    ) -> list[Path]:
-        """
-        Run the conversion, writing one NWB file per distinct channel offset.
-
-        This is a convenience wrapper around :py:meth:`split_by_offset` and
-        :py:meth:`run_conversion`. When the recording has heterogeneous offsets (which cannot be
-        represented in a single ``ElectricalSeries``), the channels are partitioned by offset and
-        each partition is written to its own NWB file. The output paths are derived from
-        ``nwbfile_path`` by inserting an ``_offset{index}`` suffix before the file extension
-        (e.g. ``recording.nwb`` -> ``recording_offset0.nwb``, ``recording_offset1.nwb``, ...).
-
-        When the recording has a single (or no) distinct offset, a single file is written to
-        ``nwbfile_path`` unchanged.
-
-        Parameters
-        ----------
-        nwbfile_path : FilePath
-            Base path used to derive the output file path(s). See above for the suffixing scheme.
-        metadata : dict, optional
-            Metadata dictionary used to create each NWBFile. The same metadata is used for every
-            output file.
-        overwrite : bool, default: False
-            Whether to overwrite existing files at the derived paths.
-        backend : {"hdf5", "zarr"}, optional
-            The type of backend to use when writing the files.
-        **conversion_options
-            Additional keyword arguments forwarded to each :py:meth:`run_conversion` call.
-
-        Returns
-        -------
-        list of pathlib.Path
-            The paths of the NWB files that were written.
-        """
-        sub_interfaces = self.split_by_offset()
-
-        if len(sub_interfaces) == 1:
-            sub_interfaces[0].run_conversion(
-                nwbfile_path=nwbfile_path,
-                metadata=metadata,
-                overwrite=overwrite,
-                backend=backend,
-                **conversion_options,
-            )
-            return [Path(nwbfile_path)]
-
-        base_path = Path(nwbfile_path)
-        written_paths = []
-        for index, sub_interface in enumerate(sub_interfaces):
-            split_path = base_path.parent / f"{base_path.stem}_offset{index}{base_path.suffix}"
-            sub_interface.run_conversion(
-                nwbfile_path=split_path,
-                metadata=metadata,
-                overwrite=overwrite,
-                backend=backend,
-                **conversion_options,
-            )
-            written_paths.append(split_path)
-
-        return written_paths

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -487,4 +487,3 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
             sub_interfaces.append(sub_interface)
 
         return sub_interfaces
-

--- a/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baserecordingextractorinterface.py
@@ -1,6 +1,9 @@
+import copy
+from pathlib import Path
 from typing import Literal
 
 import numpy as np
+from pydantic import FilePath
 from pynwb import NWBFile
 from pynwb.device import Device
 from pynwb.ecephys import ElectricalSeries, ElectrodeGroup
@@ -443,3 +446,105 @@ class BaseRecordingExtractorInterface(BaseExtractorInterface):
                 nwbfile=nwbfile,
                 metadata=metadata,
             )
+
+    def split_by_offset(self) -> list["BaseRecordingExtractorInterface"]:
+        """
+        Split this interface into one sub-interface per distinct channel offset.
+
+        NWB's ``ElectricalSeries`` stores a single scalar ``offset`` shared by all channels, so a
+        recording whose channels have heterogeneous offsets cannot be written to a single
+        ``ElectricalSeries``. This method partitions the channels by their offset value and returns
+        one interface per distinct offset, each restricted (via
+        :py:meth:`~spikeinterface.core.BaseRecording.select_channels`) to the channels that share
+        that offset. Each returned interface can therefore be written to its own NWB file.
+
+        Returns
+        -------
+        list of BaseRecordingExtractorInterface
+            One interface per distinct offset, ordered by offset value. If the recording has a
+            single (or no) distinct offset, a single-element list containing this interface is
+            returned unchanged.
+        """
+        from ...tools.spikeinterface import _group_channel_ids_by_offset
+
+        offset_to_channel_ids = _group_channel_ids_by_offset(recording=self.recording_extractor)
+
+        if len(offset_to_channel_ids) <= 1:
+            return [self]
+
+        sub_interfaces = []
+        for offset in sorted(offset_to_channel_ids):
+            channel_ids = offset_to_channel_ids[offset]
+            sub_interface = copy.copy(self)
+            sub_interface.recording_extractor = self.recording_extractor.select_channels(channel_ids=channel_ids)
+            sub_interface._number_of_segments = sub_interface.recording_extractor.get_num_segments()
+            sub_interfaces.append(sub_interface)
+
+        return sub_interfaces
+
+    def run_conversion_split_by_offset(
+        self,
+        nwbfile_path: FilePath,
+        metadata: dict | None = None,
+        overwrite: bool = False,
+        backend: Literal["hdf5", "zarr"] | None = None,
+        **conversion_options,
+    ) -> list[Path]:
+        """
+        Run the conversion, writing one NWB file per distinct channel offset.
+
+        This is a convenience wrapper around :py:meth:`split_by_offset` and
+        :py:meth:`run_conversion`. When the recording has heterogeneous offsets (which cannot be
+        represented in a single ``ElectricalSeries``), the channels are partitioned by offset and
+        each partition is written to its own NWB file. The output paths are derived from
+        ``nwbfile_path`` by inserting an ``_offset{index}`` suffix before the file extension
+        (e.g. ``recording.nwb`` -> ``recording_offset0.nwb``, ``recording_offset1.nwb``, ...).
+
+        When the recording has a single (or no) distinct offset, a single file is written to
+        ``nwbfile_path`` unchanged.
+
+        Parameters
+        ----------
+        nwbfile_path : FilePath
+            Base path used to derive the output file path(s). See above for the suffixing scheme.
+        metadata : dict, optional
+            Metadata dictionary used to create each NWBFile. The same metadata is used for every
+            output file.
+        overwrite : bool, default: False
+            Whether to overwrite existing files at the derived paths.
+        backend : {"hdf5", "zarr"}, optional
+            The type of backend to use when writing the files.
+        **conversion_options
+            Additional keyword arguments forwarded to each :py:meth:`run_conversion` call.
+
+        Returns
+        -------
+        list of pathlib.Path
+            The paths of the NWB files that were written.
+        """
+        sub_interfaces = self.split_by_offset()
+
+        if len(sub_interfaces) == 1:
+            sub_interfaces[0].run_conversion(
+                nwbfile_path=nwbfile_path,
+                metadata=metadata,
+                overwrite=overwrite,
+                backend=backend,
+                **conversion_options,
+            )
+            return [Path(nwbfile_path)]
+
+        base_path = Path(nwbfile_path)
+        written_paths = []
+        for index, sub_interface in enumerate(sub_interfaces):
+            split_path = base_path.parent / f"{base_path.stem}_offset{index}{base_path.suffix}"
+            sub_interface.run_conversion(
+                nwbfile_path=split_path,
+                metadata=metadata,
+                overwrite=overwrite,
+                backend=backend,
+                **conversion_options,
+            )
+            written_paths.append(split_path)
+
+        return written_paths

--- a/src/neuroconv/tools/spikeinterface/__init__.py
+++ b/src/neuroconv/tools/spikeinterface/__init__.py
@@ -15,6 +15,7 @@ from .spikeinterface import (
     _check_if_recording_traces_fit_into_memory,
     add_recording_metadata_to_nwbfile,
     _stub_recording,
+    _group_channel_ids_by_offset,
 )
 
 

--- a/src/neuroconv/tools/spikeinterface/spikeinterface.py
+++ b/src/neuroconv/tools/spikeinterface/spikeinterface.py
@@ -1425,15 +1425,25 @@ def _recording_traces_to_hdmf_iterator(
     return traces_as_iterator
 
 
-def _report_variable_offset(recording: BaseRecording) -> None:
+def _group_channel_ids_by_offset(recording: BaseRecording) -> dict:
     """
-    Helper function to report variable offsets per channel IDs.
-    Groups the different available offsets per channel IDs and raises a ValueError.
+    Group the channel IDs of a recording by their offset value.
+
+    Parameters
+    ----------
+    recording : BaseRecording
+        A recording extractor from spikeinterface.
+
+    Returns
+    -------
+    dict
+        A dictionary mapping each distinct offset value to the list of channel IDs that share it.
+        The native Python types of the offsets and channel IDs are preserved (numpy scalars are
+        converted to their Python equivalents).
     """
     channel_offsets = recording.get_channel_offsets()
     channel_ids = recording.get_channel_ids()
 
-    # Group the different offsets per channel IDs
     offset_to_channel_ids = {}
     for offset, channel_id in zip(channel_offsets, channel_ids):
         offset = offset.item() if isinstance(offset, np.generic) else offset
@@ -1441,6 +1451,16 @@ def _report_variable_offset(recording: BaseRecording) -> None:
         if offset not in offset_to_channel_ids:
             offset_to_channel_ids[offset] = []
         offset_to_channel_ids[offset].append(channel_id)
+
+    return offset_to_channel_ids
+
+
+def _report_variable_offset(recording: BaseRecording) -> None:
+    """
+    Helper function to report variable offsets per channel IDs.
+    Groups the different available offsets per channel IDs and raises a ValueError.
+    """
+    offset_to_channel_ids = _group_channel_ids_by_offset(recording=recording)
 
     # Create a user-friendly message
     message_lines = ["Recording extractors with heterogeneous offsets are not supported."]

--- a/tests/test_modalities/test_ecephys/test_ecephys_interfaces.py
+++ b/tests/test_modalities/test_ecephys/test_ecephys_interfaces.py
@@ -339,32 +339,22 @@ class TestRecordingInterface(RecordingExtractorInterfaceTestMixin):
 
         sub_interfaces = interface.split_by_offset()
 
+        # One sub-interface per distinct offset, ordered by offset value, with distinct es_keys.
         assert len(sub_interfaces) == 3
-        # Ordered by offset value: 0.0, 1.0, 2.0
+        assert [sub.es_key for sub in sub_interfaces] == ["ElectricalSeries0", "ElectricalSeries1", "ElectricalSeries2"]
         assert list(sub_interfaces[0].recording_extractor.get_channel_ids()) == ["a", "b"]
         assert list(sub_interfaces[1].recording_extractor.get_channel_ids()) == ["c", "d"]
         assert list(sub_interfaces[2].recording_extractor.get_channel_ids()) == ["e"]
 
-        # Each sub-interface has a single, homogeneous offset
+        # Each sub-interface has a single, homogeneous offset.
         for sub_interface in sub_interfaces:
             assert len(set(sub_interface.recording_extractor.get_channel_offsets())) == 1
 
-        # The original interface is left untouched
+        # The original interface is left untouched.
         assert interface.recording_extractor.get_num_channels() == 5
 
-    def test_run_conversion_split_by_offset_single_file(self, setup_interface, tmp_path):
-        """With homogeneous offsets a single file is written at the given path."""
-        interface = self.interface
-        interface.recording_extractor.set_channel_offsets(offsets=[5.0, 5.0, 5.0, 5.0])
-        nwbfile_path = tmp_path / "recording.nwb"
-
-        written_paths = interface.run_conversion_split_by_offset(nwbfile_path=nwbfile_path, overwrite=True)
-
-        assert written_paths == [nwbfile_path]
-        assert nwbfile_path.exists()
-
-    def test_run_conversion_split_by_offset_multiple_files(self, tmp_path):
-        """With heterogeneous offsets one valid NWB file is written per distinct offset."""
+    def test_split_by_offset_combined_in_converter_pipe(self, tmp_path):
+        """The split sub-interfaces combine in a ConverterPipe to one file with one series per offset."""
         from pynwb import NWBHDF5IO
 
         interface = MockRecordingInterface(num_channels=5, durations=[0.100])
@@ -374,24 +364,24 @@ class TestRecordingInterface(RecordingExtractorInterfaceTestMixin):
         interface.recording_extractor.set_channel_gains(gains=[1.0, 1.0, 1.0, 1.0, 1.0])
         interface.recording_extractor.set_channel_offsets(offsets=[0.0, 0.0, 1.0, 1.0, 2.0])
 
+        sub_interfaces = interface.split_by_offset()
+        converter = ConverterPipe(data_interfaces={sub.es_key: sub for sub in sub_interfaces})
+
         nwbfile_path = tmp_path / "recording.nwb"
-        written_paths = interface.run_conversion_split_by_offset(nwbfile_path=nwbfile_path, overwrite=True)
+        converter.run_conversion(nwbfile_path=nwbfile_path, overwrite=True)
 
-        expected_paths = [
-            tmp_path / "recording_offset0.nwb",
-            tmp_path / "recording_offset1.nwb",
-            tmp_path / "recording_offset2.nwb",
-        ]
-        assert written_paths == expected_paths
-
+        expected_names = ["ElectricalSeries0", "ElectricalSeries1", "ElectricalSeries2"]
         expected_offsets = [0.0, 1.0, 2.0]
         expected_channel_counts = [2, 2, 1]
-        for path, expected_offset, expected_count in zip(expected_paths, expected_offsets, expected_channel_counts):
-            assert path.exists()
-            with NWBHDF5IO(path=str(path), mode="r") as io:
-                nwbfile = io.read()
-                electrical_series = nwbfile.acquisition["ElectricalSeries"]
-                # Offsets are stored in volts (micro-volt offset scaled by 1e-6)
+        with NWBHDF5IO(path=str(nwbfile_path), mode="r") as io:
+            nwbfile = io.read()
+            # One ElectricalSeries per distinct offset, all in the same file.
+            assert sorted(nwbfile.acquisition.keys()) == expected_names
+            # A single shared electrodes table holds every channel.
+            assert len(nwbfile.electrodes) == 5
+            for name, expected_offset, expected_count in zip(expected_names, expected_offsets, expected_channel_counts):
+                electrical_series = nwbfile.acquisition[name]
+                # Offsets are stored in volts (micro-volt offset scaled by 1e-6); no rescaling.
                 assert electrical_series.offset == expected_offset * 1e-6
                 assert electrical_series.data.shape[1] == expected_count
 

--- a/tests/test_modalities/test_ecephys/test_ecephys_interfaces.py
+++ b/tests/test_modalities/test_ecephys/test_ecephys_interfaces.py
@@ -319,6 +319,82 @@ class TestRecordingInterface(RecordingExtractorInterfaceTestMixin):
         with pytest.raises(jsonschema.exceptions.ValidationError):
             interface.validate_metadata(metadata)
 
+    def test_split_by_offset_homogeneous(self, setup_interface):
+        """A recording with a single offset is returned unchanged as a one-element list."""
+        interface = self.interface
+        interface.recording_extractor.set_channel_offsets(offsets=[5.0, 5.0, 5.0, 5.0])
+
+        sub_interfaces = interface.split_by_offset()
+
+        assert sub_interfaces == [interface]
+
+    def test_split_by_offset_heterogeneous(self):
+        """A recording with heterogeneous offsets is split into one interface per distinct offset."""
+        interface = MockRecordingInterface(num_channels=5, durations=[0.100])
+        interface.recording_extractor = interface.recording_extractor.rename_channels(
+            new_channel_ids=["a", "b", "c", "d", "e"]
+        )
+        interface.recording_extractor.set_channel_gains(gains=[1.0, 1.0, 1.0, 1.0, 1.0])
+        interface.recording_extractor.set_channel_offsets(offsets=[0.0, 0.0, 1.0, 1.0, 2.0])
+
+        sub_interfaces = interface.split_by_offset()
+
+        assert len(sub_interfaces) == 3
+        # Ordered by offset value: 0.0, 1.0, 2.0
+        assert list(sub_interfaces[0].recording_extractor.get_channel_ids()) == ["a", "b"]
+        assert list(sub_interfaces[1].recording_extractor.get_channel_ids()) == ["c", "d"]
+        assert list(sub_interfaces[2].recording_extractor.get_channel_ids()) == ["e"]
+
+        # Each sub-interface has a single, homogeneous offset
+        for sub_interface in sub_interfaces:
+            assert len(set(sub_interface.recording_extractor.get_channel_offsets())) == 1
+
+        # The original interface is left untouched
+        assert interface.recording_extractor.get_num_channels() == 5
+
+    def test_run_conversion_split_by_offset_single_file(self, setup_interface, tmp_path):
+        """With homogeneous offsets a single file is written at the given path."""
+        interface = self.interface
+        interface.recording_extractor.set_channel_offsets(offsets=[5.0, 5.0, 5.0, 5.0])
+        nwbfile_path = tmp_path / "recording.nwb"
+
+        written_paths = interface.run_conversion_split_by_offset(nwbfile_path=nwbfile_path, overwrite=True)
+
+        assert written_paths == [nwbfile_path]
+        assert nwbfile_path.exists()
+
+    def test_run_conversion_split_by_offset_multiple_files(self, tmp_path):
+        """With heterogeneous offsets one valid NWB file is written per distinct offset."""
+        from pynwb import NWBHDF5IO
+
+        interface = MockRecordingInterface(num_channels=5, durations=[0.100])
+        interface.recording_extractor = interface.recording_extractor.rename_channels(
+            new_channel_ids=["a", "b", "c", "d", "e"]
+        )
+        interface.recording_extractor.set_channel_gains(gains=[1.0, 1.0, 1.0, 1.0, 1.0])
+        interface.recording_extractor.set_channel_offsets(offsets=[0.0, 0.0, 1.0, 1.0, 2.0])
+
+        nwbfile_path = tmp_path / "recording.nwb"
+        written_paths = interface.run_conversion_split_by_offset(nwbfile_path=nwbfile_path, overwrite=True)
+
+        expected_paths = [
+            tmp_path / "recording_offset0.nwb",
+            tmp_path / "recording_offset1.nwb",
+            tmp_path / "recording_offset2.nwb",
+        ]
+        assert written_paths == expected_paths
+
+        expected_offsets = [0.0, 1.0, 2.0]
+        expected_channel_counts = [2, 2, 1]
+        for path, expected_offset, expected_count in zip(expected_paths, expected_offsets, expected_channel_counts):
+            assert path.exists()
+            with NWBHDF5IO(path=str(path), mode="r") as io:
+                nwbfile = io.read()
+                electrical_series = nwbfile.acquisition["ElectricalSeries"]
+                # Offsets are stored in volts (micro-volt offset scaled by 1e-6)
+                assert electrical_series.offset == expected_offset * 1e-6
+                assert electrical_series.data.shape[1] == expected_count
+
     def test_set_probe(self, setup_interface):
         """Test setting probe with by_probe group mode."""
         # Create a simple probe


### PR DESCRIPTION
Related to #1106

Added BaseRecordingExtractorInterface.split_by_offset and BaseRecordingExtractorInterface.run_conversion_split_by_offset to support recordings (e.g. some EDF files) whose channels have heterogeneous offsets, which cannot be represented in a single NWB ElectricalSeries. The channels are partitioned by offset value and each partition is written to its own NWB file (paths derived by inserting an _offset{index} suffix). Recordings with a single offset are written to one file unchanged.