### PR TITLE
Drop three `get_conversion_options_schema` overrides that repeat the parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * `HDF5DatasetIOConfiguration` and `ZarrDatasetIOConfiguration` now describe a dataset's codec pipeline with an ordered `compressors` list and a matching `compressor_options`, which makes the HDF5 `shuffle` and `fletcher32` filters reachable for the first time and gives both backends the same vocabulary. [PR #1979](https://github.com/catalystneuro/neuroconv/pull/1979)
 
 ## Improvements
+* Removed the `get_conversion_options_schema` overrides on `ConverterPipe`, `SpikeGLXConverterPipe` and `OpenEphysBinaryConverter`, which repeated what `NWBConverter` already does and returned the same schema. [PR #2027](https://github.com/catalystneuro/neuroconv/pull/2027)
 * `EDFRecordingInterface` now reports the patient field's birthdate as `Subject.date_of_birth`, parsed into an ISO 8601 date from the `17 mar 1985` spelling the readers hand back. [PR #1999](https://github.com/catalystneuro/neuroconv/pull/1999)
 
 # v0.10.1 (September 1, 2026)

--- a/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinaryconverter.py
+++ b/src/neuroconv/datainterfaces/ecephys/openephys/openephysbinaryconverter.py
@@ -166,10 +166,3 @@ class OpenEphysBinaryConverter(ConverterPipe):
             electrical_series_metadata[metadata_key]["name"] = series_name
 
         return metadata
-
-    def get_conversion_options_schema(self) -> dict:
-        conversion_options_schema = super().get_conversion_options_schema()
-        conversion_options_schema["properties"].update(
-            {name: interface.get_conversion_options_schema() for name, interface in self.data_interface_objects.items()}
-        )
-        return conversion_options_schema

--- a/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxconverter.py
+++ b/src/neuroconv/datainterfaces/ecephys/spikeglx/spikeglxconverter.py
@@ -140,10 +140,3 @@ class SpikeGLXConverterPipe(ConverterPipe):
             )
 
         super().__init__(data_interfaces=data_interfaces, verbose=verbose)
-
-    def get_conversion_options_schema(self) -> dict:
-        conversion_options_schema = super().get_conversion_options_schema()
-        conversion_options_schema["properties"].update(
-            {name: interface.get_conversion_options_schema() for name, interface in self.data_interface_objects.items()}
-        )
-        return conversion_options_schema

--- a/src/neuroconv/nwbconverter.py
+++ b/src/neuroconv/nwbconverter.py
@@ -521,31 +521,3 @@ class ConverterPipe(NWBConverter):
         self.data_interface_classes = {
             name: interface.__class__ for name, interface in self.data_interface_objects.items()
         }
-
-    def get_conversion_options_schema(self) -> dict:
-        """
-        Compile conversion option schemas from each of the data interface classes.
-
-        Returns
-        -------
-        dict
-            The compiled conversion options schema containing:
-            - root: True
-            - id: "conversion_options.schema.json"
-            - title: "Conversion options schema"
-            - description: "Schema for the conversion options"
-            - version: "0.1.0"
-            - properties: Dictionary mapping interface names to their unrooted schemas
-        """
-        conversion_options_schema = get_base_schema(
-            root=True,
-            id_="conversion_options.schema.json",
-            title="Conversion options schema",
-            description="Schema for the conversion options",
-            version="0.1.0",
-        )
-        for interface_name, data_interface in self.data_interface_objects.items():
-
-            schema = data_interface.get_conversion_options_schema()
-            conversion_options_schema["properties"].update({interface_name: unroot_schema(schema)})
-        return conversion_options_schema


### PR DESCRIPTION
Closes #2026.

`ConverterPipe.get_conversion_options_schema` was a line-for-line copy of the `NWBConverter` method. `SpikeGLXConverterPipe` and `OpenEphysBinaryConverter` each called the parent and then re-added every interface's schema on top of the entry the parent had just added. The one thing the overrides did differently was skip `unroot_schema`, and for the five interfaces those converters hold the generated schema carries only `additionalProperties`, `properties` and `type`, which `unroot_schema` keeps, so the override and the parent returned the same dictionary. I checked that by building each interface's schema from its `add_to_nwbfile` signature and comparing it against its unrooted form.

No behaviour changes; 42 lines go. The change was drafted by the AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDEA1i6RePp7Tfrbxu3Y3P