### PR TITLE
Expose `always_write_timestamps` and `data_representation` on LFP interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Removed the `hdf5` and `sbx` installation extras, aliases of `hdf5imaging` and `scanbox` kept for gallery pages that named the old spellings and marked for removal at the start of 2026. Use `neuroconv[hdf5imaging]` and `neuroconv[scanbox]`.
 
 ## Bug Fixes
+* `BaseLFPExtractorInterface.add_to_nwbfile` now accepts and forwards `always_write_timestamps` and `data_representation`, which the recording base already took, so an LFP interface can write an irregular clock as explicit timestamps or heterogeneous offsets as physical units the same way a raw interface does, through `add_to_nwbfile`, `run_conversion` and a converter's `conversion_options`. [PR #2033](https://github.com/catalystneuro/neuroconv/pull/2033)
 * Filter empty fluorescence traces on `math.prod(trace.shape)` instead of `trace.size`, which the `DatasetView` objects `get_traces_dict()` can return do not have. [PR #2005](https://github.com/catalystneuro/neuroconv/pull/2005)
 * Reading an existing Zarr file now reports its shuffle in `compressors` rather than among the filters, so a file this library wrote reports the configuration that wrote it and naming shuffle again does not apply it twice. [PR #2002](https://github.com/catalystneuro/neuroconv/pull/2002)
 * Fixed the Zarr shuffle codec taking `numcodecs`' default `elementsize` of 4 regardless of the dataset's dtype, which on float64 grouped the wrong bytes and recovered almost nothing, so it is now taken from the dtype unless the caller states one. [PR #1984](https://github.com/catalystneuro/neuroconv/pull/1984)

--- a/src/neuroconv/datainterfaces/ecephys/baselfpextractorinterface.py
+++ b/src/neuroconv/datainterfaces/ecephys/baselfpextractorinterface.py
@@ -43,10 +43,18 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
         stub_test: bool = False,
         parent_container: Literal["acquisition", "processing/LFP", "processing/FilteredEphys"] = "processing/LFP",
         write_as: Literal["raw", "lfp", "processed"] | None = None,
+        data_representation: Literal["digital_counts", "physical_units"] = "digital_counts",
         write_electrical_series: bool = True,
         iterator_type: str = "v2",
         iterator_options: dict | None = None,
+        always_write_timestamps: bool = False,
     ):
+        """
+        Add the LFP traces to the NWBFile, into ``processing/LFP`` unless ``parent_container`` says otherwise.
+
+        The arguments are those of :meth:`BaseRecordingExtractorInterface.add_to_nwbfile`, with
+        ``parent_container`` defaulting to ``"processing/LFP"``.
+        """
         # Handle deprecated positional arguments
         if args:
             parameter_names = [
@@ -97,7 +105,9 @@ class BaseLFPExtractorInterface(BaseRecordingExtractorInterface):
             metadata=metadata,
             stub_test=stub_test,
             parent_container=parent_container,
+            data_representation=data_representation,
             write_electrical_series=write_electrical_series,
             iterator_type=iterator_type,
             iterator_options=iterator_options,
+            always_write_timestamps=always_write_timestamps,
         )

--- a/tests/test_modalities/test_ecephys/test_lfp_interface.py
+++ b/tests/test_modalities/test_ecephys/test_lfp_interface.py
@@ -1,0 +1,60 @@
+"""The LFP base forwards the recording base's conversion options; nothing in the repository tested it directly."""
+
+import numpy as np
+from pynwb.testing.mock.file import mock_NWBFile
+
+from neuroconv.datainterfaces.ecephys.baselfpextractorinterface import BaseLFPExtractorInterface
+
+
+class MinimalLFPInterface(BaseLFPExtractorInterface):
+    """An LFP interface over spikeinterface's generated recording, the way ``MockRecordingInterface`` is built."""
+
+    @classmethod
+    def get_extractor_class(cls):
+        from spikeinterface.core.generate import generate_recording
+
+        return generate_recording
+
+    def _initialize_extractor(self, interface_kwargs: dict):
+        # ``generate_recording`` does not take the ``all_annotations`` the recording base adds for real extractors.
+        self.extractor_kwargs = {
+            key: value for key, value in interface_kwargs.items() if key not in ("verbose", "es_key", "metadata_key")
+        }
+        return self.get_extractor_class()(**self.extractor_kwargs)
+
+
+def _make_interface() -> MinimalLFPInterface:
+    return MinimalLFPInterface(num_channels=4, sampling_frequency=1_000.0, durations=(1.0,), seed=0)
+
+
+def test_lfp_interface_writes_to_processing_by_default():
+    interface = _make_interface()
+    nwbfile = mock_NWBFile()
+    interface.add_to_nwbfile(nwbfile=nwbfile)
+    assert "ElectricalSeriesLFP" in nwbfile.processing["ecephys"]["LFP"].electrical_series
+
+
+def test_lfp_interface_forwards_always_write_timestamps():
+    interface = _make_interface()
+    nwbfile = mock_NWBFile()
+    interface.add_to_nwbfile(nwbfile=nwbfile, always_write_timestamps=True)
+    electrical_series = nwbfile.processing["ecephys"]["LFP"].electrical_series["ElectricalSeriesLFP"]
+    np.testing.assert_array_equal(electrical_series.timestamps[:], interface.recording_extractor.get_times())
+
+
+def test_lfp_interface_forwards_data_representation():
+    interface = _make_interface()
+    # Heterogeneous offsets are what physical_units is for: a single series cannot carry them as digital counts.
+    interface.recording_extractor.set_channel_gains(gains=[0.5, 0.5, 0.5, 0.5])
+    interface.recording_extractor.set_channel_offsets(offsets=[0.0, 1.0, 2.0, 3.0])
+    nwbfile = mock_NWBFile()
+    interface.add_to_nwbfile(nwbfile=nwbfile, data_representation="physical_units")
+    electrical_series = nwbfile.processing["ecephys"]["LFP"].electrical_series["ElectricalSeriesLFP"]
+    assert electrical_series.conversion == 1e-6
+    assert electrical_series.offset == 0.0
+    assert np.issubdtype(np.asarray(electrical_series.data[:5]).dtype, np.floating)
+
+
+def test_lfp_interface_conversion_options_schema_names_both_options():
+    schema = _make_interface().get_conversion_options_schema()
+    assert {"always_write_timestamps", "data_representation"} <= set(schema["properties"])


### PR DESCRIPTION
Closes #2032.

`BaseLFPExtractorInterface.add_to_nwbfile` overrides the recording base's method to make `processing/LFP` the default `parent_container`, but its signature stopped at `iterator_options`. `always_write_timestamps` and `data_representation`, which the parent takes and hands to `add_recording_to_nwbfile`, could therefore not reach the writer through an LFP interface, whether by `add_to_nwbfile`, `run_conversion` or a converter's `conversion_options`, and the options schema derived from the signature left them out. Both are now taken and forwarded. An LFP band with an irregular clock, or with heterogeneous channel offsets, has the same need for them as the raw band.

Nothing tested the LFP base directly, so the new module builds a minimal LFP interface over spikeinterface's generated recording, the way `MockRecordingInterface` is built, and checks the default container, the explicit timestamps, the physical-unit write over heterogeneous offsets, and that the schema names both options. The three option tests fail on `main`. The code and tests were drafted by the AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDEA1i6RePp7Tfrbxu3Y3P