### PR TITLE
Enable Zarr read-back checks for imaging conversions

### DIFF
--- a/changelog_entries/2048.improvement.md
+++ b/changelog_entries/2048.improvement.md
@@ -1,0 +1,1 @@
+Imaging conversion tests now check read-back on both HDF5 and Zarr, requiring `roiextractors>=0.10.0`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -367,7 +367,7 @@ fiber_photometry = [
 
 ## Ophys
 ophys_minimal = [  # Keeps the minimal version of ophys dependencies in the repo
-    "roiextractors>=0.9.0",
+    "roiextractors>=0.10.0",
 ]
 # What it takes to read a tiff, stated once for the formats that are stored as one. Membership is by
 # what the format reads and not by modality, so Inscopix (.isxd) and Miniscope (video) are not here.

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -298,9 +298,6 @@ class ImagingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
     data_interface_cls: type[BaseImagingExtractorInterface]
     optical_series_name: str = "TwoPhotonSeries"
 
-    # `check_read_nwb` goes through roiextractors' NwbImagingExtractor, which opens the file with NWBHDF5IO
-    check_read_nwb_backends = ("hdf5",)
-
     # TODO: remove test_metadata_old_list_format and check_extracted_metadata_old_list_format
     # when old list-based metadata format is removed
     def test_metadata_old_list_format(self, setup_interface):
@@ -1041,9 +1038,6 @@ class MiniscopeImagingInterfaceMixin(ImagingExtractorInterfaceTestMixin):
     """
 
     optical_series_name = "OnePhotonSeries"
-
-    # This mixin reads the file itself instead of going through NwbImagingExtractor, so zarr is checkable
-    check_read_nwb_backends = ("hdf5", "zarr")
 
     def check_read_nwb(self, nwbfile_path: str):
         from ndx_miniscope import Miniscope


### PR DESCRIPTION
More Zarr support. Now that roiextractors 0.10.0 supports reading Zarr-backed NWB files, the imaging checks no longer need their HDF5-only restriction. This PR bumps the minimum version and lets imaging conversion tests check both backends.
