### PR TITLE
Align gzip defaults across backends and preserve iterator dtype

### DIFF
--- a/changelog_entries/2047.deprecation.md
+++ b/changelog_entries/2047.deprecation.md
@@ -1,0 +1,1 @@
+Gzip now defaults explicitly to level 4 on both backends, changing Zarr's default from level 1; pass an explicit `level` in `compressor_options` to select another level.

--- a/changelog_entries/2047.improvement.md
+++ b/changelog_entries/2047.improvement.md
@@ -1,0 +1,1 @@
+Backend configuration now passes the configured dtype when wrapping data in `DataChunkIterator`, avoiding a buffer read solely to infer the dtype.

--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_base_dataset_io.py
@@ -34,6 +34,9 @@ from neuroconv.utils.str_utils import human_readable_size
 from ._pydantic_pure_json_schema_generator import PureJSONSchemaGenerator
 from ...hdmf import SliceableDataChunkIterator
 
+# Match HDF5's existing default on both backends, independently of codec library defaults.
+_DEFAULT_GZIP_LEVEL = 4
+
 
 def _recursively_find_location_in_memory_nwbfile(current_location: str, neurodata_object: Container) -> str:
     """

--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_hdf5_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_hdf5_dataset_io.py
@@ -7,7 +7,7 @@ from hdmf import Container
 from pydantic import Field, InstanceOf, model_validator
 from typing_extensions import Self
 
-from ._base_dataset_io import DatasetIOConfiguration
+from ._base_dataset_io import _DEFAULT_GZIP_LEVEL, DatasetIOConfiguration
 from ...importing import is_package_installed
 
 _base_hdf5_filters = set(h5py.filters.decode)
@@ -133,7 +133,10 @@ class HDF5DatasetIOConfiguration(DatasetIOConfiguration):
             # configuration read back off disk, so the value is taken by position rather than by name.
             compression_bundle = dict(
                 compression=compression_method,
-                compression_opts=next(iter((compression_options or dict()).values()), None),
+                compression_opts=next(
+                    iter((compression_options or dict()).values()),
+                    _DEFAULT_GZIP_LEVEL if compression_method == "gzip" else None,
+                ),
             )
         elif isinstance(compression_method, h5py._hl.filters.FilterRefBase):
             compression_bundle = dict(**compression_method, allow_plugin_filters=True)

--- a/src/neuroconv/tools/nwb_helpers/_configuration_models/_zarr_dataset_io.py
+++ b/src/neuroconv/tools/nwb_helpers/_configuration_models/_zarr_dataset_io.py
@@ -10,7 +10,7 @@ from numcodecs import Shuffle
 from pydantic import Field, InstanceOf, model_validator
 from typing_extensions import Self
 
-from ._base_dataset_io import DatasetIOConfiguration
+from ._base_dataset_io import _DEFAULT_GZIP_LEVEL, DatasetIOConfiguration
 
 _base_zarr_codecs = set(zarr.codec_registry.keys())
 _lossy_zarr_codecs = set(("astype", "bitround", "quantize"))
@@ -217,6 +217,9 @@ class ZarrDatasetIOConfiguration(DatasetIOConfiguration):
             return codec
 
         codec_options = dict(codec_options or dict())
+        if codec == "gzip":
+            codec_options.setdefault("level", _DEFAULT_GZIP_LEVEL)
+
         # `numcodecs.Shuffle` defaults `elementsize` to 4 whatever the dtype is, so on anything wider it
         # transposes the wrong byte planes and recovers almost nothing. The configuration knows the dtype.
         # TODO: remove once hdmf-zarr moves off `zarr<3.0`, where `Shuffle.evolve_from_array_spec` fills

--- a/src/neuroconv/tools/nwb_helpers/_configure_backend.py
+++ b/src/neuroconv/tools/nwb_helpers/_configure_backend.py
@@ -69,7 +69,9 @@ def configure_backend(
             # we wrap each neurodata_object in a DataChunkIterator in order to support changes to the I/O settings.
             # For more detail, see https://github.com/hdmf-dev/hdmf/issues/1170.
             data_chunk_iterator_class = DataChunkIterator
-            data_chunk_iterator_kwargs = dict(buffer_size=math.prod(dataset_configuration.buffer_shape))
+            data_chunk_iterator_kwargs = dict(
+                buffer_size=math.prod(dataset_configuration.buffer_shape), dtype=dataset_configuration.dtype
+            )
 
         # Table columns
         if isinstance(neurodata_object, Data):

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_configure_and_write_unimported_extension.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_configure_and_write_unimported_extension.py
@@ -76,4 +76,4 @@ def test_configure_and_write_nwbfile_with_unimported_extension(
         if backend == "hdf5":
             assert written_data.compression == "gzip"
         else:
-            assert written_data.compressor == numcodecs.GZip(level=1)
+            assert written_data.compressor == numcodecs.GZip(level=4)

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_configure_backend_appended_files.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_configure_backend_appended_files.py
@@ -54,3 +54,24 @@ def test_appended_time_series(nwbfile_path: str):
 
     assert_array_equal(written_nwbfile.acquisition["ExistingTimeSeries"].data[:], EXISTING_ARRAY)
     written_nwbfile.read_io.close()
+
+
+@pytest.mark.parametrize("backend", ["hdf5", "zarr"])
+def test_configuring_existing_data_does_not_read_iterator_buffer(nwbfile_path, backend, monkeypatch):
+    """The source dtype is already known, so constructing its iterator should not read data."""
+    from hdmf.data_utils import DataChunkIterator
+
+    def unexpected_read(self):
+        raise AssertionError("Iterator construction should use the configured dtype without reading a buffer")
+
+    with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
+        nwbfile = io.read()
+        configuration = get_default_backend_configuration(nwbfile=nwbfile, backend=backend)
+        with monkeypatch.context() as patch:
+            patch.setattr(DataChunkIterator, "_read_next_chunk", unexpected_read)
+            configure_backend(nwbfile=nwbfile, backend_configuration=configuration)
+
+        iterator = nwbfile.acquisition["ExistingTimeSeries"].data.data
+        assert isinstance(iterator, DataChunkIterator)
+        assert iterator.dtype == EXISTING_ARRAY.dtype
+        assert_array_equal(next(iterator).data, EXISTING_ARRAY)

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_configure_backend_defaults.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_configure_backend_defaults.py
@@ -84,8 +84,9 @@ def test_simple_time_series(
 
     if backend == "hdf5":
         assert written_data.compression == "gzip"
+        assert written_data.compression_opts == 4
     elif backend == "zarr":
-        assert written_data.compressor == numcodecs.GZip(level=1)
+        assert written_data.compressor == numcodecs.GZip(level=4)
 
     assert_array_equal(integer_array, written_data[:])
     written_nwbfile.read_io.close()
@@ -117,8 +118,9 @@ def test_simple_dynamic_table(tmpdir: Path, integer_array: np.ndarray, backend: 
 
     if backend == "hdf5":
         assert written_data.compression == "gzip"
+        assert written_data.compression_opts == 4
     elif backend == "zarr":
-        assert written_data.compressor == numcodecs.GZip(level=1)
+        assert written_data.compressor == numcodecs.GZip(level=4)
 
     assert_array_equal(integer_array, written_data[:])
     written_nwbfile.read_io.close()
@@ -152,8 +154,9 @@ def test_simple_image(tmpdir: Path, backend: Literal["hdf5", "zarr"]):
 
     if backend == "hdf5":
         assert written_data.compression == "gzip"
+        assert written_data.compression_opts == 4
     elif backend == "zarr":
-        assert written_data.compressor == numcodecs.GZip(level=1)
+        assert written_data.compressor == numcodecs.GZip(level=4)
 
     assert_array_equal(array, written_data[:])
     written_nwbfile.read_io.close()
@@ -216,24 +219,27 @@ def test_time_series_timestamps_linkage(
     assert written_data_1.chunks == dataset_configuration_1.chunk_shape
     if backend == "hdf5":
         assert written_data_1.compression == "gzip"
+        assert written_data_1.compression_opts == 4
     elif backend == "zarr":
-        assert written_data_1.compressor == numcodecs.GZip(level=1)
+        assert written_data_1.compressor == numcodecs.GZip(level=4)
     assert_array_equal(integer_array, written_data_1[:])
 
     written_data_2 = written_nwbfile.acquisition["TestTimeSeries2"].data
     assert written_data_2.chunks == dataset_configuration_2.chunk_shape
     if backend == "hdf5":
         assert written_data_2.compression == "gzip"
+        assert written_data_2.compression_opts == 4
     elif backend == "zarr":
-        assert written_data_2.compressor == numcodecs.GZip(level=1)
+        assert written_data_2.compressor == numcodecs.GZip(level=4)
     assert_array_equal(integer_array, written_data_2[:])
 
     written_timestamps_1 = written_nwbfile.acquisition["TestTimeSeries1"].timestamps
     assert written_timestamps_1.chunks == timestamps_configuration_1.chunk_shape
     if backend == "hdf5":
         assert written_timestamps_1.compression == "gzip"
+        assert written_timestamps_1.compression_opts == 4
     elif backend == "zarr":
-        assert written_timestamps_1.compressor == numcodecs.GZip(level=1)
+        assert written_timestamps_1.compressor == numcodecs.GZip(level=4)
     assert_array_equal(timestamps_array, written_timestamps_1[:])
 
     written_timestamps_2 = written_nwbfile.acquisition["TestTimeSeries2"].timestamps
@@ -285,7 +291,8 @@ def test_plane_segmentation_pixel_mask(
     assert written_dataset.chunks == dataset_configuration.chunk_shape
     if backend == "hdf5":
         assert written_dataset.compression == "gzip"
+        assert written_dataset.compression_opts == 4
     elif backend == "zarr":
-        assert written_dataset.compressor == numcodecs.GZip(level=1)
+        assert written_dataset.compressor == numcodecs.GZip(level=4)
     assert_array_equal(written_dataset[:], expected_pixel_mask)
     written_nwbfile.read_io.close()

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_configure_backend_overrides.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_configure_backend_overrides.py
@@ -155,5 +155,5 @@ def test_shuffle_is_correctly_propagated_as_filter_in_zarr(tmpdir: Path):
 
     filters, compressors = written_filters_and_compressors(written_data)
     assert filters == [numcodecs.Shuffle(elementsize=2)]
-    assert compressors == [numcodecs.GZip(level=1)]
+    assert compressors == [numcodecs.GZip(level=4)]
     written_nwbfile.read_io.close()

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_configure_backend_zero_length_axes.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_configure_backend_zero_length_axes.py
@@ -85,7 +85,7 @@ def test_time_series_skip_zero_length_axis(
     #     if backend == "hdf5":
     #         assert written_data.compression == "gzip"
     #     elif backend == "zarr":
-    #         assert written_data.compressor == numcodecs.GZip(level=1)
+    #         assert written_data.compressor == numcodecs.GZip(level=4)
     #
     #     assert_array_equal(integer_array, written_data[:])
 
@@ -128,7 +128,7 @@ def test_dynamic_table_skip_zero_length_axis(
     if backend == "hdf5":
         assert written_data.compression == "gzip"
     elif backend == "zarr":
-        assert written_data.compressor == numcodecs.GZip(level=1)
+        assert written_data.compressor == numcodecs.GZip(level=4)
 
     assert_array_equal(integer_array, written_data[:])
     written_nwbfile.read_io.close()

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_repack_nwbfile.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_helpers/test_repack_nwbfile.py
@@ -118,7 +118,7 @@ def zarr_nwbfile_path(tmpdir_factory):
 
 @pytest.mark.parametrize("backend", ["hdf5", "zarr"])
 def test_repack_nwbfile(hdf5_nwbfile_path, zarr_nwbfile_path, backend):
-    default_compressor = GZip(level=1)
+    default_compressor = GZip(level=4)
 
     if backend == "hdf5":
         nwbfile_path = hdf5_nwbfile_path
@@ -157,7 +157,7 @@ def test_repack_nwbfile(hdf5_nwbfile_path, zarr_nwbfile_path, backend):
 def test_repack_nwbfile_hdf5_to_zarr(hdf5_nwbfile_path: str, tmp_path: Path):
     """Test repackaging an NWB file from HDF5 to Zarr."""
     export_nwbfile_path = tmp_path / "repacked_hdf5_to_zarr.nwb.zarr"
-    default_compressor = GZip(level=1)
+    default_compressor = GZip(level=4)
 
     repack_nwbfile(
         nwbfile_path=Path(hdf5_nwbfile_path),

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_models/test_gzip_defaults.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_models/test_gzip_defaults.py
@@ -1,0 +1,38 @@
+"""Gzip defaults agree across backends without overriding caller settings."""
+
+import pytest
+from numcodecs import GZip
+
+from neuroconv.tools.testing import mock_HDF5DatasetIOConfiguration, mock_ZarrDatasetIOConfiguration
+
+
+@pytest.mark.parametrize(
+    "options,expected_level", [(None, 4), ({}, 4), ({"level": 0}, 0), ({"level": 1}, 1), ({"level": 9}, 9)]
+)
+@pytest.mark.parametrize("with_shuffle", [False, True])
+def test_gzip_level_agrees_across_backends(options, expected_level, with_shuffle):
+    compressors = ["shuffle", "gzip"] if with_shuffle else ["gzip"]
+    compressor_options = [None, options] if with_shuffle else [options]
+    hdf5 = mock_HDF5DatasetIOConfiguration(compressors=compressors, compressor_options=compressor_options)
+    zarr = mock_ZarrDatasetIOConfiguration(compressors=compressors, compressor_options=compressor_options)
+
+    assert hdf5.get_data_io_kwargs()["compression_opts"] == expected_level
+    assert zarr.get_data_io_kwargs()["compressor"].level == expected_level
+    assert hdf5.compressor_options == compressor_options
+    assert zarr.compressor_options == compressor_options
+
+
+def test_gzip_instance_is_preserved():
+    compressor = GZip(level=1)
+    configuration = mock_ZarrDatasetIOConfiguration(compressors=[compressor])
+    assert configuration.get_data_io_kwargs()["compressor"] is compressor
+
+
+def test_hdf5_existing_gzip_options_are_preserved():
+    configuration = mock_HDF5DatasetIOConfiguration(compressor_options=[{"compression_opts": 0}])
+    assert configuration.get_data_io_kwargs()["compression_opts"] == 0
+
+
+def test_other_hdf5_compression_does_not_receive_gzip_level():
+    configuration = mock_HDF5DatasetIOConfiguration(compressors=["lzf"])
+    assert configuration.get_data_io_kwargs()["compression_opts"] is None

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_models/test_hdf5_dataset_io_configuration_model.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_models/test_hdf5_dataset_io_configuration_model.py
@@ -23,7 +23,7 @@ def test_get_data_io_kwargs():
     hdf5_dataset_configuration = mock_HDF5DatasetIOConfiguration()
 
     assert hdf5_dataset_configuration.get_data_io_kwargs() == dict(
-        chunks=(78125, 64), compression="gzip", compression_opts=None
+        chunks=(78125, 64), compression="gzip", compression_opts=4
     )
 
 
@@ -37,7 +37,7 @@ def test_get_data_io_kwargs_with_shuffle():
     hdf5_dataset_configuration = mock_HDF5DatasetIOConfiguration(compressors=["shuffle", "gzip"])
 
     assert hdf5_dataset_configuration.get_data_io_kwargs() == dict(
-        chunks=(78125, 64), compression="gzip", compression_opts=None, shuffle=True
+        chunks=(78125, 64), compression="gzip", compression_opts=4, shuffle=True
     )
 
 
@@ -45,7 +45,7 @@ def test_get_data_io_kwargs_with_shuffle_and_fletcher32():
     hdf5_dataset_configuration = mock_HDF5DatasetIOConfiguration(compressors=["shuffle", "gzip", "fletcher32"])
 
     assert hdf5_dataset_configuration.get_data_io_kwargs() == dict(
-        chunks=(78125, 64), compression="gzip", compression_opts=None, shuffle=True, fletcher32=True
+        chunks=(78125, 64), compression="gzip", compression_opts=4, shuffle=True, fletcher32=True
     )
 
 

--- a/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_models/test_zarr_dataset_io_configuration_model.py
+++ b/tests/test_minimal/test_tools/test_backend_and_dataset_configuration/test_models/test_zarr_dataset_io_configuration_model.py
@@ -56,7 +56,7 @@ def test_get_data_io_kwargs():
     zarr_dataset_configuration = mock_ZarrDatasetIOConfiguration()
 
     assert zarr_dataset_configuration.get_data_io_kwargs() == dict(
-        chunks=(78125, 64), compressor=GZip(level=1), filters=None
+        chunks=(78125, 64), compressor=GZip(level=4), filters=None
     )
 
 
@@ -71,7 +71,7 @@ def test_get_data_io_kwargs_with_shuffle():
     zarr_dataset_configuration = mock_ZarrDatasetIOConfiguration(compressors=["shuffle", "gzip"])
 
     assert zarr_dataset_configuration.get_data_io_kwargs() == dict(
-        chunks=(78125, 64), compressor=GZip(level=1), filters=[Shuffle(elementsize=2)]
+        chunks=(78125, 64), compressor=GZip(level=4), filters=[Shuffle(elementsize=2)]
     )
 
 
@@ -82,7 +82,7 @@ def test_get_data_io_kwargs_with_shuffle_and_a_filter_method():
     )
 
     assert zarr_dataset_configuration.get_data_io_kwargs() == dict(
-        chunks=(78125, 64), compressor=GZip(level=1), filters=[Delta(dtype="int16"), Shuffle(elementsize=2)]
+        chunks=(78125, 64), compressor=GZip(level=4), filters=[Delta(dtype="int16"), Shuffle(elementsize=2)]
     )
 
 


### PR DESCRIPTION
I was running a session of the IBL conversion on Zarr and I realized that our gzip defaults differ between backends. This PR aligns them at level 4. I also pass the configured dtype to `DataChunkIterator` to avoid reading a buffer just to infer it.
