### PR TITLE
Index the electrode group list in the metadata editing example

### DIFF
--- a/docs/user_guide/datainterfaces.rst
+++ b/docs/user_guide/datainterfaces.rst
@@ -146,7 +146,7 @@ We can add this information as follows:
 
 .. code-block:: python
 
-    metadata["Ecephys"]["ElectrodeGroup"]["location"] = "V1"
+    metadata["Ecephys"]["ElectrodeGroup"][0]["location"] = "V1"
 
 
 Use ``.get_metadata_schema()`` to get the schema of the metadata dictionary.


### PR DESCRIPTION
The metadata editing example in the user guide prints `ElectrodeGroup` as a list and the sentence above the snippet indexes it as one, but the snippet itself does not, so running it raises `TypeError: list indices must be integers or slices, not str`. This PR adds the missing index.
