### PR TITLE
Accept every installed HDF5 compression filter instead of a list frozen in source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Removed `get_device_metadata` from `spikeglx_utils`, deprecated since [PR #1599](https://github.com/catalystneuro/neuroconv/pull/1599) for removal on or after May 2026. Use `SpikeGLXRecordingInterface._get_device_metadata_from_probe()` instead.
 
 ## Bug Fixes
+* `HDF5DatasetIOConfiguration` accepts every compression filter installed rather than a list written out in its own source, which had frozen in June 2025 and so rejected the `Htj2k` filter that `hdf5plugin` 7.1.0 added while `AVAILABLE_HDF5_COMPRESSION_METHODS` went on reporting it as available. [PR #1998](https://github.com/catalystneuro/neuroconv/pull/1998)
 * `SLEAPInterface.get_available_tracks` now offers only the tracks carrying an instance, so one the tracking run left empty cannot be selected and no longer fails inside numpy. [PR #1993](https://github.com/catalystneuro/neuroconv/pull/1993)
 * `SLEAPInterface` now treats instances carrying no track as SLEAP does, writing a file where nothing is tracked as one individual and otherwise dropping them with a warning naming what was skipped, and raising where such a file holds several of them in one frame. [PR #1993](https://github.com/catalystneuro/neuroconv/pull/1993)
 * `DeepLabCutInterface` now excludes the landmark keypoints saved as "single". [PR #1992](https://github.com/catalystneuro/neuroconv/pull/1992)

--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_hdf5_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_hdf5_dataset_io.py
@@ -34,25 +34,11 @@ if is_package_installed(package_name="hdf5plugin"):
 class HDF5DatasetIOConfiguration(DatasetIOConfiguration):
     """A data model for configuring options about an object that will become a HDF5 Dataset in the file."""
 
+    # Built from the same dictionary the rest of the library reports as available, rather than spelled out
+    # here, so a filter a new hdf5plugin release adds is accepted instead of being announced as available
+    # and then rejected by this field.
     compression_method: (
-        Literal[
-            "szip",
-            "lzf",
-            "gzip",
-            "Bitshuffle",
-            "Blosc",
-            "Blosc2",
-            "BZip2",
-            "FciDecomp",
-            "LZ4",
-            "Sperr",
-            "SZ",
-            "SZ3",
-            "Zfp",
-            "Zstd",
-        ]
-        | InstanceOf[h5py._hl.filters.FilterRefBase]
-        | None
+        Literal[tuple(AVAILABLE_HDF5_COMPRESSION_METHODS.keys())] | InstanceOf[h5py._hl.filters.FilterRefBase] | None
     ) = Field(
         default="gzip",
         description=(

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_setting_global_compression.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_setting_global_compression.py
@@ -109,6 +109,11 @@ def create_test_nwbfile():
     return nwbfile
 
 
+# Filters that reject the float datasets written above, rather than compressing them badly: HTJ2K is a
+# JPEG 2000 image codec and only accepts integer datatypes, so the write fails inside HDF5 with
+# "Unsupported datatype class". Testing it needs a dataset of its own rather than a different expectation.
+HDF5_COMPRESSION_METHODS_WITHOUT_FLOAT_SUPPORT = {"Htj2k"}
+
 # We need this so that pytest-xdist can run tests in parallel without issues
 # Otherwise the order of the parameterized test is not deterministic and the
 # Different runners fail to find the same tests
@@ -121,6 +126,9 @@ class TestGlobalCompressionHDF5:
     @pytest.mark.parametrize("compression_method", sorted_hdf5_compression_methods)
     def test_global_compression_method_only(self, tmp_path, compression_method):
         """Test applying only global compression method without options using backend configuration."""
+        if compression_method in HDF5_COMPRESSION_METHODS_WITHOUT_FLOAT_SUPPORT:
+            pytest.skip(f"Compression method '{compression_method}' does not accept the float data written here")
+
         nwbfile = create_test_nwbfile()
         nwbfile_path = tmp_path / f"test_global_compression_{compression_method}.nwb"
 


### PR DESCRIPTION
While looking at why CI was failing on #1997 I found it was not that branch: `hdf5plugin` 7.1.0 landed this morning with a new `Htj2k` filter, and `HDF5DatasetIOConfiguration` rejects it because its `Literal` was spelled out by hand in #1379 while `AVAILABLE_HDF5_COMPRESSION_METHODS` right above it is computed from what is installed. This PR builds the field from that dictionary again, the way the Zarr model never stopped doing, and skips `Htj2k` in the compression test as the filter only accepts integer data.

