### PR TITLE
Fix dev-dallies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Pose estimation now supports device model addition in their metadata. [PR #1961](https://github.com/catalystneuro/neuroconv/pull/1961)
 
 ## Improvements
+* `dimension`, `field_of_view`, `starting_frame`, `control` and `control_description` are named explicitly as array-valued metadata in the schema generator, so they stay in a generated metadata schema even where pynwb declares them the way it declares `data`, which its development branch now does and which was dropping them and failing every conversion that supplied one. [PR #1988](https://github.com/catalystneuro/neuroconv/pull/1988)
 * The YAML DANDI upload test appends the platform and Python version to its subject and session identifiers, the way the other DANDI upload tests already do, so two CI runs overlapping no longer replace each other's assets in the shared sandbox dandiset and fail with a 404. [PR #1986](https://github.com/catalystneuro/neuroconv/pull/1986)
 * The docker image tests run weekly instead of daily, matching the cadence at which the images they exercise are built, and their jobs now install `pytest-xdist`, without which the `--numprocesses` that [PR #1973](https://github.com/catalystneuro/neuroconv/pull/1973) moved into `addopts` failed them at argument parsing. [PR #1983](https://github.com/catalystneuro/neuroconv/pull/1983)
 * Added `MockExternalVideoInterface` [PR #1981](https://github.com/catalystneuro/neuroconv/pull/1981)

--- a/src/neuroconv/utils/json_schema.py
+++ b/src/neuroconv/utils/json_schema.py
@@ -364,6 +364,22 @@ def _is_member(types: type | tuple[type, ...], target_types: type | tuple[type, 
     return any(t in target_types for t in types)
 
 
+# Small array-valued metadata that must stay in the generated schema whatever pynwb declares for it.
+# The branch below infers "this is a bulk dataset, leave it out" from `DataIO` appearing among the
+# accepted types, since only bulk data is ever wrapped for chunked and compressed writing. pynwb's
+# development branch replaced the `collections.abc.Iterable` these fields used to declare, which was too
+# wide because it also accepted `str`, with the same explicit tuple that `data` and `timestamps` carry,
+# `DataIO` included. That reclassified a fixed-length pair of integers as bulk data. Nobody compresses a
+# frame size, so the signal carries no information for these and they are named instead of inferred.
+ARRAY_VALUED_METADATA_ARGUMENTS = (
+    "dimension",
+    "field_of_view",
+    "starting_frame",
+    "control",
+    "control_description",
+)
+
+
 def get_schema_from_hdmf_class(hdmf_class: type) -> dict[str, Any]:
     """
     Get metadata schema from hdmf class.
@@ -409,6 +425,8 @@ def get_schema_from_hdmf_class(hdmf_class: type) -> dict[str, Any]:
         elif _is_member(arg_type, str):
             schema_val.update(type="string")
         elif _is_member(arg_type, collections.abc.Iterable):
+            schema_val.update(type="array")
+        elif arg_name in ARRAY_VALUED_METADATA_ARGUMENTS:
             schema_val.update(type="array")
         elif isinstance(arg_type, tuple) and (np.ndarray in arg_type and hdmf.data_utils.DataIO not in arg_type):
             # extend type array without including type where DataIO in tuple

--- a/tests/test_minimal/test_utils/test_json_schema_utils.py
+++ b/tests/test_minimal/test_utils/test_json_schema_utils.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 import numpy as np
 import pytest
+from pynwb.image import ImageSeries
 from pynwb.ophys import ImagingPlane, TwoPhotonSeries
 
 from neuroconv.utils import (
@@ -233,6 +234,21 @@ def test_get_schema_from_TwoPhotonSeries_array_type():
     assert "data" not in two_photon_series_schema["properties"]
     assert "timestamps" not in two_photon_series_schema["properties"]
     assert "external_file" not in two_photon_series_schema["properties"]
+
+
+@pytest.mark.parametrize("hdmf_class", [ImageSeries, TwoPhotonSeries])
+def test_array_valued_metadata_survives_a_widened_type_declaration(hdmf_class):
+    """Small array-valued metadata stays in the schema even where pynwb declares it as `data` is declared.
+
+    Whether an argument accepts a `DataIO` is the generator's proxy for it being a bulk dataset. pynwb's
+    development branch widened these fields to the same declaration `data` carries, so the proxy stopped
+    separating them and every conversion supplying one failed validation.
+    """
+    schema = get_schema_from_hdmf_class(hdmf_class)
+
+    assert schema["properties"]["dimension"]["type"] == "array"
+    if hdmf_class is TwoPhotonSeries:
+        assert schema["properties"]["field_of_view"]["type"] == "array"
 
 
 def test_np_array_encoding():


### PR DESCRIPTION
Whether an argument accepts a `DataIO` is how `get_schema_from_hdmf_class` guesses that it is a bulk dataset rather than something a human writes into metadata, since only bulk data is ever wrapped for chunked and compressed writing, and pynwb's development branch has replaced the `collections.abc.Iterable` that `dimension`, `field_of_view`, `starting_frame`, `control` and `control_description` used to declare, too wide because it also accepted `str`, with the same explicit tuple that `data` and `timestamps` carry, which moved all five onto the wrong side of that guess and out of the generated schema so that the miniscope converter setting a frame size started failing validation on "Additional properties are not allowed". Naming them is deliberately duller than a cleverer type test: the signal we were reading was never a contract pynwb owed us, and on the released version it came from a type these declarations no longer contain, so there is nothing left to infer from. I included `control` to keep the generated schema identical to what a released pynwb produces rather than change two things at once, though it is one value per sample and a reasonable argument exists that it never belonged in a metadata schema.