### PR TITLE
More zarr v3 forward compatibility, and fix the wrong shuffle expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # v0.10.2 (Upcoming)
 
 ## Removals, Deprecations and Changes
-* `ZarrDatasetIOConfiguration.filter_methods` is renamed to `filters`, with the old name deprecated for removal in v0.12.0, so a dataset's codec stages are named the way `zarr.Array` names them: `filters` for the codecs applied to the values and `compressors` for those applied to the bytes they serialize to. [PR #2000](https://github.com/catalystneuro/neuroconv/pull/2000)
-* Naming `shuffle` in a `ZarrDatasetIOConfiguration`'s `filters` is deprecated, to be removed in v0.12.0, and `shuffle` no longer appears in `AVAILABLE_ZARR_COMPRESSION_METHODS`, since it rearranges the serialized bytes rather than the values and so belongs in `compressors` beside the compression method. [PR #2000](https://github.com/catalystneuro/neuroconv/pull/2000)
+* `ZarrDatasetIOConfiguration.filter_methods` is renamed to `filters`, with the old name deprecated for removal in v0.12.0, so a dataset's codec stages are named the way `zarr.Array` names them: `filters` for the codecs applied to the values and `compressors` for those applied to the bytes they serialize to. [PR #2002](https://github.com/catalystneuro/neuroconv/pull/2002)
+* Naming `shuffle` in a `ZarrDatasetIOConfiguration`'s `filters` is deprecated, to be removed in v0.12.0, and `shuffle` no longer appears in `AVAILABLE_ZARR_COMPRESSION_METHODS`, since it rearranges the serialized bytes rather than the values and so belongs in `compressors` beside the compression method. [PR #2002](https://github.com/catalystneuro/neuroconv/pull/2002)
 * A `timestamps` dataset is now written with the lossless shuffle filter ahead of its compression method, which on two million irregular float64 timestamps takes 11.75 MB down to 7.51 MB on HDF5 and 11.62 MB down to 7.62 MB on Zarr at the same chunk shape and compression level, leaving `data` untouched. [PR #1984](https://github.com/catalystneuro/neuroconv/pull/1984)
 * Deprecated `compression_method` and `compression_options` on both dataset IO configuration models, and the single-valued form of `BackendConfiguration.apply_global_compression`, to be removed in v0.12.0, in favor of `compressors` and `compressor_options`. [PR #1979](https://github.com/catalystneuro/neuroconv/pull/1979)
 * Removed the `hdf5` and `sbx` installation extras, aliases of `hdf5imaging` and `scanbox` kept for gallery pages that named the old spellings and marked for removal at the start of 2026. Use `neuroconv[hdf5imaging]` and `neuroconv[scanbox]`.
 
 ## Bug Fixes
-* Reading an existing Zarr file now reports its shuffle in `compressors` rather than among the filters, so a file this library wrote reports the configuration that wrote it and naming shuffle again does not apply it twice. [PR #2000](https://github.com/catalystneuro/neuroconv/pull/2000)
+* Reading an existing Zarr file now reports its shuffle in `compressors` rather than among the filters, so a file this library wrote reports the configuration that wrote it and naming shuffle again does not apply it twice. [PR #2002](https://github.com/catalystneuro/neuroconv/pull/2002)
 * Fixed the Zarr shuffle codec taking `numcodecs`' default `elementsize` of 4 regardless of the dataset's dtype, which on float64 grouped the wrong bytes and recovered almost nothing, so it is now taken from the dtype unless the caller states one. [PR #1984](https://github.com/catalystneuro/neuroconv/pull/1984)
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # v0.10.2 (Upcoming)
 
 ## Removals, Deprecations and Changes
+* `ZarrDatasetIOConfiguration.filter_methods` is renamed to `filters`, with the old name deprecated for removal in v0.12.0, so a dataset's codec stages are named the way `zarr.Array` names them: `filters` for the codecs applied to the values and `compressors` for those applied to the bytes they serialize to. [PR #2000](https://github.com/catalystneuro/neuroconv/pull/2000)
+* Naming `shuffle` in a `ZarrDatasetIOConfiguration`'s `filters` is deprecated, to be removed in v0.12.0, and `shuffle` no longer appears in `AVAILABLE_ZARR_COMPRESSION_METHODS`, since it rearranges the serialized bytes rather than the values and so belongs in `compressors` beside the compression method. [PR #2000](https://github.com/catalystneuro/neuroconv/pull/2000)
 * A `timestamps` dataset is now written with the lossless shuffle filter ahead of its compression method, which on two million irregular float64 timestamps takes 11.75 MB down to 7.51 MB on HDF5 and 11.62 MB down to 7.62 MB on Zarr at the same chunk shape and compression level, leaving `data` untouched. [PR #1984](https://github.com/catalystneuro/neuroconv/pull/1984)
 * Deprecated `compression_method` and `compression_options` on both dataset IO configuration models, and the single-valued form of `BackendConfiguration.apply_global_compression`, to be removed in v0.12.0, in favor of `compressors` and `compressor_options`. [PR #1979](https://github.com/catalystneuro/neuroconv/pull/1979)
 * Removed the `hdf5` and `sbx` installation extras, aliases of `hdf5imaging` and `scanbox` kept for gallery pages that named the old spellings and marked for removal at the start of 2026. Use `neuroconv[hdf5imaging]` and `neuroconv[scanbox]`.
 
 ## Bug Fixes
+* Reading an existing Zarr file now reports its shuffle in `compressors` rather than among the filters, so a file this library wrote reports the configuration that wrote it and naming shuffle again does not apply it twice. [PR #2000](https://github.com/catalystneuro/neuroconv/pull/2000)
 * Fixed the Zarr shuffle codec taking `numcodecs`' default `elementsize` of 4 regardless of the dataset's dtype, which on float64 grouped the wrong bytes and recovered almost nothing, so it is now taken from the dtype unless the caller states one. [PR #1984](https://github.com/catalystneuro/neuroconv/pull/1984)
 
 ## Features

--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_zarr_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_zarr_dataset_io.py
@@ -1,10 +1,12 @@
 """Base Pydantic models for the ZarrDatasetConfiguration."""
 
-from typing import Any, Literal
+import warnings
+from typing import Any, ClassVar, Literal
 
 import numcodecs
 import zarr
 from hdmf import Container
+from numcodecs import Shuffle
 from pydantic import Field, InstanceOf, model_validator
 from typing_extensions import Self
 
@@ -26,6 +28,7 @@ _excluded_zarr_codecs = set(
         "adler32",  # checksum
         "crc32",  # checksum
         "fixedscaleoffset",  # enforced indirectly by HDMF/PyNWB data types
+        "shuffle",  # not a compression method; reachable as an entry of `compressors`
         "base64",  # unsure what this would ever be used for
         "n5_wrapper",  # different data format
         "pcodec",  # is erroneously imported before numcodecs 0.15, see https://numcodecs.readthedocs.io/en/stable/release.html?utm_source=chatgpt.com#id9
@@ -44,8 +47,15 @@ AVAILABLE_ZARR_COMPRESSION_METHODS = {
 class ZarrDatasetIOConfiguration(DatasetIOConfiguration):
     """A data model for configuring options about an object that will become a Zarr Dataset in the file."""
 
+    # Shuffle rearranges bytes rather than compressing them, so it can never be the compression method of a
+    # dataset. Zarr v2 has nowhere but `filters` to store it, which is where `get_data_io_kwargs()` puts it.
+    _pure_filter_names: ClassVar[tuple[str, ...]] = ("shuffle",)
+
     compressors: (
-        list[Literal[tuple(AVAILABLE_ZARR_COMPRESSION_METHODS.keys())] | InstanceOf[numcodecs.abc.Codec]] | None
+        list[
+            Literal[(*_pure_filter_names, *AVAILABLE_ZARR_COMPRESSION_METHODS.keys())] | InstanceOf[numcodecs.abc.Codec]
+        ]
+        | None
     ) = Field(
         default=["gzip"],  # TODO: would like this to be 'auto'
         description=(
@@ -62,28 +72,31 @@ class ZarrDatasetIOConfiguration(DatasetIOConfiguration):
     compressor_options: list[dict[str, Any] | None] | None = Field(
         default=None, description="The optional parameters to use for each specified compressor."
     )
-    filter_methods: (
-        list[Literal[tuple(AVAILABLE_ZARR_COMPRESSION_METHODS.keys())] | InstanceOf[numcodecs.abc.Codec]] | None
+    filters: (
+        list[
+            Literal[(*_pure_filter_names, *AVAILABLE_ZARR_COMPRESSION_METHODS.keys())] | InstanceOf[numcodecs.abc.Codec]
+        ]
+        | None
     ) = Field(
         default=None,
         description=(
-            "The ordered collection of filtering methods to apply to this dataset prior to compression. "
+            "The ordered collection of codecs to apply to this dataset's values before it is serialized to bytes. "
             "Each element can be either a string that matches an available method on your system, "
             "or an instantiated numcodec.Codec object."
             "Set to `None` to disable filtering."
         ),
     )
     filter_options: list[dict[str, Any]] | None = Field(
-        default=None, description="The optional parameters to use for each specified filter method."
+        default=None, description="The optional parameters to use for each specified filter."
     )
 
     def __str__(self) -> str:  # Inherited docstring from parent. noqa: D105
         string = super().__str__()
-        if self.filter_methods is not None:
-            string += f"\n  filter methods : {self.filter_methods}"
+        if self.filters is not None:
+            string += f"\n  filters : {self.filters}"
         if self.filter_options is not None:
             string += f"\n  filter options : {self.filter_options}"
-        if self.filter_methods is not None or self.filter_options is not None:
+        if self.filters is not None or self.filter_options is not None:
             string += "\n"
 
         return string
@@ -108,27 +121,96 @@ class ZarrDatasetIOConfiguration(DatasetIOConfiguration):
         return self
 
     @model_validator(mode="before")
-    def validate_filter_methods_and_options_length_match(cls, values: dict[str, Any]):
-        filter_methods = values.get("filter_methods", None)
+    def validate_filters_and_options_length_match(cls, values: dict[str, Any]):
+        filters = values.get("filters", None)
         filter_options = values.get("filter_options", None)
 
-        if filter_methods is None and filter_options is not None:
-            raise ValueError(
-                f"`filter_methods` is `None` but `filter_options` is not `None` (received `{filter_options=}`)!"
-            )
+        if filters is None and filter_options is not None:
+            raise ValueError(f"`filters` is `None` but `filter_options` is not `None` (received `{filter_options=}`)!")
         elif filter_options is None:
             return values
 
-        len_filter_methods = len(filter_methods)
+        len_filters = len(filters)
         len_filter_options = len(filter_options)
-        if len_filter_methods != len_filter_options:
+        if len_filters != len_filter_options:
             raise ValueError(
-                f"Length mismatch between `filter_methods` ({len_filter_methods} methods specified) and "
-                f"`filter_options` ({len_filter_options} options found)! `filter_methods` and `filter_options` should "
+                f"Length mismatch between `filters` ({len_filters} specified) and "
+                f"`filter_options` ({len_filter_options} options found)! `filters` and `filter_options` should "
                 "be the same length."
             )
 
         return values
+
+    # ==================================================================================================
+    # Deprecated in v0.10.2, to be removed in v0.12.0.
+    #
+    # Two things are deprecated here, both of them about `filters` saying what zarr says.
+    #
+    # `filter_methods` and `filters` are the same field under two names, and the second is the one
+    # `zarr.Array` uses for the codecs applied to a dataset's values.
+    #
+    # `filters` holds the codecs that transform values, such as `delta`. `shuffle` transforms the bytes
+    # those values serialize to, which is a different slot in the vocabulary this model speaks, and since
+    # the `timestamps` default puts it in `compressors` a dataset that names it in both applies it twice.
+    #
+    # Deleting this block at v0.12.0 leaves `filters` under one name, holding value codecs alone.
+    # ==================================================================================================
+
+    _FILTER_METHODS_DEPRECATION_MESSAGE: ClassVar[str] = (
+        "`filter_methods` is deprecated and will be removed in v0.12.0. Use `filters` instead, which is what "
+        "`zarr.Array` calls the codecs applied to a dataset's values."
+    )
+
+    @property
+    def filter_methods(self):
+        """
+        The codecs applied to this dataset's values.
+
+        .. deprecated:: 0.10.2
+            `filter_methods` is deprecated and will be removed in v0.12.0. Use `filters` instead.
+        """
+        warnings.warn(self._FILTER_METHODS_DEPRECATION_MESSAGE, FutureWarning, stacklevel=2)
+        return self.filters
+
+    @filter_methods.setter
+    def filter_methods(self, filter_methods) -> None:
+        warnings.warn(self._FILTER_METHODS_DEPRECATION_MESSAGE, FutureWarning, stacklevel=2)
+        self.filters = filter_methods
+
+    @model_validator(mode="before")
+    def translate_deprecated_filter_methods(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Accept the deprecated `filter_methods` spelling for one release cycle."""
+        if not isinstance(values, dict) or "filter_methods" not in values:
+            return values
+        if "filters" in values:
+            raise ValueError(
+                "Both the deprecated `filter_methods` and the new `filters` were specified. Use only `filters`."
+            )
+
+        warnings.warn(cls._FILTER_METHODS_DEPRECATION_MESSAGE, FutureWarning, stacklevel=2)
+        values["filters"] = values.pop("filter_methods")
+        return values
+
+    @model_validator(mode="after")
+    def warn_on_shuffle_in_filters(self) -> Self:
+        """Accept the deprecated spelling of shuffle as a filter method for one release cycle."""
+        if not self.filters:
+            return self
+
+        if any(filter_method == "shuffle" or isinstance(filter_method, Shuffle) for filter_method in self.filters):
+            warnings.warn(
+                "Naming 'shuffle' in `filters` is deprecated and will be removed in v0.12.0. It rearranges "
+                "the serialized bytes rather than the values, so it belongs in `compressors`, as in "
+                '`compressors=["shuffle", "gzip"]`.',
+                FutureWarning,
+                stacklevel=2,
+            )
+
+        return self
+
+    # ==================================================================================================
+    # End of the block deprecated in v0.10.2, to be removed in v0.12.0.
+    # ==================================================================================================
 
     def _instantiate_codec(self, codec, codec_options: dict[str, Any] | None):
         if isinstance(codec, numcodecs.abc.Codec):
@@ -146,11 +228,11 @@ class ZarrDatasetIOConfiguration(DatasetIOConfiguration):
 
     def get_data_io_kwargs(self) -> dict[str, Any]:
         filters = None
-        if self.filter_methods:
-            all_filter_options = self.filter_options or [dict() for _ in self.filter_methods]
+        if self.filters:
+            all_filter_options = self.filter_options or [dict() for _ in self.filters]
             filters = [
                 self._instantiate_codec(filter_method, filter_options)
-                for filter_method, filter_options in zip(self.filter_methods, all_filter_options)
+                for filter_method, filter_options in zip(self.filters, all_filter_options)
             ]
 
         # Zarr v2 has a single compressor slot, so every other entry of `compressors` has to ride in `filters`.
@@ -197,9 +279,23 @@ class ZarrDatasetIOConfiguration(DatasetIOConfiguration):
             dataset_name=dataset_name,
         )
         compression_method = getattr(neurodata_object, dataset_name).compressor
-        filter_methods = getattr(neurodata_object, dataset_name).filters
+        filters = list(getattr(neurodata_object, dataset_name).filters or [])
+
+        # Shuffle lives in `compressors` in this model and in `filters` on disk, since Zarr v2 has nowhere
+        # else to put it, so it is moved back here. Without this a file this library wrote reports a
+        # different configuration than the one that wrote it.
+        shuffle_methods = [filter_method for filter_method in filters if isinstance(filter_method, Shuffle)]
+        filters = [filter_method for filter_method in filters if not isinstance(filter_method, Shuffle)]
+
+        compressors = ["shuffle" for _ in shuffle_methods]
+        compressor_options = [dict(elementsize=shuffle.elementsize) for shuffle in shuffle_methods]
+        if compression_method is not None:
+            compressors.append(compression_method)
+            compressor_options.append(None)
+
         return cls(
             **kwargs,
-            compressors=None if compression_method is None else [compression_method],
-            filter_methods=filter_methods,
+            compressors=compressors or None,
+            compressor_options=compressor_options if any(compressor_options) else None,
+            filters=filters or None,
         )

--- a/src/neuroconv/tools/testing/_mock/_mock_dataset_models.py
+++ b/src/neuroconv/tools/testing/_mock/_mock_dataset_models.py
@@ -53,7 +53,7 @@ def mock_ZarrDatasetIOConfiguration(
         "gzip",
     ),
     compressor_options: Iterable[dict[str, Any] | None] | None = None,
-    filter_methods: (
+    filters: (
         Iterable[Literal[tuple(AVAILABLE_ZARR_COMPRESSION_METHODS.keys())] | numcodecs.abc.Codec | None] | None
     ) = None,
     filter_options: Iterable[dict[str, Any]] | None = None,
@@ -69,7 +69,7 @@ def mock_ZarrDatasetIOConfiguration(
         buffer_shape=buffer_shape,
         compressors=None if compressors is None else list(compressors),
         compressor_options=None if compressor_options is None else list(compressor_options),
-        filter_methods=filter_methods,
+        filters=filters,
         filter_options=filter_options,
     )
 
@@ -101,7 +101,7 @@ def mock_ZarrBackendConfiguration() -> ZarrBackendConfiguration:
         "acquisition/TestElectricalSeriesAP/data": mock_ZarrDatasetIOConfiguration(
             location_in_file="acquisition/TestElectricalSeriesAP/data",
             dataset_name="data",
-            filter_methods=["delta"],
+            filters=["delta"],
         ),
         "acquisition/TestElectricalSeriesLF/data": mock_ZarrDatasetIOConfiguration(
             object_id="bc37e164-519f-4b65-a976-206440f1d325",
@@ -110,7 +110,7 @@ def mock_ZarrBackendConfiguration() -> ZarrBackendConfiguration:
             full_shape=(75_000, 384),
             chunk_shape=(37_500, 128),  # ~10 MB
             buffer_shape=(75_000, 384),
-            filter_methods=["delta"],
+            filters=["delta"],
         ),
     }
 

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_configure_backend_overrides.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_configure_backend_overrides.py
@@ -116,3 +116,44 @@ def test_simple_dynamic_table_override(tmpdir: Path, backend: Literal["hdf5", "z
     elif backend == "zarr":
         assert written_data.compressor == numcodecs.GZip(level=5)
     written_nwbfile.read_io.close()
+
+
+def written_filters_and_compressors(array) -> tuple[list, list]:
+    """
+    Read a written Zarr array's codec chain in the terms zarr 3 uses.
+
+    `Array.compressors` is a zarr 3 property that reports the bytes-to-bytes run for a v2 and a v3 array
+    alike, while `Array.compressor` is the v2-only spelling it deprecates. Reading through it here keeps
+    these assertions phrased in the vocabulary the model speaks, and the fallback can go when hdmf-zarr
+    moves off `zarr<3.0`.
+    """
+    filters = list(array.filters or ())
+    if hasattr(array, "compressors"):
+        return filters, list(array.compressors)
+    return filters, [] if array.compressor is None else [array.compressor]
+
+
+def test_shuffle_is_correctly_propagated_as_filter_in_zarr(tmpdir: Path):
+    """Zarr v2 has one compressor slot, so a shuffle named beside a compression method is written as a filter."""
+    array = np.zeros(shape=(3_000, 16), dtype="int16")
+
+    nwbfile = mock_NWBFile()
+    nwbfile.add_acquisition(mock_TimeSeries(name="TestTimeSeries", data=array))
+
+    backend_configuration = get_default_backend_configuration(nwbfile=nwbfile, backend="zarr")
+    dataset_configuration = backend_configuration.dataset_configurations["acquisition/TestTimeSeries/data"]
+    dataset_configuration.compressors = ["shuffle", "gzip"]
+
+    configure_backend(nwbfile=nwbfile, backend_configuration=backend_configuration)
+
+    nwbfile_path = str(tmpdir / "test_configure_overrides_shuffle_with_compression.nwb")
+    with BACKEND_NWB_IO["zarr"](path=nwbfile_path, mode="w") as io:
+        io.write(nwbfile)
+
+    written_nwbfile = read_nwb(nwbfile_path)
+    written_data = written_nwbfile.acquisition["TestTimeSeries"].data
+
+    filters, compressors = written_filters_and_compressors(written_data)
+    assert filters == [numcodecs.Shuffle(elementsize=2)]
+    assert compressors == [numcodecs.GZip(level=1)]
+    written_nwbfile.read_io.close()

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_get_default_dataset_io_configurations.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_get_default_dataset_io_configurations.py
@@ -49,7 +49,7 @@ def test_configuration_on_time_series(iterator: callable, backend: Literal["hdf5
     assert dataset_configuration.compressor_options is None
 
     if backend == "zarr":
-        assert dataset_configuration.filter_methods is None
+        assert dataset_configuration.filters is None
         assert dataset_configuration.filter_options is None
 
 
@@ -162,7 +162,7 @@ def test_configuration_on_dynamic_table(iterator: callable, backend: Literal["hd
     assert dataset_configuration.compressor_options is None
 
     if backend == "zarr":
-        assert dataset_configuration.filter_methods is None
+        assert dataset_configuration.filters is None
         assert dataset_configuration.filter_options is None
 
 
@@ -199,7 +199,7 @@ def test_configuration_on_ragged_units_table(backend: Literal["hdf5", "zarr"]):
     assert dataset_configuration.compressor_options is None
 
     if backend == "zarr":
-        assert dataset_configuration.filter_methods is None
+        assert dataset_configuration.filters is None
         assert dataset_configuration.filter_options is None
 
     dataset_configuration = next(
@@ -216,7 +216,7 @@ def test_configuration_on_ragged_units_table(backend: Literal["hdf5", "zarr"]):
     assert dataset_configuration.compressor_options is None
 
     if backend == "zarr":
-        assert dataset_configuration.filter_methods is None
+        assert dataset_configuration.filters is None
         assert dataset_configuration.filter_options is None
 
     dataset_configuration = next(
@@ -233,7 +233,7 @@ def test_configuration_on_ragged_units_table(backend: Literal["hdf5", "zarr"]):
     assert dataset_configuration.compressor_options is None
 
     if backend == "zarr":
-        assert dataset_configuration.filter_methods is None
+        assert dataset_configuration.filters is None
         assert dataset_configuration.filter_options is None
 
     dataset_configuration = next(
@@ -250,7 +250,7 @@ def test_configuration_on_ragged_units_table(backend: Literal["hdf5", "zarr"]):
     assert dataset_configuration.compressor_options is None
 
     if backend == "zarr":
-        assert dataset_configuration.filter_methods is None
+        assert dataset_configuration.filters is None
         assert dataset_configuration.filter_options is None
 
     dataset_configuration = next(
@@ -267,7 +267,7 @@ def test_configuration_on_ragged_units_table(backend: Literal["hdf5", "zarr"]):
     assert dataset_configuration.compressor_options is None
 
     if backend == "zarr":
-        assert dataset_configuration.filter_methods is None
+        assert dataset_configuration.filters is None
         assert dataset_configuration.filter_options is None
 
 
@@ -299,7 +299,7 @@ def test_configuration_on_compass_direction(iterator: callable, backend: Literal
     assert dataset_configuration.compressor_options is None
 
     if backend == "zarr":
-        assert dataset_configuration.filter_methods is None
+        assert dataset_configuration.filters is None
         assert dataset_configuration.filter_options is None
 
 
@@ -348,7 +348,7 @@ def test_configuration_on_ndx_events(backend: Literal["hdf5", "zarr"]):
     assert data_dataset_configuration.compressor_options is None
 
     if backend == "zarr":
-        assert data_dataset_configuration.filter_methods is None
+        assert data_dataset_configuration.filters is None
         assert data_dataset_configuration.filter_options is None
 
     timestamps_dataset_configuration = next(
@@ -367,7 +367,7 @@ def test_configuration_on_ndx_events(backend: Literal["hdf5", "zarr"]):
     assert timestamps_dataset_configuration.compressor_options is None
 
     if backend == "zarr":
-        assert timestamps_dataset_configuration.filter_methods is None
+        assert timestamps_dataset_configuration.filters is None
         assert timestamps_dataset_configuration.filter_options is None
 
 

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_get_default_dataset_io_configurations_appended_files.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_get_default_dataset_io_configurations_appended_files.py
@@ -93,7 +93,7 @@ def test_unwrapped_time_series_zarr(zarr_nwbfile_path):
     assert dataset_configuration.buffer_shape == array.shape
     assert dataset_configuration.compressors == ["gzip"]
     assert dataset_configuration.compressor_options is None
-    assert dataset_configuration.filter_methods is None
+    assert dataset_configuration.filters is None
     assert dataset_configuration.filter_options is None
 
 
@@ -143,5 +143,5 @@ def test_unwrapped_dynamic_table_zarr(zarr_nwbfile_path):
     assert dataset_configuration.buffer_shape == array.shape
     assert dataset_configuration.compressors == ["gzip"]
     assert dataset_configuration.compressor_options is None
-    assert dataset_configuration.filter_methods is None
+    assert dataset_configuration.filters is None
     assert dataset_configuration.filter_options is None

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_get_existing_backend_configuration.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_get_existing_backend_configuration.py
@@ -259,7 +259,7 @@ intervals/trials/compressed_start_time/data
 
   compressors : [Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)]
 
-  filter methods : [Blosc(cname='zstd', clevel=1, shuffle=SHUFFLE, blocksize=0), Blosc(cname='zstd', clevel=2, shuffle=SHUFFLE, blocksize=0)]
+  filters : [Blosc(cname='zstd', clevel=1, shuffle=SHUFFLE, blocksize=0), Blosc(cname='zstd', clevel=2, shuffle=SHUFFLE, blocksize=0)]
 
 
 processing/ecephys/ProcessedTimeSeries/data
@@ -306,7 +306,7 @@ acquisition/CompressedRawTimeSeries/data
 
   compressors : [Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)]
 
-  filter methods : [Blosc(cname='zstd', clevel=1, shuffle=SHUFFLE, blocksize=0), Blosc(cname='zstd', clevel=2, shuffle=SHUFFLE, blocksize=0)]
+  filters : [Blosc(cname='zstd', clevel=1, shuffle=SHUFFLE, blocksize=0), Blosc(cname='zstd', clevel=2, shuffle=SHUFFLE, blocksize=0)]
 
 """
     assert stdout.getvalue() == expected_print

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_get_existing_dataset_io_configurations.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_get_existing_dataset_io_configurations.py
@@ -7,7 +7,7 @@ import pytest
 from hdmf.common import VectorData
 from hdmf_zarr import ZarrDataIO
 from hdmf_zarr.nwb import NWBZarrIO
-from numcodecs import Blosc, GZip
+from numcodecs import Blosc, Delta, GZip, Shuffle
 from pynwb import NWBHDF5IO, H5DataIO
 from pynwb.base import DynamicTable
 from pynwb.behavior import CompassDirection
@@ -77,7 +77,7 @@ def test_configuration_on_time_series(tmp_path, backend: Literal["hdf5", "zarr"]
         elif backend == "zarr":
             assert dataset_configuration.chunk_shape == (2, 3)
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods is None
+            assert dataset_configuration.filters is None
             assert dataset_configuration.filter_options is None
 
         dataset_configuration = dataset_configurations[1]
@@ -96,7 +96,7 @@ def test_configuration_on_time_series(tmp_path, backend: Literal["hdf5", "zarr"]
         elif backend == "zarr":
             assert dataset_configuration.compressors == [compressor]
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods == filters
+            assert dataset_configuration.filters == filters
             assert dataset_configuration.filter_options is None
 
 
@@ -170,7 +170,7 @@ def test_configuration_on_dynamic_table(tmp_path, backend: Literal["hdf5", "zarr
         elif backend == "zarr":
             assert dataset_configuration.chunk_shape == (3,)
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods is None
+            assert dataset_configuration.filters is None
             assert dataset_configuration.filter_options is None
 
         dataset_configuration = dataset_configurations[1]
@@ -188,7 +188,7 @@ def test_configuration_on_dynamic_table(tmp_path, backend: Literal["hdf5", "zarr
         elif backend == "zarr":
             assert dataset_configuration.compressors == [compressor]
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods == filters
+            assert dataset_configuration.filters == filters
             assert dataset_configuration.filter_options is None
 
 
@@ -250,7 +250,7 @@ def test_configuration_on_ragged_units_table(tmp_path, backend: Literal["hdf5", 
             assert dataset_configuration.compressors == [compressor]
             assert dataset_configuration.chunk_shape == (5,)
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods is None
+            assert dataset_configuration.filters is None
             assert dataset_configuration.filter_options is None
 
         dataset_configuration = next(
@@ -270,7 +270,7 @@ def test_configuration_on_ragged_units_table(tmp_path, backend: Literal["hdf5", 
             assert dataset_configuration.compressors == [compressor]
             assert dataset_configuration.chunk_shape == (2,)
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods is None
+            assert dataset_configuration.filters is None
             assert dataset_configuration.filter_options is None
 
         dataset_configuration = next(
@@ -290,7 +290,7 @@ def test_configuration_on_ragged_units_table(tmp_path, backend: Literal["hdf5", 
             assert dataset_configuration.compressors == [compressor]
             assert dataset_configuration.chunk_shape == (15, 3)
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods is None
+            assert dataset_configuration.filters is None
             assert dataset_configuration.filter_options is None
 
         dataset_configuration = next(
@@ -310,7 +310,7 @@ def test_configuration_on_ragged_units_table(tmp_path, backend: Literal["hdf5", 
             assert dataset_configuration.compressors == [compressor]
             assert dataset_configuration.chunk_shape == (5,)
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods is None
+            assert dataset_configuration.filters is None
             assert dataset_configuration.filter_options is None
 
         dataset_configuration = next(
@@ -330,7 +330,7 @@ def test_configuration_on_ragged_units_table(tmp_path, backend: Literal["hdf5", 
             assert dataset_configuration.compressors == [compressor]
             assert dataset_configuration.chunk_shape == (2,)
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods is None
+            assert dataset_configuration.filters is None
             assert dataset_configuration.filter_options is None
 
         dataset_configuration = next(
@@ -349,7 +349,7 @@ def test_configuration_on_ragged_units_table(tmp_path, backend: Literal["hdf5", 
         elif backend == "zarr":
             assert dataset_configuration.compressors == [compressor]
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods == filters
+            assert dataset_configuration.filters == filters
             assert dataset_configuration.filter_options is None
 
         dataset_configuration = next(
@@ -368,7 +368,7 @@ def test_configuration_on_ragged_units_table(tmp_path, backend: Literal["hdf5", 
         elif backend == "zarr":
             assert dataset_configuration.compressors == [compressor]
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods is None
+            assert dataset_configuration.filters is None
             assert dataset_configuration.filter_options is None
             assert dataset_configuration.chunk_shape == (2,)
 
@@ -388,7 +388,7 @@ def test_configuration_on_ragged_units_table(tmp_path, backend: Literal["hdf5", 
         elif backend == "zarr":
             assert dataset_configuration.compressors == [compressor]
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods == filters
+            assert dataset_configuration.filters == filters
             assert dataset_configuration.filter_options is None
 
         dataset_configuration = next(
@@ -407,7 +407,7 @@ def test_configuration_on_ragged_units_table(tmp_path, backend: Literal["hdf5", 
         elif backend == "zarr":
             assert dataset_configuration.compressors == [compressor]
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods is None
+            assert dataset_configuration.filters is None
             assert dataset_configuration.filter_options is None
             assert dataset_configuration.chunk_shape == (2,)
 
@@ -467,7 +467,7 @@ def test_configuration_on_compass_direction(tmp_path, backend: Literal["hdf5", "
         elif backend == "zarr":
             assert dataset_configuration.compressor_options is None
             assert dataset_configuration.chunk_shape == data.shape
-            assert dataset_configuration.filter_methods is None
+            assert dataset_configuration.filters is None
             assert dataset_configuration.filter_options is None
 
         dataset_configuration = dataset_configurations[1]
@@ -487,7 +487,7 @@ def test_configuration_on_compass_direction(tmp_path, backend: Literal["hdf5", "
         elif backend == "zarr":
             assert dataset_configuration.compressors == [compressor]
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods == filters
+            assert dataset_configuration.filters == filters
             assert dataset_configuration.filter_options is None
 
 
@@ -567,7 +567,7 @@ def test_configuration_on_ndx_events(tmp_path, backend: Literal["hdf5", "zarr"])
         elif backend == "zarr":
             assert data_dataset_configuration.compressor_options is None
             assert data_dataset_configuration.chunk_shape == data.shape
-            assert data_dataset_configuration.filter_methods is None
+            assert data_dataset_configuration.filters is None
             assert data_dataset_configuration.filter_options is None
 
         timestamps_dataset_configuration = next(
@@ -587,7 +587,7 @@ def test_configuration_on_ndx_events(tmp_path, backend: Literal["hdf5", "zarr"])
         elif backend == "zarr":
             assert timestamps_dataset_configuration.compressor_options is None
             assert timestamps_dataset_configuration.chunk_shape == timestamps.shape
-            assert timestamps_dataset_configuration.filter_methods is None
+            assert timestamps_dataset_configuration.filters is None
             assert timestamps_dataset_configuration.filter_options is None
 
         data_dataset_configuration = next(
@@ -607,7 +607,7 @@ def test_configuration_on_ndx_events(tmp_path, backend: Literal["hdf5", "zarr"])
         elif backend == "zarr":
             assert data_dataset_configuration.compressors == [compressor]
             assert data_dataset_configuration.compressor_options is None
-            assert data_dataset_configuration.filter_methods == filters
+            assert data_dataset_configuration.filters == filters
             assert data_dataset_configuration.filter_options is None
 
         timestamps_dataset_configuration = next(
@@ -627,7 +627,7 @@ def test_configuration_on_ndx_events(tmp_path, backend: Literal["hdf5", "zarr"])
         elif backend == "zarr":
             assert timestamps_dataset_configuration.compressors == [compressor]
             assert timestamps_dataset_configuration.compressor_options is None
-            assert timestamps_dataset_configuration.filter_methods == filters
+            assert timestamps_dataset_configuration.filters == filters
             assert timestamps_dataset_configuration.filter_options is None
 
 
@@ -683,7 +683,7 @@ def test_configuration_on_time_series_automatic_backend(tmp_path, backend: Liter
         elif backend == "zarr":
             assert dataset_configuration.chunk_shape == (2, 3)
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods is None
+            assert dataset_configuration.filters is None
             assert dataset_configuration.filter_options is None
 
         dataset_configuration = dataset_configurations[1]
@@ -702,7 +702,7 @@ def test_configuration_on_time_series_automatic_backend(tmp_path, backend: Liter
         elif backend == "zarr":
             assert dataset_configuration.compressors == [compressor]
             assert dataset_configuration.compressor_options is None
-            assert dataset_configuration.filter_methods == filters
+            assert dataset_configuration.filters == filters
             assert dataset_configuration.filter_options is None
 
 
@@ -849,4 +849,66 @@ def test_timestamps_written_without_shuffle_are_read_back_without_it(tmp_path, b
             assert dataset_configuration.compressors == ["gzip"]
         elif backend == "zarr":
             assert dataset_configuration.compressors == [GZip(level=1)]
-            assert dataset_configuration.filter_methods is None
+            assert dataset_configuration.filters is None
+
+
+def test_zarr_shuffle_is_read_back_into_compressors(tmp_path):
+    """Zarr v2 stores shuffle in `filters`, so a file this library wrote has to report `compressors`."""
+    timestamps = ZarrDataIO(
+        data=np.arange(100, dtype="float64") / 30.0,
+        chunks=(100,),
+        compressor=GZip(level=1),
+        filters=[Shuffle(elementsize=8)],
+    )
+
+    nwbfile = mock_NWBFile()
+    nwbfile.add_acquisition(mock_TimeSeries(name="TestTimeSeries", data=np.zeros(shape=(100,)), timestamps=timestamps))
+
+    nwbfile_path = tmp_path / "test_existing_dataset_io_configurations_shuffled_timestamps.nwb.zarr"
+    with NWBZarrIO(str(nwbfile_path), "w") as io:
+        io.write(nwbfile)
+    with NWBZarrIO(str(nwbfile_path), "r") as io:
+        nwbfile = io.read()
+
+        dataset_configuration = next(
+            dataset_configuration
+            for dataset_configuration in get_existing_dataset_io_configurations(nwbfile=nwbfile)
+            if dataset_configuration.location_in_file == "acquisition/TestTimeSeries/timestamps"
+        )
+
+    assert dataset_configuration.compressors == ["shuffle", GZip(level=1)]
+    assert dataset_configuration.compressor_options == [dict(elementsize=8), None]
+    assert dataset_configuration.filters is None
+
+    # The configuration read back reproduces the settings it was read from
+    assert dataset_configuration.get_data_io_kwargs() == dict(
+        chunks=(100,), compressor=GZip(level=1), filters=[Shuffle(elementsize=8)]
+    )
+
+
+def test_zarr_value_filters_are_read_back_into_filters(tmp_path):
+    """Only shuffle moves: a codec that transforms values is still a filter method."""
+    data = ZarrDataIO(
+        data=np.arange(100, dtype="int16"),
+        chunks=(100,),
+        compressor=GZip(level=1),
+        filters=[Delta(dtype="int16")],
+    )
+
+    nwbfile = mock_NWBFile()
+    nwbfile.add_acquisition(mock_TimeSeries(name="TestTimeSeries", data=data))
+
+    nwbfile_path = tmp_path / "test_existing_dataset_io_configurations_delta.nwb.zarr"
+    with NWBZarrIO(str(nwbfile_path), "w") as io:
+        io.write(nwbfile)
+    with NWBZarrIO(str(nwbfile_path), "r") as io:
+        nwbfile = io.read()
+
+        dataset_configuration = next(
+            dataset_configuration
+            for dataset_configuration in get_existing_dataset_io_configurations(nwbfile=nwbfile)
+            if dataset_configuration.location_in_file == "acquisition/TestTimeSeries/data"
+        )
+
+    assert dataset_configuration.compressors == [GZip(level=1)]
+    assert dataset_configuration.filters == [Delta(dtype="int16")]

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_models/test_text_representations.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_models/test_text_representations.py
@@ -101,7 +101,7 @@ acquisition/TestElectricalSeriesLF/data
 
 
 def test_zarr_backend_configuration_print():
-    """The printout of a ZarrBackendConfiguration also renders the filter methods."""
+    """The printout of a ZarrBackendConfiguration also renders the filters."""
     zarr_backend_configuration = mock_ZarrBackendConfiguration()
 
     expected_print = """
@@ -122,7 +122,7 @@ acquisition/TestElectricalSeriesAP/data
 
   compressors : ['gzip']
 
-  filter methods : ['delta']
+  filters : ['delta']
 
 
 acquisition/TestElectricalSeriesLF/data
@@ -139,7 +139,7 @@ acquisition/TestElectricalSeriesLF/data
 
   compressors : ['gzip']
 
-  filter methods : ['delta']
+  filters : ['delta']
 """
     assert str(zarr_backend_configuration) == expected_print
 
@@ -162,7 +162,7 @@ def test_zarr_dataset_configuration_print_omits_unset_compression_and_filters():
 
     assert "compressors" not in printout
     assert "compressor options" not in printout
-    assert "filter methods" not in printout
+    assert "filters :" not in printout
     assert "filter options" not in printout
 
 

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_models/test_zarr_dataset_io_configuration_model.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_models/test_zarr_dataset_io_configuration_model.py
@@ -17,29 +17,29 @@ def test_validator_filter_options_has_methods():
         mock_ZarrDatasetIOConfiguration(
             chunk_shape=(78_125, 64),
             buffer_shape=(1_250_000, 384),
-            filter_methods=None,
+            filters=None,
             filter_options=[dict(clevel=5)],
         )
 
     expected_error = (
-        "`filter_methods` is `None` but `filter_options` is not `None` "
+        "`filters` is `None` but `filter_options` is not `None` "
         "(received `filter_options=[{'clevel': 5}]`)! [type=value_error, "
     )
     assert expected_error in str(error_info.value)
 
 
-def test_validator_filter_methods_length_match_options():
+def test_validator_filters_length_match_options():
     with pytest.raises(ValueError) as error_info:
         mock_ZarrDatasetIOConfiguration(
             chunk_shape=(78_125, 64),
             buffer_shape=(1_250_000, 384),
-            filter_methods=["blosc", "delta"],
+            filters=["blosc", "delta"],
             filter_options=[dict(clevel=5)],  # Correction would be to add a second element `dict()` to avoid ambiguity
         )
 
     expected_error = (
-        "Length mismatch between `filter_methods` (2 methods specified) and `filter_options` (1 options found)! "
-        "`filter_methods` and `filter_options` should be the same length. [type=value_error, "
+        "Length mismatch between `filters` (2 specified) and `filter_options` (1 options found)! "
+        "`filters` and `filter_options` should be the same length. [type=value_error, "
     )
     assert expected_error in str(error_info.value)
 
@@ -78,7 +78,7 @@ def test_get_data_io_kwargs_with_shuffle():
 def test_get_data_io_kwargs_with_shuffle_and_a_filter_method():
     """An array-to-array filter method stays ahead of the entries moved out of `compressors`."""
     zarr_dataset_configuration = mock_ZarrDatasetIOConfiguration(
-        compressors=["shuffle", "gzip"], filter_methods=["delta"], filter_options=[dict(dtype="int16")]
+        compressors=["shuffle", "gzip"], filters=["delta"], filter_options=[dict(dtype="int16")]
     )
 
     assert zarr_dataset_configuration.get_data_io_kwargs() == dict(
@@ -113,8 +113,8 @@ def test_shuffle_elementsize_follows_the_dtype():
 
 
 def test_shuffle_elementsize_follows_the_dtype_on_the_deprecated_path():
-    """The deprecated `filter_methods` spelling instantiates through the same helper."""
-    zarr_dataset_configuration = mock_ZarrDatasetIOConfiguration(filter_methods=["shuffle"], dtype=np.dtype("float64"))
+    """The deprecated `filters` spelling instantiates through the same helper."""
+    zarr_dataset_configuration = mock_ZarrDatasetIOConfiguration(filters=["shuffle"], dtype=np.dtype("float64"))
 
     assert zarr_dataset_configuration.get_data_io_kwargs()["filters"] == [Shuffle(elementsize=8)]
 


### PR DESCRIPTION
While shipping the `timestamps` shuffle default in #1984 I saw that when we write a Zarr file and then read it back, the library reports shuffle as a filter instead of as part of `compressors`, so asking for shuffle again on that configuration applies it twice.

This fixes it by moving shuffle into `compressors` on the way in, and moves `filter_methods` to `filters`, the name zarr v3 gives the codecs applied to a dataset's values.

The old spellings are deprecated for removal in v0.12.0, the same clock `compression_method` and `compression_options` are on from [PR #1979](https://github.com/catalystneuro/neuroconv/pull/1979).
