### PR TITLE
Filter empty traces on `shape` instead of `size`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Removed the `hdf5` and `sbx` installation extras, aliases of `hdf5imaging` and `scanbox` kept for gallery pages that named the old spellings and marked for removal at the start of 2026. Use `neuroconv[hdf5imaging]` and `neuroconv[scanbox]`.
 
 ## Bug Fixes
-* Filter empty fluorescence traces on `math.prod(trace.shape)` instead of `trace.size`, so the check works on anything array-like that `get_traces_dict()` returns. The h5py-backed segmentation extractors (CaImAn, CNMF-E, EXTRACT, NWB) hand back a `DatasetView`, and `.size` only ever reached the wrapped dataset through `lazy_ops`'s attribute forwarding, which its maintained successor `lazyslice` does not do. Neither form reads data, since `shape` is metadata. See [catalystneuro/roiextractors#615](https://github.com/catalystneuro/roiextractors/pull/615).
+* Filter empty fluorescence traces on `math.prod(trace.shape)` instead of `trace.size`, which the `DatasetView` objects `get_traces_dict()` can return do not have. [PR #2005](https://github.com/catalystneuro/neuroconv/pull/2005)
 * Reading an existing Zarr file now reports its shuffle in `compressors` rather than among the filters, so a file this library wrote reports the configuration that wrote it and naming shuffle again does not apply it twice. [PR #2002](https://github.com/catalystneuro/neuroconv/pull/2002)
 * Fixed the Zarr shuffle codec taking `numcodecs`' default `elementsize` of 4 regardless of the dataset's dtype, which on float64 grouped the wrong bytes and recovered almost nothing, so it is now taken from the dtype unless the caller states one. [PR #1984](https://github.com/catalystneuro/neuroconv/pull/1984)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Removed the `hdf5` and `sbx` installation extras, aliases of `hdf5imaging` and `scanbox` kept for gallery pages that named the old spellings and marked for removal at the start of 2026. Use `neuroconv[hdf5imaging]` and `neuroconv[scanbox]`.
 
 ## Bug Fixes
+* Filter empty fluorescence traces on `math.prod(trace.shape)` instead of `trace.size`, so the check works on anything array-like that `get_traces_dict()` returns. The h5py-backed segmentation extractors (CaImAn, CNMF-E, EXTRACT, NWB) hand back a `DatasetView`, and `.size` only ever reached the wrapped dataset through `lazy_ops`'s attribute forwarding, which its maintained successor `lazyslice` does not do. Neither form reads data, since `shape` is metadata. See [catalystneuro/roiextractors#615](https://github.com/catalystneuro/roiextractors/pull/615).
 * Reading an existing Zarr file now reports its shuffle in `compressors` rather than among the filters, so a file this library wrote reports the configuration that wrote it and naming shuffle again does not apply it twice. [PR #2002](https://github.com/catalystneuro/neuroconv/pull/2002)
 * Fixed the Zarr shuffle codec taking `numcodecs`' default `elementsize` of 4 regardless of the dataset's dtype, which on float64 grouped the wrong bytes and recovered almost nothing, so it is now taken from the dtype unless the caller states one. [PR #1984](https://github.com/catalystneuro/neuroconv/pull/1984)
 

--- a/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ophys/basesegmentationextractorinterface.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 from typing import Literal
 
@@ -217,7 +218,7 @@ class BaseSegmentationExtractorInterface(BaseExtractorInterface):
         # extractor does not hold is a blank nobody can fill, since the object is never written.
         traces_dict = self.segmentation_extractor.get_traces_dict()
         available_traces = [
-            trace_name for trace_name, trace in traces_dict.items() if trace is not None and trace.size != 0
+            trace_name for trace_name, trace in traces_dict.items() if trace is not None and math.prod(trace.shape) != 0
         ]
         if available_traces:
             ophys["RoiResponses"] = {

--- a/src/neuroconv/tools/roiextractors/roiextractors.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors.py
@@ -679,7 +679,9 @@ def _add_roi_response_traces_to_nwbfile(
     # Get traces from extractor, filter None/empty
     traces_dict = segmentation_extractor.get_traces_dict()
     traces_to_add = {
-        trace_name: trace for trace_name, trace in traces_dict.items() if trace is not None and trace.size != 0
+        trace_name: trace
+        for trace_name, trace in traces_dict.items()
+        if trace is not None and math.prod(trace.shape) != 0
     }
 
     roi_responses = metadata.get("Ophys", {}).get("RoiResponses", {})
@@ -1380,7 +1382,7 @@ def _segmentation_extractor_has_data(segmentation_extractor: SegmentationExtract
         return True
 
     traces = segmentation_extractor.get_traces_dict().values()
-    if any(trace is not None and trace.size != 0 for trace in traces):
+    if any(trace is not None and math.prod(trace.shape) != 0 for trace in traces):
         return True
 
     return any(image is not None for image in segmentation_extractor.get_images_dict().values())
@@ -1528,7 +1530,7 @@ def add_segmentation_to_nwbfile(
         # That is boilerplate rather than a request, and the old writer answered it by writing nothing, so
         # the block goes here rather than letting the writer reject metadata the caller never wrote.
         traces = segmentation_extractor.get_traces_dict().values()
-        if not any(trace is not None and trace.size != 0 for trace in traces):
+        if not any(trace is not None and math.prod(trace.shape) != 0 for trace in traces):
             metadata["Ophys"] = {key: value for key, value in metadata["Ophys"].items() if key != "RoiResponses"}
 
     if _is_dict_based_metadata(metadata):

--- a/src/neuroconv/tools/roiextractors/roiextractors_pending_deprecation.py
+++ b/src/neuroconv/tools/roiextractors/roiextractors_pending_deprecation.py
@@ -5,6 +5,7 @@ compatibility during the migration to the new dict-based format. They will be
 removed once the migration is complete.
 """
 
+import math
 import warnings
 from collections import defaultdict
 from typing import Literal
@@ -1183,7 +1184,9 @@ def _add_segmentation_to_nwbfile_old_list_format(
     traces_to_add = segmentation_extractor.get_traces_dict()
     # Filter empty data and background traces
     traces_to_add = {
-        trace_name: trace for trace_name, trace in traces_to_add.items() if trace is not None and trace.size != 0
+        trace_name: trace
+        for trace_name, trace in traces_to_add.items()
+        if trace is not None and math.prod(trace.shape) != 0
     }
     if include_background_segmentation:
         traces_to_add.pop("neuropil", None)
@@ -1207,7 +1210,7 @@ def _add_segmentation_to_nwbfile_old_list_format(
         traces_to_add = {
             trace_name: trace
             for trace_name, trace in traces_to_add.items()
-            if trace is not None and trace.size != 0 and trace_name == "neuropil"
+            if trace is not None and math.prod(trace.shape) != 0 and trace_name == "neuropil"
         }
         if traces_to_add:
             background_ids = segmentation_extractor.get_background_ids()
@@ -1260,7 +1263,9 @@ def add_fluorescence_traces_to_nwbfile(
     traces_to_add = segmentation_extractor.get_traces_dict()
     # Filter empty data and background traces
     traces_to_add = {
-        trace_name: trace for trace_name, trace in traces_to_add.items() if trace is not None and trace.size != 0
+        trace_name: trace
+        for trace_name, trace in traces_to_add.items()
+        if trace is not None and math.prod(trace.shape) != 0
     }
     if include_background_segmentation:
         traces_to_add.pop("neuropil", None)


### PR DESCRIPTION
Needed before roiextractors can move off `lazy_ops`, catalystneuro/roiextractors#615.

`get_traces_dict()` does not always hand back numpy arrays. The h5py-backed segmentation extractors return a `DatasetView`, and `trace.size` only ever worked because `lazy_ops` forwarded any attribute it did not define down to the wrapped dataset. `lazyslice`, its maintained successor, does not forward, so the filter raises `AttributeError: 'DatasetView' object has no attribute 'size'`. This PR uses `math.prod(trace.shape)`, which every candidate has and which reads nothing, since `shape` is metadata.

I changed all seven occurrences and not only the one that fails right now, as the other six carry the same assumption.
