### PR TITLE
Drop a dead constructor argument and a duplicate import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * `HDF5DatasetIOConfiguration` and `ZarrDatasetIOConfiguration` now describe a dataset's codec pipeline with an ordered `compressors` list and a matching `compressor_options`, which makes the HDF5 `shuffle` and `fletcher32` filters reachable for the first time and gives both backends the same vocabulary. [PR #1979](https://github.com/catalystneuro/neuroconv/pull/1979)
 
 ## Improvements
+* Removed the `object_name` argument that two `DatasetIOConfiguration` constructors passed to a model that declares no such field, so pydantic dropped it silently, and a duplicate import in `neuroconv.utils`. [PR #2031](https://github.com/catalystneuro/neuroconv/pull/2031)
 * `EDFRecordingInterface` now reports the patient field's birthdate as `Subject.date_of_birth`, parsed into an ISO 8601 date from the `17 mar 1985` spelling the readers hand back. [PR #1999](https://github.com/catalystneuro/neuroconv/pull/1999)
 
 # v0.10.1 (September 1, 2026)

--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
@@ -412,7 +412,6 @@ class DatasetIOConfiguration(BaseModel, ABC):
 
         return cls(
             object_id=neurodata_object.object_id,
-            object_name=neurodata_object.name,
             location_in_file=location_in_file,
             dataset_name=dataset_name,
             full_shape=full_shape,
@@ -465,7 +464,6 @@ class DatasetIOConfiguration(BaseModel, ABC):
         )
         return dict(
             object_id=neurodata_object.object_id,
-            object_name=neurodata_object.name,
             location_in_file=location_in_file,
             dataset_name=dataset_name,
             full_shape=full_shape,

--- a/src/neuroconv/utils/__init__.py
+++ b/src/neuroconv/utils/__init__.py
@@ -15,7 +15,6 @@ from .json_schema import (
     get_schema_from_hdmf_class,
     get_json_schema_from_method_signature,
     unroot_schema,
-    get_json_schema_from_method_signature,
 )
 from .str_utils import to_camel_case, to_snake_case
 from .types import (


### PR DESCRIPTION
Closes #2030.

`DatasetIOConfiguration.from_neurodata_object_with_defaults` and `DatasetIOConfiguration.get_kwargs_from_neurodata_object` both passed `object_name=neurodata_object.name` to the model constructor. No configuration model declares that field, and pydantic's default `extra` policy is `ignore`, so the value was dropped without a word; nothing reads it, and `location_in_file` already carries the name. Both call sites lose the argument.

`neuroconv/utils/__init__.py` imported `get_json_schema_from_method_signature` twice in one block; the second line goes.

No behaviour changes. The backend configuration and utils suites pass. The change was drafted by the AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDEA1i6RePp7Tfrbxu3Y3P