### PR TITLE
Re-enable Spike2 real-data tests on platforms with sonpy wheels

### DIFF
--- a/tests/test_on_data/ecephys/test_recording_interfaces.py
+++ b/tests/test_on_data/ecephys/test_recording_interfaces.py
@@ -192,8 +192,8 @@ class TestBlackrockRecordingInterface(RecordingExtractorInterfaceTestMixin):
 
 
 @pytest.mark.skipif(
-    platform == "darwin" or this_python_version > version.parse("3.9"),
-    reason="Interface unsupported for OSX. Interface only runs on Python 3.9",
+    platform != "win32" and this_python_version < version.parse("3.14"),
+    reason="sonpy has no usable wheels on Linux and macOS below Python 3.14",
 )
 class TestSpike2RecordingInterface(RecordingExtractorInterfaceTestMixin):
     data_interface_cls = Spike2RecordingInterface
@@ -1285,8 +1285,8 @@ class TestWhiteMatterRecordingInterface(RecordingExtractorInterfaceTestMixin):
             dict(file_path=str(ECEPHY_DATA_PATH / "spike2" / "m365_1sec.smrx")),
             "spike2_recording",
             marks=pytest.mark.skipif(
-                platform == "darwin" or this_python_version > version.parse("3.9"),
-                reason="Interface unsupported for OSX. Interface only runs on Python 3.9",
+                platform != "win32" and this_python_version < version.parse("3.14"),
+                reason="sonpy has no usable wheels on Linux and macOS below Python 3.14",
             ),
         ),
     ],


### PR DESCRIPTION
Recreates #1886, which was closed automatically on 12 Aug when the fork
hosting its branch was detached during an account cleanup on my side —
my mistake, apologies for the noise.

The head commit is byte-identical to the original PR (`029867846a`).
All prior context and discussion: https://github.com/catalystneuro/neuroconv/pull/1886

---

Refs #1797. Follow-up to #1855, as agreed there.

**Status: draft. Merge gate is still closed.** Neo 0.14.5 (latest on PyPI) and neo `master` still call `sonpy.lib` in `cedrawio.py`. [NeuralEnsemble/python-neo#1890](https://github.com/NeuralEnsemble/python-neo/issues/1890) is open and unfixed upstream. Do not mark ready for review until that fix is released.

**The problem.** #1855 fixed the `spike2` extra but left the real-data tests dead on purpose: their guard (`this_python_version > version.parse("3.9")`) is always true under `requires-python = ">=3.10"`, and re-enabling them would hit Neo's `CedRawIO`, broken against `sonpy>=1.9.12`. There are two such guards (`TestSpike2RecordingInterface` and the `spike2` case of `test_metadata_key_is_accepted_and_forwarded`); the second one was not mentioned in #1855.

**Done in this PR so far.** Both guards now skip only where sonpy publishes no wheel (`platform != "win32" and this_python_version < version.parse("3.14")`). On the current CI matrix that means the reader is exercised on `windows-latest` Python 3.10-3.13 only.

**Still blocked on the Neo release (will land as follow-up commits on this branch):**
1. Bump `ecephys_minimal` from `neo>=0.14.5` to the first release that actually contains the #1890 fix (today's `0.14.5` floor does not).
2. Remove the temporary known-breakage `.. note::` from `docs/conversion_examples_gallery/recording/spike2.rst`.
3. Changelog entry for the full change.
4. Optional `sonpy>=1.9.12` floor, only if the Neo fix supports the new namespace alone (decision after reading the upstream PR diff).

**Verification.** Skip-side behavior is what Linux/macOS CI will show. Windows jobs will fail with `sonpy.lib` until the Neo bump lands; that is expected and is why this stays draft. Linux/macOS Python >=3.14 remains CI-untested (3.14 is not in the matrix).

Gate check once Neo publishes:

```bash
python - <<'EOF'
import io, json, urllib.request, zipfile
d = json.load(urllib.request.urlopen("https://pypi.org/pypi/neo/json"))
latest = d["info"]["version"]
url = next(u["url"] for u in d["releases"][latest] if u["filename"].endswith(".whl"))
src = zipfile.ZipFile(io.BytesIO(urllib.request.urlopen(url).read())).read("neo/rawio/cedrawio.py").decode()
print("latest neo:", latest)
print("cedrawio still references sonpy.lib:", "sonpy.lib" in src)
EOF
```
