### PR TITLE
Write GuPPy's bootstrap PSTH significance results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixed the Zarr shuffle codec taking `numcodecs`' default `elementsize` of 4 regardless of the dataset's dtype, which on float64 grouped the wrong bytes and recovered almost nothing, so it is now taken from the dtype unless the caller states one. [PR #1984](https://github.com/catalystneuro/neuroconv/pull/1984)
 
 ## Features
+* `GuppyInterface` now writes the outputs of GuPPy's bootstrap PSTH significance testing as `ndx-guppy` `GuppyPSTHSignificance` objects: the estimate, both confidence bounds and the significance flags over the peri-event window, one object per (recording site, trace type, comparison kind), with the event pairs compared against each other kept separate from the tests against zero. It is written only for a session that ran that optional GuPPy step. [PR #2000](https://github.com/catalystneuro/neuroconv/pull/2000)
 * `HDF5DatasetIOConfiguration` and `ZarrDatasetIOConfiguration` now describe a dataset's codec pipeline with an ordered `compressors` list and a matching `compressor_options`, which makes the HDF5 `shuffle` and `fletcher32` filters reachable for the first time and gives both backends the same vocabulary. [PR #1979](https://github.com/catalystneuro/neuroconv/pull/1979)
 
 ## Improvements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,8 +342,7 @@ tdt_fp = [
 ]
 guppy = [
     "neuroconv[fiber_photometry_minimal]",
-    # Temporary: the GuppyPSTHSignificance type is not released yet. Swap to ">=0.2.1" once it is.
-    "ndx-guppy @ git+https://github.com/catalystneuro/ndx-guppy.git@psth_significance",
+    "ndx-guppy>=0.2.1",
     "tables",
     # Every acquisition format GuppyConverter can read, so one install covers a GuPPy session
     # whatever it was recorded on.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,7 +342,8 @@ tdt_fp = [
 ]
 guppy = [
     "neuroconv[fiber_photometry_minimal]",
-    "ndx-guppy>=0.2.0",
+    # Temporary: the GuppyPSTHSignificance type is not released yet. Swap to ">=0.2.1" once it is.
+    "ndx-guppy @ git+https://github.com/catalystneuro/ndx-guppy.git@psth_significance",
     "tables",
     # Every acquisition format GuppyConverter can read, so one install covers a GuPPy session
     # whatever it was recorded on.

--- a/src/neuroconv/datainterfaces/fiber_photometry/guppy/guppydatainterface.py
+++ b/src/neuroconv/datainterfaces/fiber_photometry/guppy/guppydatainterface.py
@@ -73,6 +73,7 @@ class GuppyInterface(BaseDataInterface):
     * peri-event PSTHs and peak / AUC summaries, including those GuPPy's spontaneous mode aligned to its
       own detected transients instead of to external TTLs
     * recording-site-pair cross-correlations
+    * bootstrap significance of the PSTHs, where that optional GuPPy step was run
     * whole-session time-binned metrics, and the behavioral covariates binned onto and correlated
       against them, where those optional GuPPy steps were run
     * per-epoch tonic means, where GuPPy's optional tonic analysis was run
@@ -205,6 +206,9 @@ class GuppyInterface(BaseDataInterface):
         peak_aucs = self._discover_peak_aucs(
             folder_path=folder_path, event_names=product_event_names, recording_sites=recording_sites
         )
+        psth_significance = self._discover_psth_significance(
+            folder_path=folder_path, event_names=product_event_names, recording_sites=recording_sites
+        )
         valid_signal_intervals_by_recording_site = self._discover_valid_signal_intervals(
             folder_path=folder_path, recording_sites=recording_sites
         )
@@ -241,6 +245,7 @@ class GuppyInterface(BaseDataInterface):
         self._cross_correlations = cross_correlations
         self._psths = psths
         self._peak_aucs = peak_aucs
+        self._psth_significance = psth_significance
         self._valid_signal_intervals_by_recording_site = valid_signal_intervals_by_recording_site
         self._covariate_to_store_id = covariate_to_store_id
         self._binned_tables_by_recording_site = binned_tables_by_recording_site
@@ -467,6 +472,62 @@ class GuppyInterface(BaseDataInterface):
         return entries
 
     @classmethod
+    def _discover_psth_significance(
+        cls, folder_path: Path, event_names: list[str], recording_sites: list[str]
+    ) -> list[dict]:
+        """Discover GuPPy PSTH significance files, absent unless the optional step ran.
+
+        GuPPy writes one table per comparison into ``psth_significance_output/``, named
+        ``significance_<event>_<recording_site>_<feature>_<recording_site>.h5`` for a test against zero
+        and ``significance_<event_a>_vs_<event_b>_<recording_site>_<feature>_<recording_site>.h5`` for a
+        comparison between two events. Expected names are constructed and checked on disk rather than
+        parsed, for the same reason the PSTHs are: event and recording_site names both contain
+        underscores, so ``_vs_`` is not a safe delimiter.
+
+        Every event is tested against zero; the pairs are whichever the user named, so both directions
+        are looked for. A comparison whose event has fewer than three trials is skipped by GuPPy rather
+        than written, so the entries here are a subset of the PSTHs'.
+        """
+        directory = folder_path / "psth_significance_output"
+        if not directory.is_dir():
+            return []
+
+        entries = []
+        for recording_site in recording_sites:
+            for feature in cls._TRANSIENT_FEATURES:
+                suffix = f"{recording_site}_{feature}_{recording_site}.h5"
+                for event in event_names:
+                    path = directory / f"significance_{event}_{suffix}"
+                    if path.is_file():
+                        entries.append(
+                            dict(
+                                path=path,
+                                event=event,
+                                event_b=None,
+                                recording_site=recording_site,
+                                feature=feature,
+                                paired=False,
+                            )
+                        )
+                for event_a in event_names:
+                    for event_b in event_names:
+                        if event_a == event_b:
+                            continue
+                        path = directory / f"significance_{event_a}_vs_{event_b}_{suffix}"
+                        if path.is_file():
+                            entries.append(
+                                dict(
+                                    path=path,
+                                    event=event_a,
+                                    event_b=event_b,
+                                    recording_site=recording_site,
+                                    feature=feature,
+                                    paired=True,
+                                )
+                            )
+        return entries
+
+    @classmethod
     def _discover_valid_signal_intervals(cls, folder_path: Path, recording_sites: list[str]) -> dict[str, np.ndarray]:
         """Return ``{recording_site: intervals_array}`` for each recording_site with a coords file.
 
@@ -674,8 +735,9 @@ class GuppyInterface(BaseDataInterface):
             removeArtifacts="remove_artifacts",
             useTransientsAsEvents="use_transients_as_events",
             computeBinnedMetrics="compute_binned_metrics",
+            computePsthSignificance="compute_psth_significance",
         )
-        int_keys = dict(bin_psth_trials="bin_psth_trials")
+        int_keys = dict(bin_psth_trials="bin_psth_trials", psthBootstrapResamples="psth_bootstrap_resamples")
         float_keys = dict(
             baselineWindowStart="baseline_window_start",
             baselineWindowEnd="baseline_window_end",
@@ -689,6 +751,7 @@ class GuppyInterface(BaseDataInterface):
             baselineCorrectionStart="baseline_correction_start",
             baselineCorrectionEnd="baseline_correction_end",
             binnedMetricsWidth="binned_metrics_width",
+            psthSignificanceAlpha="psth_significance_alpha",
         )
 
         kwargs = dict(name="guppy_parameters")
@@ -704,6 +767,20 @@ class GuppyInterface(BaseDataInterface):
         for json_key, attribute in float_keys.items():
             if parameters.get(json_key) is not None:
                 kwargs[attribute] = float(parameters[json_key])
+        # The comparison table is stored as two parallel lists and starts with one blank row, so a
+        # session that ran only the tests against zero leaves nothing to record. These are the pairs
+        # that were *requested*: one whose event had too few trials is skipped and appears in no product.
+        comparison_events_a = parameters.get("psthComparisonsA") or []
+        comparison_events_b = parameters.get("psthComparisonsB") or []
+        requested_pairs = [
+            (event_a.strip(), event_b.strip())
+            for event_a, event_b in zip(comparison_events_a, comparison_events_b)
+            # A blank row reaches the JSON as either "" or NaN, depending on how it was cleared.
+            if isinstance(event_a, str) and isinstance(event_b, str) and event_a.strip() and event_b.strip()
+        ]
+        if requested_pairs:
+            kwargs["psth_comparison_events_a"] = [event_a for event_a, _ in requested_pairs]
+            kwargs["psth_comparison_events_b"] = [event_b for _, event_b in requested_pairs]
         # GuPPy pads peak_startPoint/peak_endPoint to a fixed length with NaN; keep only the real windows.
         if parameters.get("peak_startPoint") is not None:
             start_points = np.asarray(parameters["peak_startPoint"], dtype=np.float64)
@@ -743,6 +820,11 @@ class GuppyInterface(BaseDataInterface):
     @staticmethod
     def _peak_auc_name(recording_site: str, feature: str) -> str:
         return f"peak_auc_{recording_site}_{feature}"
+
+    @staticmethod
+    def _psth_significance_name(recording_site: str, feature: str, paired: bool) -> str:
+        kind = "significance_paired" if paired else "significance"
+        return f"psth_{kind}_{recording_site}_{feature}"
 
     def get_metadata(self) -> DeepDict:
         """Return metadata pre-populated from the GuPPy outputs and parameters file."""
@@ -873,6 +955,23 @@ class GuppyInterface(BaseDataInterface):
                     "Descriptive correlation of each behavioral covariate against each per-bin GuPPy " "metric."
                 ),
             )
+        # PSTH significance is an optional GuPPy step, so its entries appear only for a session that ran
+        # it. The two comparison kinds are separate objects, so each gets its own entry.
+        if self._psth_significance:
+            psth_significance_metadata = {}
+            for recording_site, feature, paired in self._group_by_condition(
+                self._psth_significance, ("recording_site", "feature", "paired")
+            ):
+                name = self._psth_significance_name(recording_site, feature, paired)
+                against = "each other" if paired else "zero"
+                psth_significance_metadata[name] = dict(
+                    name=name,
+                    description=(
+                        f"Bootstrap significance of the '{feature}' PSTH for recording_site "
+                        f"'{recording_site}', testing event responses against {against}."
+                    ),
+                )
+            guppy_metadata["PSTHSignificance"] = psth_significance_metadata
         # Tonic analysis is an optional GuPPy step, so its entry appears only for a session that ran it.
         if self._tonic_epochs_by_recording_site:
             guppy_metadata["TonicEpochs"] = dict(
@@ -923,6 +1022,7 @@ class GuppyInterface(BaseDataInterface):
                 CrossCorrelations=named_collection,
                 PSTHs=named_collection,
                 PeakAUCs=named_collection,
+                PSTHSignificance=named_collection,
                 Events=named_object,
                 BinnedMetrics=named_object,
                 Covariates=named_collection,
@@ -955,7 +1055,8 @@ class GuppyInterface(BaseDataInterface):
         ``GuppyEventsTable`` registries, the per-product objects (traces, transients, summary,
         cross-correlation, PSTH, peak/AUC, binned metrics, binned covariates, covariate correlations) each
         referencing its registry rows, the ``GuppyValidSignalIntervals`` object, and, where GuPPy's optional
-        tonic analysis was run, the ``GuppyTonicEpochs`` object. Products are written on the timestamps
+        tonic analysis and PSTH significance testing were run, the ``GuppyTonicEpochs`` and
+        ``GuppyPSTHSignificance`` objects. Products are written on the timestamps
         GuPPy emits. Each behavioral covariate's scored values are written as a ``TimeSeries`` that the two
         covariate products reference.
 
@@ -1119,6 +1220,94 @@ class GuppyInterface(BaseDataInterface):
             events_table=events_table,
             bin_basis=bin_basis,
         )
+
+        # PSTH significance: one GuppyPSTHSignificance per (recording_site, trace_type, comparison kind),
+        # written only for a session that ran that optional GuPPy step.
+        if self._psth_significance:
+            self._add_guppy_psth_significance_to_nwbfile(
+                ndx_guppy=ndx_guppy,
+                processing_module=processing_module,
+                psth_significance_metadata=guppy_metadata["PSTHSignificance"],
+                recording_sites_table=recording_sites_table,
+                events_table=events_table,
+            )
+
+    def _add_guppy_psth_significance_to_nwbfile(
+        self,
+        *,
+        ndx_guppy,
+        processing_module,
+        psth_significance_metadata: dict,
+        recording_sites_table,
+        events_table,
+    ) -> None:
+        """Add one GuppyPSTHSignificance per (recording_site, trace_type, comparison kind).
+
+        Each comparison's table is one row per timepoint over the PSTH's own peri-event axis, so the
+        comparisons of one condition stack into ``(num_samples, num_comparisons)`` matrices. The two
+        comparison kinds are separate objects: the event-versus-event one additionally carries the
+        ``event_b`` region and ``num_trials_b``, which is what distinguishes it, mirroring the ``n_b``
+        column that distinguishes the two kinds on disk.
+        """
+        significance_groups = self._group_by_condition(self._psth_significance, ("recording_site", "feature", "paired"))
+        for (recording_site, feature, paired), entries in significance_groups.items():
+            entry_metadata = psth_significance_metadata[self._psth_significance_name(recording_site, feature, paired)]
+
+            axis = None
+            estimate_columns: list[np.ndarray] = []
+            lower_columns: list[np.ndarray] = []
+            upper_columns: list[np.ndarray] = []
+            significant_columns: list[np.ndarray] = []
+            num_trials: list[int] = []
+            num_trials_b: list[int] = []
+            event_names: list[str] = []
+            event_b_names: list[str] = []
+
+            for entry in entries:
+                dataframe = pandas.read_hdf(entry["path"])
+
+                comparison_axis = dataframe["timestamps"].to_numpy(dtype=np.float64)
+                if axis is None:
+                    axis = comparison_axis
+                else:
+                    assert np.array_equal(axis, comparison_axis), (
+                        f"GuPPy significance files for one condition must share an identical peri-event "
+                        f"axis to be concatenated across comparisons, but '{entry['path'].name}' differs."
+                    )
+
+                estimate_columns.append(dataframe["estimate"].to_numpy(dtype=np.float64))
+                lower_columns.append(dataframe["ci_lower"].to_numpy(dtype=np.float64))
+                upper_columns.append(dataframe["ci_upper"].to_numpy(dtype=np.float64))
+                significant_columns.append(dataframe["significant"].to_numpy(dtype=bool))
+                # alpha and n are constant down a file's rows.
+                num_trials.append(int(dataframe["n"].iloc[0]))
+                event_names.append(entry["event"])
+                if paired:
+                    num_trials_b.append(int(dataframe["n_b"].iloc[0]))
+                    event_b_names.append(entry["event_b"])
+
+            significance_kwargs = dict(
+                name=entry_metadata["name"],
+                description=entry_metadata["description"],
+                trace_type=feature,
+                unit="a.u.",
+                recording_site=self._recording_site_reference(recording_sites_table, [recording_site]),
+                event=self._event_reference(events_table, event_names, recording_site=recording_site),
+                peri_event_time=axis,
+                estimate=np.stack(estimate_columns, axis=1),
+                confidence_interval_lower=np.stack(lower_columns, axis=1),
+                confidence_interval_upper=np.stack(upper_columns, axis=1),
+                significant=np.stack(significant_columns, axis=1),
+                num_trials=np.array(num_trials, dtype=np.int32),
+            )
+            if paired:
+                significance_kwargs.update(
+                    event_b=self._event_reference(
+                        events_table, event_b_names, name="event_b", recording_site=recording_site
+                    ),
+                    num_trials_b=np.array(num_trials_b, dtype=np.int32),
+                )
+            processing_module.add(ndx_guppy.GuppyPSTHSignificance(**significance_kwargs))
 
     def _recording_site_reference(self, recording_sites_table, recording_site_names: list[str]) -> DynamicTableRegion:
         """Build a DynamicTableRegion into the GuppyRecordingSitesTable for the given recording_site name(s)."""

--- a/src/neuroconv/tools/testing/mock_guppy.py
+++ b/src/neuroconv/tools/testing/mock_guppy.py
@@ -40,6 +40,10 @@ _DEFAULT_COVARIATES = {"akinesia": ((1.1, 1.6, 1.7, 2.6), (2.0, 3.0, 4.0, 5.0))}
 # Detected transient times, shared by transientsOccurrences_*, the per-bin counts, and the
 # spontaneous-mode event trains.
 _TRANSIENT_PEAK_TIMES = (1.2, 1.5, 1.8, 2.5)
+# Sentinel default for ``psth_comparisons``: pair the session's own first two events, so the default
+# holds for any topology a caller passes rather than only for the default event names. GuPPy tests
+# every event against zero on its own; which two events are worth contrasting is the part a user names.
+_PAIR_THE_FIRST_TWO_EVENTS = "first_two_events"
 # Seconds of raw recording GuPPy's lights-on trim discards before analysis (its default).
 _TIME_FOR_LIGHTS_TURN_ON = 1.0
 
@@ -65,6 +69,7 @@ def generate_mock_guppy_output_folder(
     tonic_epochs: tuple[tuple[str, float, float], ...] = (("baseline", 1.0, 2.0), ("post_injection", 2.0, 3.0)),
     bin_size_in_trials: int = 3,
     use_transients_as_events: bool = False,
+    psth_comparisons: tuple[tuple[str, str], ...] | str | None = _PAIR_THE_FIRST_TWO_EVENTS,
     guppy_version: str = "2.0.0a7",
     zscore_method: str = "standard z-score",
 ) -> Path:
@@ -137,6 +142,13 @@ def generate_mock_guppy_output_folder(
         site), holding a *subset* of that site's detected transients, since trial rejection drops some;
         the two recording sites keep different subsets, as two sites detecting their own transients
         would. Every peri-event product is then emitted for those events as well.
+    psth_comparisons : tuple of (str, str), optional
+        The event pairs GuPPy's optional PSTH significance step compares against each other. Three
+        states: ``None`` means the step did not run, so no ``psth_significance_output/`` directory is
+        written at all; ``()`` runs only the tests against zero, which GuPPy does for every event
+        automatically; and a tuple of pairs adds an event-versus-event comparison for each. Every
+        comparison is written once per (recording site, feature). Defaults to pairing the session's own
+        first two events, so the default holds whatever ``event_store_to_name`` names them.
     guppy_version, zscore_method : str, optional
         Provenance values written to ``GuPPyParamtersUsed.json``.
 
@@ -164,6 +176,8 @@ def generate_mock_guppy_output_folder(
     covariates = covariates if covariates is not None else _DEFAULT_COVARIATES
     recording_sites = list(recording_site_to_stores)
     event_names = list(event_store_to_name.values())
+    if psth_comparisons == _PAIR_THE_FIRST_TWO_EVENTS:
+        psth_comparisons = (tuple(event_names[:2]),) if len(event_names) >= 2 else ()
 
     # Raw store timebase, session-relative and starting at 0.0. The lights-on trim drops its leading
     # second; ``num_samples`` counts what survives, so every downstream array keeps that length.
@@ -210,6 +224,7 @@ def generate_mock_guppy_output_folder(
         remove_artifacts=bool(valid_signal_intervals),
         use_transients_as_events=use_transients_as_events,
         bin_width=bin_width,
+        psth_comparisons=psth_comparisons,
     )
 
     for recording_site in recording_sites:
@@ -280,6 +295,39 @@ def generate_mock_guppy_output_folder(
                     bin_edges=bin_edges,
                     num_windows=len(peak_start_points),
                 )
+
+    if psth_comparisons is not None:
+        # GuPPy tests every event against zero automatically and each named pair against each other, once
+        # per recording site and metric. Trial counts differ per event, so each comparison's n differs.
+        comparison_index = 0
+        for recording_site in recording_sites:
+            for feature in features:
+                for event_name in event_names:
+                    _write_psth_significance(
+                        folder_path,
+                        event=event_name,
+                        event_b=None,
+                        recording_site=recording_site,
+                        feature=feature,
+                        peri_event_time=peri_event_time,
+                        num_trials=len(event_name_to_onsets[event_name]),
+                        num_trials_b=None,
+                        offset=0.1 * comparison_index,
+                    )
+                    comparison_index += 1
+                for event_a, event_b in psth_comparisons:
+                    _write_psth_significance(
+                        folder_path,
+                        event=event_a,
+                        event_b=event_b,
+                        recording_site=recording_site,
+                        feature=feature,
+                        peri_event_time=peri_event_time,
+                        num_trials=len(event_name_to_onsets[event_a]),
+                        num_trials_b=len(event_name_to_onsets[event_b]),
+                        offset=0.1 * comparison_index,
+                    )
+                    comparison_index += 1
 
     if use_transients_as_events:
         # Each recording site stands its own detected transients in for the TTLs, keeping the subset that
@@ -391,6 +439,7 @@ def _write_parameters(
     remove_artifacts,
     use_transients_as_events,
     bin_width,
+    psth_comparisons,
 ) -> None:
     """``GuPPyParamtersUsed.json`` written via ``json.dump``.
 
@@ -427,6 +476,13 @@ def _write_parameters(
         useTransientsAsEvents=use_transients_as_events,
         computeBinnedMetrics=bin_width is not None,
         binnedMetricsWidth=bin_width if bin_width is not None else 60.0,
+        computePsthSignificance=psth_comparisons is not None,
+        # The comparison table is two parallel lists, and it is empty when only the tests against zero
+        # were run. A blank row reaches the JSON as "", which the interface drops.
+        psthComparisonsA=[event_a for event_a, _ in psth_comparisons or ()] or [""],
+        psthComparisonsB=[event_b for _, event_b in psth_comparisons or ()] or [""],
+        psthSignificanceAlpha=0.05,
+        psthBootstrapResamples=1000,
     )
     with open(folder_path / "GuPPyParamtersUsed.json", "w", encoding="utf-8") as parameters_file:
         json.dump(parameters, parameters_file, indent=4)
@@ -671,6 +727,57 @@ def _write_psth(
     filename = f"{event}_{recording_site}_{suffix}{feature}_{recording_site}.h5"
     dataframe = _event_matrix_dataframe(peri_event_time, trial_onsets, bin_edges)
     dataframe.to_hdf(folder_path / filename, key="df", mode="w")
+
+
+def _significance_dataframe(axis, num_trials, num_trials_b, offset) -> pandas.DataFrame:
+    """Build the shared PSTH significance DataFrame layout, one row per timepoint.
+
+    Columns: ``timestamps``, ``estimate``, ``ci_lower``, ``ci_upper``, ``significant``, ``alpha``, ``n``
+    -- plus ``n_b`` for a two-event comparison, which is what tells the two kinds apart on disk. The
+    interval straddles zero over the first half of the window and clears it over the second, so the
+    significance flags are not constant; the second timepoint's interval is NaN, the case GuPPy reports
+    where too few trials overlap to resample.
+
+    ``offset`` shifts the whole comparison, so no two comparisons of one session carry the same values
+    and a column mix-up cannot pass.
+    """
+    num_points = axis.shape[0]
+    estimate = np.linspace(-0.5, 1.5, num_points) + offset
+    lower = estimate - 0.25
+    upper = estimate + 0.25
+    lower[1] = np.nan
+    upper[1] = np.nan
+    data = {
+        "timestamps": axis,
+        "estimate": estimate,
+        "ci_lower": lower,
+        "ci_upper": upper,
+        # A NaN interval cannot exclude zero, so that timepoint is reported as not significant.
+        "significant": np.where(np.isfinite(lower) & (lower > 0.0), 1, 0),
+        "alpha": np.full(num_points, 0.05),
+        "n": np.full(num_points, num_trials, dtype=int),
+    }
+    if num_trials_b is not None:
+        data["n_b"] = np.full(num_points, num_trials_b, dtype=int)
+    return pandas.DataFrame(data)
+
+
+def _write_psth_significance(
+    folder_path, event, event_b, recording_site, feature, peri_event_time, num_trials, num_trials_b, offset
+) -> None:
+    """Significance ``.h5`` and ``.csv`` -- ``psth_significance_output/significance_<comparison>.h5``.
+
+    The comparison stem is the PSTH's own stem, ``<event>_<recording_site>_<feature>_<recording_site>``,
+    with the two events joined by ``_vs_`` for an event-versus-event comparison. The ``.csv`` twin holds
+    the same table, written without the index.
+    """
+    directory = folder_path / "psth_significance_output"
+    directory.mkdir(exist_ok=True)
+    events = event if event_b is None else f"{event}_vs_{event_b}"
+    stem = f"significance_{events}_{recording_site}_{feature}_{recording_site}"
+    dataframe = _significance_dataframe(peri_event_time, num_trials, num_trials_b, offset)
+    dataframe.to_hdf(directory / f"{stem}.h5", key="df", mode="w")
+    dataframe.to_csv(directory / f"{stem}.csv", index=False)
 
 
 def _write_cross_correlation(

--- a/tests/test_modalities/test_guppy/test_guppy_interface.py
+++ b/tests/test_modalities/test_guppy/test_guppy_interface.py
@@ -58,6 +58,17 @@ TONIC_EPOCHS = [("baseline", 1.0, 2.0), ("post_injection", 2.0, 3.0)]
 MOCK_TRIAL_ONSETS = [10.0, 20.0, 30.0, 40.0]
 # The generator's default significance comparison, the one pair tested against each other.
 PSTH_COMPARISON = ("rewarded_nose_pokes", "unrewarded_nose_pokes")
+# The smallest session the generator will write: one site, one event, no optional products. The
+# significance tests that assert on an *absence* need nothing the rest of the topology provides.
+MINIMAL_SESSION = dict(
+    recording_site_to_stores={"dms": {"signal": "Dv2A", "control": "Dv1A"}},
+    event_store_to_name={"PrtR": "port_entries"},
+    cross_correlation_pairs=(),
+    bin_width=None,
+    covariates={},
+    tonic_epochs=(),
+    num_psth_timepoints=5,
+)
 
 
 class TestExtractBins:
@@ -172,7 +183,15 @@ class TestGuppyInterfaceBehavior:
         derived unit ever leak into the metadata.
         """
         guppy_metadata = interface.get_metadata()["FiberPhotometry"]["Guppy"][interface.metadata_key]
-        for family in ("Traces", "Transients", "CrossCorrelations", "PSTHs", "PeakAUCs", "Covariates"):
+        for family in (
+            "Traces",
+            "Transients",
+            "CrossCorrelations",
+            "PSTHs",
+            "PeakAUCs",
+            "Covariates",
+            "PSTHSignificance",
+        ):
             for name, entry in guppy_metadata[family].items():
                 assert set(entry.keys()) == {"name", "description"}, (family, entry)
                 assert entry["name"] == name
@@ -520,20 +539,23 @@ class TestGuppyInterfaceBehavior:
 
     @pytest.fixture(scope="class")
     @classmethod
-    def significance_output_folder(cls, tmp_path_factory):
-        """A significance session with a five-point PSTH window, so every value is hand-checkable."""
-        return generate_mock_guppy_output_folder(
+    def significance_nwbfile(cls, tmp_path_factory):
+        """One written file for the significance assertions, which only read it.
+
+        A five-point PSTH window keeps every value hand-checkable, and writing once keeps the three
+        assertions below from paying for three full conversions of the same session.
+        """
+        folder_path = generate_mock_guppy_output_folder(
             tmp_path_factory.mktemp("guppy_significance") / "guppy_output", num_psth_timepoints=5
         )
+        interface = GuppyInterface(folder_path=str(folder_path))
+        nwbfile = mock_NWBFile()
+        interface.add_to_nwbfile(nwbfile, interface.get_metadata(), stub_test=False)
+        return nwbfile
 
-    @pytest.fixture
-    def significance_interface(self, significance_output_folder):
-        return GuppyInterface(folder_path=str(significance_output_folder))
-
-    def test_psth_significance_stacks_every_comparison_of_one_condition(self, significance_interface, nwbfile):
+    def test_psth_significance_stacks_every_comparison_of_one_condition(self, significance_nwbfile):
         """The tests against zero of one (recording site, feature) are the columns of one object."""
-        module = self.add_to_nwbfile(significance_interface, nwbfile, stub_test=False)
-        significance = module["psth_significance_dms_z_score"]
+        significance = significance_nwbfile.processing["guppy"]["psth_significance_dms_z_score"]
         assert significance.neurodata_type == "GuppyPSTHSignificance"
         assert significance.trace_type == "z_score"
 
@@ -569,10 +591,9 @@ class TestGuppyInterfaceBehavior:
         assert significance.event_b is None
         assert significance.num_trials_b is None
 
-    def test_paired_psth_significance_names_both_events(self, significance_interface, nwbfile):
+    def test_paired_psth_significance_names_both_events(self, significance_nwbfile):
         """An event-versus-event comparison is its own object, naming event A and event B per column."""
-        module = self.add_to_nwbfile(significance_interface, nwbfile, stub_test=False)
-        paired = module["psth_significance_paired_dms_z_score"]
+        paired = significance_nwbfile.processing["guppy"]["psth_significance_paired_dms_z_score"]
 
         event_names = list(paired.event.table["event_name"].data)
         assert [event_names[index] for index in paired.event.data] == [PSTH_COMPARISON[0]]
@@ -582,12 +603,11 @@ class TestGuppyInterfaceBehavior:
         # The estimate is A minus B, on its own offset, so it is not a copy of either one-sample column.
         np.testing.assert_allclose(paired.estimate[:, 0], [-0.2, 0.3, 0.8, 1.3, 1.8], atol=1e-6)
 
-    def test_psth_significance_covers_every_recording_site_and_feature(self, significance_interface, nwbfile):
+    def test_psth_significance_covers_every_recording_site_and_feature(self, interface):
         """One object per (recording site, feature, comparison kind), and no others."""
-        module = self.add_to_nwbfile(significance_interface, nwbfile, stub_test=False)
+        guppy_metadata = interface.get_metadata()["FiberPhotometry"]["Guppy"][interface.metadata_key]
 
-        written = sorted(name for name in module.data_interfaces if name.startswith("psth_significance"))
-        assert written == sorted(
+        assert sorted(guppy_metadata["PSTHSignificance"]) == sorted(
             f"psth_significance{'_paired' if paired else ''}_{recording_site}_{feature}"
             for recording_site in RECORDING_SITES
             for feature in ["z_score", "dff"]
@@ -597,7 +617,7 @@ class TestGuppyInterfaceBehavior:
     def test_no_psth_significance_writes_no_objects(self, tmp_path, nwbfile):
         """A session that never ran the optional step has no output directory, so no object."""
         folder_path = generate_mock_guppy_output_folder(
-            tmp_path / "guppy_output_no_significance", psth_comparisons=None
+            tmp_path / "guppy_output_no_significance", psth_comparisons=None, **MINIMAL_SESSION
         )
         interface = GuppyInterface(folder_path=str(folder_path))
 
@@ -609,7 +629,9 @@ class TestGuppyInterfaceBehavior:
 
     def test_significance_without_named_pairs_writes_only_the_tests_against_zero(self, tmp_path, nwbfile):
         """Testing against zero needs no configuration, so it runs even with an empty comparison table."""
-        folder_path = generate_mock_guppy_output_folder(tmp_path / "guppy_output_zero_only", psth_comparisons=())
+        folder_path = generate_mock_guppy_output_folder(
+            tmp_path / "guppy_output_zero_only", psth_comparisons=(), **MINIMAL_SESSION
+        )
         interface = GuppyInterface(folder_path=str(folder_path))
 
         module = self.add_to_nwbfile(interface, nwbfile, stub_test=True)
@@ -621,10 +643,9 @@ class TestGuppyInterfaceBehavior:
         assert parameters.psth_comparison_events_a is None
         assert parameters.psth_comparison_events_b is None
 
-    def test_psth_significance_parameters_land_on_guppy_parameters(self, significance_interface, nwbfile):
+    def test_psth_significance_parameters_land_on_guppy_parameters(self, significance_nwbfile):
         """The threshold, the resample count, and the pairs that were asked for."""
-        self.add_to_nwbfile(significance_interface, nwbfile, stub_test=True)
-        parameters = nwbfile.lab_meta_data["guppy_parameters"]
+        parameters = significance_nwbfile.lab_meta_data["guppy_parameters"]
 
         assert parameters.compute_psth_significance
         assert parameters.psth_significance_alpha == 0.05

--- a/tests/test_modalities/test_guppy/test_guppy_interface.py
+++ b/tests/test_modalities/test_guppy/test_guppy_interface.py
@@ -33,6 +33,8 @@ SESSION = "Photo_249_391-200721-120136"
 # The mock topology: two recording sites, three events, two features, num_trials=4 binned three to a bin.
 RECORDING_SITES = ["dms", "dls"]
 EVENT_NAMES = ["rewarded_nose_pokes", "unrewarded_nose_pokes", "port_entries"]
+# The order the events registry puts them in, which every per-event column follows.
+EVENT_NAMES_IN_REGISTRY_ORDER = ["port_entries", "rewarded_nose_pokes", "unrewarded_nose_pokes"]
 TRACE_PREFIXES = ["cntrl_sig_fit", "dff", "z_score"]
 MOCK_SAMPLING_RATE = 200.0
 MOCK_STARTING_TIME = 1.0
@@ -54,6 +56,8 @@ TONIC_EPOCHS = [("baseline", 1.0, 2.0), ("post_injection", 2.0, 3.0)]
 # The generator's default onsets, shared by every event: they label the trial columns of every
 # peri-event product and fill <event>_<recording_site>.hdf5.
 MOCK_TRIAL_ONSETS = [10.0, 20.0, 30.0, 40.0]
+# The generator's default significance comparison, the one pair tested against each other.
+PSTH_COMPARISON = ("rewarded_nose_pokes", "unrewarded_nose_pokes")
 
 
 class TestExtractBins:
@@ -511,6 +515,122 @@ class TestGuppyInterfaceBehavior:
 
         with pytest.raises(AssertionError, match="tonic outputs for recording site"):
             GuppyInterface(folder_path=str(copied_folder))
+
+    # ------------------------------------------------------------------ PSTH significance
+
+    @pytest.fixture(scope="class")
+    @classmethod
+    def significance_output_folder(cls, tmp_path_factory):
+        """A significance session with a five-point PSTH window, so every value is hand-checkable."""
+        return generate_mock_guppy_output_folder(
+            tmp_path_factory.mktemp("guppy_significance") / "guppy_output", num_psth_timepoints=5
+        )
+
+    @pytest.fixture
+    def significance_interface(self, significance_output_folder):
+        return GuppyInterface(folder_path=str(significance_output_folder))
+
+    def test_psth_significance_stacks_every_comparison_of_one_condition(self, significance_interface, nwbfile):
+        """The tests against zero of one (recording site, feature) are the columns of one object."""
+        module = self.add_to_nwbfile(significance_interface, nwbfile, stub_test=False)
+        significance = module["psth_significance_dms_z_score"]
+        assert significance.neurodata_type == "GuppyPSTHSignificance"
+        assert significance.trace_type == "z_score"
+
+        event_names = list(significance.event.table["event_name"].data)
+        assert [event_names[index] for index in significance.event.data] == EVENT_NAMES_IN_REGISTRY_ORDER
+        recording_site_names = list(significance.recording_site.table["recording_site"].data)
+        assert [recording_site_names[index] for index in significance.recording_site.data] == ["dms"]
+
+        # The mock's window is linspace(-5, 10, 5) and each comparison's estimate is a
+        # linspace(-0.5, 1.5, 5) ramp shifted by a per-comparison offset, so no two columns agree.
+        # The columns are ordered by the events registry, which is why port_entries leads.
+        np.testing.assert_allclose(significance.peri_event_time, [-5.0, -1.25, 2.5, 6.25, 10.0])
+        np.testing.assert_allclose(
+            significance.estimate,
+            [[-0.3, -0.5, -0.4], [0.2, 0.0, 0.1], [0.7, 0.5, 0.6], [1.2, 1.0, 1.1], [1.7, 1.5, 1.6]],
+            atol=1e-6,
+        )
+        # The bounds sit a quarter either side of the estimate, except at the one timepoint where too
+        # few trials overlapped to resample, which GuPPy reports as a NaN interval.
+        np.testing.assert_allclose(significance.confidence_interval_lower[0], [-0.55, -0.75, -0.65], atol=1e-6)
+        np.testing.assert_allclose(significance.confidence_interval_upper[0], [-0.05, -0.25, -0.15], atol=1e-6)
+        assert np.all(np.isnan(significance.confidence_interval_lower[1]))
+        assert np.all(np.isnan(significance.confidence_interval_upper[1]))
+
+        # A NaN interval cannot exclude zero, so that timepoint is not significant.
+        np.testing.assert_array_equal(
+            significance.significant,
+            [[False] * 3, [False] * 3, [True] * 3, [True] * 3, [True] * 3],
+        )
+        np.testing.assert_array_equal(significance.num_trials, [len(MOCK_TRIAL_ONSETS)] * len(EVENT_NAMES))
+
+        # Nothing was tested against a second event here, so there is no second event to name.
+        assert significance.event_b is None
+        assert significance.num_trials_b is None
+
+    def test_paired_psth_significance_names_both_events(self, significance_interface, nwbfile):
+        """An event-versus-event comparison is its own object, naming event A and event B per column."""
+        module = self.add_to_nwbfile(significance_interface, nwbfile, stub_test=False)
+        paired = module["psth_significance_paired_dms_z_score"]
+
+        event_names = list(paired.event.table["event_name"].data)
+        assert [event_names[index] for index in paired.event.data] == [PSTH_COMPARISON[0]]
+        assert [event_names[index] for index in paired.event_b.data] == [PSTH_COMPARISON[1]]
+        np.testing.assert_array_equal(paired.num_trials, [len(MOCK_TRIAL_ONSETS)])
+        np.testing.assert_array_equal(paired.num_trials_b, [len(MOCK_TRIAL_ONSETS)])
+        # The estimate is A minus B, on its own offset, so it is not a copy of either one-sample column.
+        np.testing.assert_allclose(paired.estimate[:, 0], [-0.2, 0.3, 0.8, 1.3, 1.8], atol=1e-6)
+
+    def test_psth_significance_covers_every_recording_site_and_feature(self, significance_interface, nwbfile):
+        """One object per (recording site, feature, comparison kind), and no others."""
+        module = self.add_to_nwbfile(significance_interface, nwbfile, stub_test=False)
+
+        written = sorted(name for name in module.data_interfaces if name.startswith("psth_significance"))
+        assert written == sorted(
+            f"psth_significance{'_paired' if paired else ''}_{recording_site}_{feature}"
+            for recording_site in RECORDING_SITES
+            for feature in ["z_score", "dff"]
+            for paired in (False, True)
+        )
+
+    def test_no_psth_significance_writes_no_objects(self, tmp_path, nwbfile):
+        """A session that never ran the optional step has no output directory, so no object."""
+        folder_path = generate_mock_guppy_output_folder(
+            tmp_path / "guppy_output_no_significance", psth_comparisons=None
+        )
+        interface = GuppyInterface(folder_path=str(folder_path))
+
+        guppy_metadata = interface.get_metadata()["FiberPhotometry"]["Guppy"][interface.metadata_key]
+        assert "PSTHSignificance" not in guppy_metadata
+
+        module = self.add_to_nwbfile(interface, nwbfile, stub_test=True)
+        assert not [name for name in module.data_interfaces if name.startswith("psth_significance")]
+
+    def test_significance_without_named_pairs_writes_only_the_tests_against_zero(self, tmp_path, nwbfile):
+        """Testing against zero needs no configuration, so it runs even with an empty comparison table."""
+        folder_path = generate_mock_guppy_output_folder(tmp_path / "guppy_output_zero_only", psth_comparisons=())
+        interface = GuppyInterface(folder_path=str(folder_path))
+
+        module = self.add_to_nwbfile(interface, nwbfile, stub_test=True)
+        assert "psth_significance_dms_z_score" in module.data_interfaces
+        assert "psth_significance_paired_dms_z_score" not in module.data_interfaces
+
+        parameters = nwbfile.lab_meta_data["guppy_parameters"]
+        # The blank row GuPPy's comparison table starts with is not a requested pair.
+        assert parameters.psth_comparison_events_a is None
+        assert parameters.psth_comparison_events_b is None
+
+    def test_psth_significance_parameters_land_on_guppy_parameters(self, significance_interface, nwbfile):
+        """The threshold, the resample count, and the pairs that were asked for."""
+        self.add_to_nwbfile(significance_interface, nwbfile, stub_test=True)
+        parameters = nwbfile.lab_meta_data["guppy_parameters"]
+
+        assert parameters.compute_psth_significance
+        assert parameters.psth_significance_alpha == 0.05
+        assert parameters.psth_bootstrap_resamples == 1000
+        assert list(parameters.psth_comparison_events_a) == [PSTH_COMPARISON[0]]
+        assert list(parameters.psth_comparison_events_b) == [PSTH_COMPARISON[1]]
 
     def test_cross_correlation_without_bin_columns(self, guppy_output_folder, tmp_path, nwbfile):
         """A GuPPy run with binning disabled writes no bin_ columns, so the bin fields stay unset."""


### PR DESCRIPTION

<details>
<summary>Details (AI-generated)</summary>

`GuppyInterface` now reads the outputs of GuPPy's bootstrap PSTH significance testing ([LernerLab/GuPPy#453](https://github.com/LernerLab/GuPPy/pull/453)) — the per-comparison tables in `psth_significance_output/` — and writes them as the `GuppyPSTHSignificance` object added in [ndx-guppy#9](https://github.com/catalystneuro/ndx-guppy/pull/9), one object per (recording site, trace type, comparison kind). The tests against zero and the event pairs compared against each other are separate objects, the latter carrying `event_b` and `num_trials_b`, mirroring the `n_b` column that distinguishes the two kinds on disk. It is an optional GuPPy step, so the objects and their metadata entries appear only for a session that ran it.

Filenames are constructed from the known (event, recording site, feature) tuples and checked on disk rather than parsed, the way the PSTHs already are: event and recording site names both contain underscores, so `_vs_` is not a safe delimiter. The alpha, the resample count and the requested comparison pairs are carried onto `GuppyParameters` — the pairs record what was *asked for*, since a comparison whose event had fewer than three trials is skipped by GuPPy and would otherwise appear nowhere in the file.

`generate_mock_guppy_output_folder` gained `psth_comparisons`, defaulting to pairing the session's own first two events so it holds for any topology a caller passes; `None` writes no output directory at all and `()` writes only the tests against zero. Each comparison is given distinct values, so a column mix-up cannot pass.

This pins the ndx-guppy branch so CI exercises the new type; it becomes `ndx-guppy>=0.2.1` once that is released.

Verification: `pytest tests/test_modalities/test_guppy tests/test_on_data/fiber_photometry/guppy` — 123 passed. The reference-session fixture predates the feature, so its expected module contents are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>