### PR TITLE
Let a session's YAML `conversion_options` override the global block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Removed the `hdf5` and `sbx` installation extras, aliases of `hdf5imaging` and `scanbox` kept for gallery pages that named the old spellings and marked for removal at the start of 2026. Use `neuroconv[hdf5imaging]` and `neuroconv[scanbox]`.
 
 ## Bug Fixes
+* In a YAML conversion specification, a session's own `conversion_options` now override the top-level `conversion_options` block where both state the same option, in the same order the metadata blocks merge. The global values used to win, so a session could not turn off a global `stub_test` or refine a global option for one of its interfaces. [PR #2023](https://github.com/catalystneuro/neuroconv/pull/2023)
 * Filter empty fluorescence traces on `math.prod(trace.shape)` instead of `trace.size`, which the `DatasetView` objects `get_traces_dict()` can return do not have. [PR #2005](https://github.com/catalystneuro/neuroconv/pull/2005)
 * Reading an existing Zarr file now reports its shuffle in `compressors` rather than among the filters, so a file this library wrote reports the configuration that wrote it and naming shuffle again does not apply it twice. [PR #2002](https://github.com/catalystneuro/neuroconv/pull/2002)
 * Fixed the Zarr shuffle codec taking `numcodecs`' default `elementsize` of 4 regardless of the dataset's dtype, which on float64 grouped the wrong bytes and recovered almost nothing, so it is now taken from the dtype unless the caller states one. [PR #1984](https://github.com/catalystneuro/neuroconv/pull/1984)

--- a/src/neuroconv/tools/yaml_conversion_specification/_yaml_conversion_specification.py
+++ b/src/neuroconv/tools/yaml_conversion_specification/_yaml_conversion_specification.py
@@ -47,6 +47,25 @@ def run_conversion_from_yaml_cli(
     )
 
 
+def _resolve_conversion_options(
+    *,
+    interface_names,
+    global_conversion_options: dict,
+    session_conversion_options: dict,
+) -> dict[str, dict]:
+    """
+    Assemble the conversion options handed to each interface of one session.
+
+    The top-level ``conversion_options`` block applies to every interface of every session, and a session's
+    own block is keyed by interface name. The session's values win where both state the same option, the
+    same way the session's metadata wins over the global block.
+    """
+    return {
+        interface_name: {**global_conversion_options, **session_conversion_options.get(interface_name, dict())}
+        for interface_name in interface_names
+    }
+
+
 def run_conversion_from_yaml(
     specification_file_path: FilePath,
     data_folder_path: DirectoryPath | None = None,
@@ -157,10 +176,11 @@ def run_conversion_from_yaml(
                 )
                 raise ValueError(message)
 
-            session_conversion_options = session.get("conversion_options", dict())
-            conversion_options = dict()
-            for key in converter.data_interface_objects:
-                conversion_options[key] = dict(session_conversion_options.get(key, dict()), **global_conversion_options)
+            conversion_options = _resolve_conversion_options(
+                interface_names=converter.data_interface_objects,
+                global_conversion_options=global_conversion_options,
+                session_conversion_options=session.get("conversion_options", dict()),
+            )
 
             nwbfile_name = session.get("nwbfile_name", f"temp_nwbfile_name_{file_counter}").strip(".nwb")
             converter.run_conversion(

--- a/tests/test_minimal/test_tools/test_yaml_conversion_options.py
+++ b/tests/test_minimal/test_tools/test_yaml_conversion_options.py
@@ -1,0 +1,32 @@
+from neuroconv.tools.yaml_conversion_specification._yaml_conversion_specification import (
+    _resolve_conversion_options,
+)
+
+
+def test_global_conversion_options_reach_every_interface():
+    conversion_options = _resolve_conversion_options(
+        interface_names=["ap", "lf"],
+        global_conversion_options=dict(stub_test=True),
+        session_conversion_options=dict(),
+    )
+    assert conversion_options == dict(ap=dict(stub_test=True), lf=dict(stub_test=True))
+
+
+def test_session_conversion_options_override_global_ones():
+    # The more specific level wins, as it does for metadata: the session turns stub_test off for one interface
+    # and adds an option of its own, and the other interface keeps the global value.
+    conversion_options = _resolve_conversion_options(
+        interface_names=["ap", "lf"],
+        global_conversion_options=dict(stub_test=True),
+        session_conversion_options=dict(ap=dict(stub_test=False, iterator_type=None)),
+    )
+    assert conversion_options == dict(ap=dict(stub_test=False, iterator_type=None), lf=dict(stub_test=True))
+
+
+def test_session_conversion_options_for_an_absent_interface_are_ignored():
+    conversion_options = _resolve_conversion_options(
+        interface_names=["ap"],
+        global_conversion_options=dict(),
+        session_conversion_options=dict(phy=dict(stub_test=True)),
+    )
+    assert conversion_options == dict(ap=dict())


### PR DESCRIPTION
Closes #2022.

`run_conversion_from_yaml` built each interface's options as `dict(session_options, **global_options)`, so the top-level `conversion_options` block won wherever a session stated the same option. A session could not turn off a global `stub_test`, or refine a global option for one of its interfaces, and got the global value silently. The merge now runs the other way, with the session's values on top, which is the order the metadata blocks already merge in (global, then experiment, then session).

The merge moved into a small helper, `_resolve_conversion_options`, so it can be tested without a data-bearing specification. Three unit tests cover the global block reaching every interface, a session overriding and extending it for one interface while the other keeps the global value, and session options for an interface the specification does not declare being ignored. They live under `test_minimal`, since the module imports `dandi` only inside the run function.

Neither the schema nor the docs stated a precedence, so this changes behaviour only for a specification that names the same option at both levels. The code and tests were drafted by the AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDEA1i6RePp7Tfrbxu3Y3P