### PR TITLE
Run custom conversion checks on both HDF5 and Zarr

### DIFF
--- a/changelog_entries/2048.improvement.md
+++ b/changelog_entries/2048.improvement.md
@@ -1,0 +1,1 @@
+Imaging conversion tests now check read-back on both HDF5 and Zarr, requiring `roiextractors>=0.10.0`.

--- a/changelog_entries/2050.improvement.md
+++ b/changelog_entries/2050.improvement.md
@@ -1,0 +1,1 @@
+Custom conversion checks now run on both HDF5 and Zarr, including the DeepLabCut custom timestamp check.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -367,7 +367,7 @@ fiber_photometry = [
 
 ## Ophys
 ophys_minimal = [  # Keeps the minimal version of ophys dependencies in the repo
-    "roiextractors>=0.9.0",
+    "roiextractors>=0.10.0",
 ]
 # What it takes to read a tiff, stated once for the formats that are stored as one. Membership is by
 # what the format reads and not by modality, so Inscopix (.isxd) and Miniscope (video) are not here.

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -160,6 +160,7 @@ class DataInterfaceTestMixin:
 
         nwbfile_path = str(tmp_path / f"{self.__class__.__name__}_{self.test_name}_{backend}.nwb")
         self.nwbfile_path = nwbfile_path
+        self.backend = backend
 
         self.interface.run_conversion(
             nwbfile_path=nwbfile_path,
@@ -172,9 +173,7 @@ class DataInterfaceTestMixin:
         if backend in self.check_read_nwb_backends:
             self.check_read_nwb(nwbfile_path=nwbfile_path)
 
-        # Custom checks tend to write more files of their own, so they run against one backend only
-        if backend == "hdf5":
-            self.run_custom_checks()
+        self.run_custom_checks()
 
     def edit_metadata(self, metadata: dict) -> dict:
         """Override this to edit the interface's metadata before it is written, the way a user would."""
@@ -186,7 +185,7 @@ class DataInterfaceTestMixin:
         pass
 
     def run_custom_checks(self):
-        """Override this in child classes to inject additional custom checks."""
+        """Check each conversion using ``self.nwbfile_path`` and ``self.backend`` for any additional writes."""
         pass
 
 

--- a/src/neuroconv/tools/testing/data_interface_mixins.py
+++ b/src/neuroconv/tools/testing/data_interface_mixins.py
@@ -298,9 +298,6 @@ class ImagingExtractorInterfaceTestMixin(DataInterfaceTestMixin, TemporalAlignme
     data_interface_cls: type[BaseImagingExtractorInterface]
     optical_series_name: str = "TwoPhotonSeries"
 
-    # `check_read_nwb` goes through roiextractors' NwbImagingExtractor, which opens the file with NWBHDF5IO
-    check_read_nwb_backends = ("hdf5",)
-
     # TODO: remove test_metadata_old_list_format and check_extracted_metadata_old_list_format
     # when old list-based metadata format is removed
     def test_metadata_old_list_format(self, setup_interface):
@@ -1041,9 +1038,6 @@ class MiniscopeImagingInterfaceMixin(ImagingExtractorInterfaceTestMixin):
     """
 
     optical_series_name = "OnePhotonSeries"
-
-    # This mixin reads the file itself instead of going through NwbImagingExtractor, so zarr is checkable
-    check_read_nwb_backends = ("hdf5", "zarr")
 
     def check_read_nwb(self, nwbfile_path: str):
         from ndx_miniscope import Miniscope

--- a/tests/test_on_data/behavior/test_lightningpose_converter.py
+++ b/tests/test_on_data/behavior/test_lightningpose_converter.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from warnings import warn
 
 from hdmf.testing import TestCase
-from pynwb import NWBHDF5IO
+from pynwb import read_nwb
 from pynwb.image import ImageSeries
 
 from neuroconv import ConverterPipe, NWBConverter
@@ -149,8 +149,8 @@ class TestLightningPoseConverter(TestCase):
     def assertNWBFileStructure(self, nwbfile_path: str, stub_test: bool = False, links_video: bool = True):
         from ndx_pose import PoseEstimation
 
-        with NWBHDF5IO(path=nwbfile_path) as io:
-            nwbfile = io.read()
+        nwbfile = read_nwb(nwbfile_path)
+        try:
 
             self.assertEqual(nwbfile.session_start_time, datetime(2023, 11, 9, 10, 14, 37).astimezone())
 
@@ -196,6 +196,8 @@ class TestLightningPoseConverter(TestCase):
             for pose_estimation_series in pose_estimation_container.pose_estimation_series.values():
                 self.assertEqual(pose_estimation_series.data.shape[0], num_frames)
                 self.assertEqual(pose_estimation_series.confidence.shape[0], num_frames)
+        finally:
+            nwbfile.read_io.close()
 
     def test_converter_in_converter(self):
         class TestConverter(NWBConverter):

--- a/tests/test_on_data/behavior/test_pose_estimation_interfaces.py
+++ b/tests/test_on_data/behavior/test_pose_estimation_interfaces.py
@@ -1043,7 +1043,9 @@ class TestDeepLabCutInterfaceSetTimestamps(PoseEstimationInterfaceTestMixin):
         self.interface.set_aligned_timestamps(custom_timestamps)
         assert len(self.interface._timestamps) == 2330
 
-        self.interface.run_conversion(nwbfile_path=nwbfile_path, metadata=metadata, overwrite=True)
+        self.interface.run_conversion(
+            nwbfile_path=nwbfile_path, metadata=metadata, overwrite=True, backend=self.backend
+        )
 
         nwbfile = read_nwb(nwbfile_path)
         assert "behavior" in nwbfile.processing

--- a/tests/test_on_data/ecephys/test_sorting_interfaces.py
+++ b/tests/test_on_data/ecephys/test_sorting_interfaces.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import numpy as np
-from pynwb import NWBHDF5IO
+from pynwb import read_nwb
 
 from neuroconv.datainterfaces import (
     BlackrockRecordingInterface,
@@ -145,12 +145,14 @@ class TestCellExplorerSortingInterface(SortingExtractorInterfaceTestMixin):
                 assert expected_value == extracted_value
 
         # Test that the electrode table has the expected values
-        with NWBHDF5IO(self.nwbfile_path, "r") as io:
-            nwbfile = io.read()
+        nwbfile = read_nwb(self.nwbfile_path)
+        try:
             electrode_table = nwbfile.electrodes.to_dataframe()
             electrode_table_row = electrode_table.query(f"channel_name=='{channel_id}'").iloc[0]
             for key, value in expected_channel_properties_electrodes.items():
                 assert electrode_table_row[key] == value
+        finally:
+            nwbfile.read_io.close()
 
 
 class TestNeuralynxSortingInterfaceCheetahV551(SortingExtractorInterfaceTestMixin):

--- a/tests/test_on_data/fiber_photometry/guppy/test_doric.py
+++ b/tests/test_on_data/fiber_photometry/guppy/test_doric.py
@@ -22,7 +22,7 @@ import h5py
 import numpy as np
 import pandas
 import pytest
-from pynwb import NWBHDF5IO
+from pynwb import read_nwb
 
 from neuroconv.converters import GuppyConverter
 from neuroconv.datainterfaces.fiber_photometry.guppy.doric_utils import (
@@ -188,8 +188,8 @@ class TestGuppyConverterDoricModernHDF5(DoricConverterTestMixin):
         nwbfile_path = tmp_path / "doric_events.nwb"
         converter.run_conversion(nwbfile_path=str(nwbfile_path), metadata=metadata, overwrite=True)
 
-        with NWBHDF5IO(str(nwbfile_path), "r") as io:
-            nwbfile = io.read()
+        nwbfile = read_nwb(str(nwbfile_path))
+        try:
             counts = {
                 table_name: len(nwbfile.get_events_table(table_name))
                 for table_name in self.EXPECTED_EVENT_TABLE_TO_COUNT
@@ -199,6 +199,8 @@ class TestGuppyConverterDoricModernHDF5(DoricConverterTestMixin):
             registry = nwbfile.processing["guppy"]["events"]
             registry_names = {str(registry["event_name"][row]) for row in range(len(registry.id))}
             assert registry_names == set(self.EVENT_STORE_TO_NAME.values())
+        finally:
+            nwbfile.read_io.close()
 
 
 class TestGuppyConverterDoricLegacyHDF5(DoricConverterTestMixin):
@@ -230,10 +232,12 @@ class TestGuppyConverterDoricLegacyHDF5(DoricConverterTestMixin):
 
         nwbfile_path = tmp_path / "doric_no_events.nwb"
         converter.run_conversion(nwbfile_path=str(nwbfile_path), metadata=metadata, overwrite=True)
-        with NWBHDF5IO(str(nwbfile_path), "r") as io:
-            nwbfile = io.read()
+        nwbfile = read_nwb(str(nwbfile_path))
+        try:
             assert not nwbfile.events
             assert len(nwbfile.processing["guppy"]["events"].id) == 0
+        finally:
+            nwbfile.read_io.close()
 
 
 class TestGuppyConverterDoricCSV(DoricConverterTestMixin):

--- a/tests/test_on_data/fiber_photometry/guppy/test_mixed_formats.py
+++ b/tests/test_on_data/fiber_photometry/guppy/test_mixed_formats.py
@@ -14,7 +14,7 @@ can be dropped in beside it without touching the shared fixture.
 import numpy as np
 import pandas
 import pytest
-from pynwb import NWBHDF5IO
+from pynwb import read_nwb
 
 from neuroconv.converters import GuppyConverter
 from neuroconv.tools.testing import generate_mock_guppy_output_folder
@@ -156,8 +156,8 @@ class TestGuppyConverterMixedEvents:
         nwbfile_path = tmp_path / "mixed_events.nwb"
         converter.run_conversion(nwbfile_path=str(nwbfile_path), metadata=metadata, overwrite=True)
 
-        with NWBHDF5IO(str(nwbfile_path), "r") as io:
-            nwbfile = io.read()
+        nwbfile = read_nwb(str(nwbfile_path))
+        try:
             assert set(nwbfile.events) == set(EVENT_NAME_TO_RAW_TABLE_NAME.values()) | {GUPPY_EVENTS_TABLE_NAME}
 
             imported_table = nwbfile.get_events_table(EVENT_NAME_TO_RAW_TABLE_NAME[IMPORTED_EVENT_NAME])
@@ -166,6 +166,8 @@ class TestGuppyConverterMixedEvents:
             np.testing.assert_allclose(
                 np.sort(imported_table.to_dataframe().timestamp.to_numpy()), IMPORTED_EVENT_ONSETS
             )
+        finally:
+            nwbfile.read_io.close()
 
     def test_a_session_whose_every_event_was_imported_reads_none_from_the_tank(self, session_folder, tmp_path):
         """With nothing left for the acquisition format, only the imported stores' interfaces are built."""

--- a/tests/test_on_data/fiber_photometry/guppy/test_reference_session.py
+++ b/tests/test_on_data/fiber_photometry/guppy/test_reference_session.py
@@ -27,7 +27,7 @@ import h5py
 import numpy as np
 import pandas
 import pytest
-from pynwb import NWBHDF5IO
+from pynwb import read_nwb
 
 from neuroconv.converters import GuppyConverter
 from neuroconv.utils import dict_deep_update
@@ -202,8 +202,11 @@ class TestGuppyReferenceSession:
     @pytest.fixture(scope="class")
     @classmethod
     def nwbfile(cls, nwbfile_path):
-        with NWBHDF5IO(str(nwbfile_path), "r") as io:
-            yield io.read()
+        nwbfile = read_nwb(str(nwbfile_path))
+        try:
+            yield nwbfile
+        finally:
+            nwbfile.read_io.close()
 
     @pytest.fixture(scope="class")
     @classmethod

--- a/tests/test_on_data/fiber_photometry/guppy/test_tdt.py
+++ b/tests/test_on_data/fiber_photometry/guppy/test_tdt.py
@@ -18,7 +18,7 @@ from datetime import datetime, timezone
 
 import numpy as np
 import pytest
-from pynwb import NWBHDF5IO
+from pynwb import read_nwb
 
 from neuroconv.converters import GuppyConverter
 from neuroconv.tools.testing import generate_mock_guppy_output_folder
@@ -122,10 +122,13 @@ class TestGuppyConverterTDT:
         nwbfile_path = tmp_path / "tdt_guppy_alignment.nwb"
         converter.run_conversion(nwbfile_path=str(nwbfile_path), metadata=metadata, overwrite=True)
 
-        with NWBHDF5IO(str(nwbfile_path), "r") as io:
-            processing_module = io.read().processing["guppy"]
+        nwbfile = read_nwb(str(nwbfile_path))
+        try:
+            processing_module = nwbfile.processing["guppy"]
             for recording_site in RECORDING_SITES:
                 dff_series = processing_module.data_interfaces[f"dff_{recording_site}"]
                 assert dff_series.timestamps is None
                 assert float(dff_series.starting_time) == pytest.approx(MOCK_GUPPY_STARTING_TIME)
                 assert float(dff_series.rate) == pytest.approx(MOCK_GUPPY_RATE)
+        finally:
+            nwbfile.read_io.close()


### PR DESCRIPTION
More Zarr support, building on #2048 as the base. This PR runs `run_custom_checks` on both backends and makes the DeepLabCut timestamp check use the backend under test. I also replaced HDF5-only readers in several tests with `read_nwb`.
