### PR TITLE
Use `Asia/Tokyo` instead of the legacy `US/Pacific` alias in the docs and tests

### DIFF
--- a/changelog_entries/2053.bugfix.md
+++ b/changelog_entries/2053.bugfix.md
@@ -1,0 +1,1 @@
+The documentation examples now set time zones with `ZoneInfo("Asia/Tokyo")` instead of legacy aliases like `US/Pacific` that recent Debian and Ubuntu releases no longer install by default, so they no longer throw `ZoneInfoNotFoundError` there.

--- a/docs/conversion_examples_gallery/behavior/audio.rst
+++ b/docs/conversion_examples_gallery/behavior/audio.rst
@@ -23,7 +23,7 @@ This interface can handle conversions from `WAV` format to NWB using the
     >>>
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/behavior/boris.rst
+++ b/docs/conversion_examples_gallery/behavior/boris.rst
@@ -41,7 +41,7 @@ bout, a bout being an occurrence of a behavior whose ethogram ``type`` is ``Stat
     >>> metadata = interface.get_metadata()
 
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
 
     >>> # Add subject information (required for DANDI upload)

--- a/docs/conversion_examples_gallery/behavior/deeplabcut.rst
+++ b/docs/conversion_examples_gallery/behavior/deeplabcut.rst
@@ -24,7 +24,7 @@ This interface supports both .h5 and .csv output files from DeepLabCut.
 
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/behavior/fictrac.rst
+++ b/docs/conversion_examples_gallery/behavior/fictrac.rst
@@ -24,7 +24,7 @@ Convert FicTrac spherical motion and fictive animal path data in a FicTrac ``.da
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/behavior/lightningpose.rst
+++ b/docs/conversion_examples_gallery/behavior/lightningpose.rst
@@ -26,7 +26,7 @@ Convert LightningPose pose estimation data to NWB using :py:class:`~neuroconv.da
     >>> metadata = converter.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
-    >>> tzinfo = ZoneInfo("US/Pacific")
+    >>> tzinfo = ZoneInfo("Asia/Tokyo")
     >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/behavior/medpc.rst
+++ b/docs/conversion_examples_gallery/behavior/medpc.rst
@@ -46,7 +46,7 @@ Convert MedPC output data to NWB using
     >>> # Extract what metadata we can from the source file
     >>> metadata = interface.get_metadata()
     >>> # We add the time zone information, which is required by NWB
-    >>> session_start_time = datetime(2019, 4, 9, 10, 34, 30).replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2019, 4, 9, 10, 34, 30).replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> metadata["MedPC"]["medpc_name_to_info_dict"] = {
     ...         "A": {"name": "left_nose_poke_times", "is_array": True},

--- a/docs/conversion_examples_gallery/behavior/moseq_keypoints.rst
+++ b/docs/conversion_examples_gallery/behavior/moseq_keypoints.rst
@@ -54,7 +54,7 @@ a frame rate, because the rate is a property of the video the keypoints came fro
     >>> metadata = interface.get_metadata()
     >>> # session_start_time is required for conversion. keypoint-MoSeq records no acquisition date,
     >>> # so you must supply one.
-    >>> session_start_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -82,7 +82,7 @@ metadata supplies them.
 
     >>> custom_metadata = {
     ...     "NWBFile": {
-    ...         "session_start_time": datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("US/Pacific")),
+    ...         "session_start_time": datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo")),
     ...     },
     ...     "Subject": dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D"),
     ...     "Behavior": {
@@ -154,7 +154,7 @@ The default object names collide when two instances share a file, so rename them
 
     >>> custom_metadata = {
     ...     "NWBFile": {
-    ...         "session_start_time": datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("US/Pacific")),
+    ...         "session_start_time": datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo")),
     ...     },
     ...     "Subject": dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D"),
     ...     "Behavior": {

--- a/docs/conversion_examples_gallery/behavior/neuralynx_nvt.rst
+++ b/docs/conversion_examples_gallery/behavior/neuralynx_nvt.rst
@@ -27,7 +27,7 @@ Convert Neuralynx NVT data to NWB using
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # We add the time zone information, which is required by NWB
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/behavior/sleap.rst
+++ b/docs/conversion_examples_gallery/behavior/sleap.rst
@@ -24,7 +24,7 @@ Convert SLEAP pose estimation data to NWB using :py:class:`~neuroconv.datainterf
     >>> metadata = interface.get_metadata()
     >>> # session_start_time is required for conversion. If it cannot be inferred
     >>> # automatically from the source files you must supply one.
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/behavior/vame.rst
+++ b/docs/conversion_examples_gallery/behavior/vame.rst
@@ -75,7 +75,7 @@ to list the session names recorded in ``config.yaml``.
 
     >>> metadata = interface.get_metadata()
     >>> metadata["NWBFile"].update(
-    ...     session_start_time=datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("US/Pacific")),
+    ...     session_start_time=datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo")),
     ...     session_description="Open-field behavioral recording segmented with VAME.",
     ... )
     >>> # Add subject information (required for DANDI upload)
@@ -120,7 +120,7 @@ to retrieve the auto-populated defaults, then use
 
     >>> custom_metadata = {
     ...     "NWBFile": {
-    ...         "session_start_time": datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("US/Pacific")),
+    ...         "session_start_time": datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo")),
     ...         "session_description": "Open-field behavioral recording segmented with VAME.",
     ...     },
     ...     "Subject": dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D"),
@@ -160,7 +160,7 @@ instead of ``sampling_frequency_hz``:
     >>> interface.set_aligned_timestamps(aligned_timestamps)
     >>> metadata = interface.get_metadata()
     >>> metadata["NWBFile"].update(
-    ...     session_start_time=datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("US/Pacific")),
+    ...     session_start_time=datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo")),
     ...     session_description="Open-field behavioral recording segmented with VAME.",
     ... )
     >>> interface.run_conversion(nwbfile_path=path_to_save_nwbfile, metadata=metadata, overwrite=True)
@@ -239,7 +239,7 @@ Each instance gets its own metadata entry and its own ``VAMEProject`` group:
 
     >>> custom_metadata = {
     ...     "NWBFile": {
-    ...         "session_start_time": datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("US/Pacific")),
+    ...         "session_start_time": datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo")),
     ...         "session_description": "Multi-project VAME behavioral segmentation.",
     ...     },
     ...     "Subject": dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D"),

--- a/docs/conversion_examples_gallery/behavior/video.rst
+++ b/docs/conversion_examples_gallery/behavior/video.rst
@@ -34,7 +34,7 @@ To follow this convention use the
 
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -63,7 +63,7 @@ To follow this convention use the
 
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -116,7 +116,7 @@ This metadata can then be easily incorporated into the conversion by updating th
     >>> interface = ExternalVideoInterface(file_paths=[video_file_path], verbose=False, metadata_key="my_external_video")
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -156,7 +156,7 @@ Similarly for :py:class:`~neuroconv.datainterfaces.behavior.video.internalvideod
     >>> interface = InternalVideoInterface(file_path=video_file_path, verbose=False, metadata_key="my_internal_video")
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/combinations/ecephys_pose_estimation.rst
+++ b/docs/conversion_examples_gallery/combinations/ecephys_pose_estimation.rst
@@ -36,7 +36,7 @@ For this specific example were are combining a OpenEphys recording with KiloSort
     >>> # Extract what metadata we can from the source files
     >>> metadata = converter.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific")).isoformat()
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo")).isoformat()
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/combinations/spikeglx_and_phy.rst
+++ b/docs/conversion_examples_gallery/combinations/spikeglx_and_phy.rst
@@ -29,7 +29,7 @@ were are combining a SpikeGLX recording with Phy sorting results using the
     >>> # Extract what metadata we can from the source files
     >>> metadata = converter.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/combinations/tiff_and_suite2p.rst
+++ b/docs/conversion_examples_gallery/combinations/tiff_and_suite2p.rst
@@ -31,7 +31,7 @@ workflow in neuroconv for Tiff imaging files segmented using suite2p. This conve
     >>> # Extract what metadata we can from the source files
     >>> metadata = converter.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/events/csv_events.rst
+++ b/docs/conversion_examples_gallery/events/csv_events.rst
@@ -43,7 +43,7 @@ supplied explicitly in the metadata.
     ... )
     >>> metadata = interface.get_metadata()
     >>> # CSV recordings have no embedded start time, so it must be set explicitly.
-    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("US/Pacific"))
+    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("Asia/Tokyo"))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 

--- a/docs/conversion_examples_gallery/events/doric_events.rst
+++ b/docs/conversion_examples_gallery/events/doric_events.rst
@@ -45,7 +45,7 @@ Use :py:class:`~neuroconv.datainterfaces.events.doric_events.doriccsveventsdatai
 
     >>> metadata = interface.get_metadata()
     >>> # The DoricStudio CSV export carries no session start time, so it must be set explicitly.
-    >>> metadata["NWBFile"]["session_start_time"] = datetime(2024, 1, 1, tzinfo=ZoneInfo("US/Pacific"))
+    >>> metadata["NWBFile"]["session_start_time"] = datetime(2024, 1, 1, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 

--- a/docs/conversion_examples_gallery/events/medpc_events.rst
+++ b/docs/conversion_examples_gallery/events/medpc_events.rst
@@ -58,7 +58,7 @@ says how to read each.
     >>> # subject read from the header
     >>> metadata = array_interface.get_metadata()
     >>> # The file states no time zone, so we add it
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # The subject_id comes from the file; the rest is required for DANDI upload
     >>> metadata["Subject"].update(species="Mus musculus", sex="M", age="P30D")
@@ -110,7 +110,7 @@ variable becomes an event type named after its digits, so a code you do not name
     ... )
     >>>
     >>> metadata = packed_interface.get_metadata()
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Eastern"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> metadata["Subject"].update(species="Rattus norvegicus", sex="M", age="P90D")
     >>>

--- a/docs/conversion_examples_gallery/events/npm_events.rst
+++ b/docs/conversion_examples_gallery/events/npm_events.rst
@@ -46,7 +46,7 @@ supplied explicitly in the metadata.
     >>> interface = NPMEventsInterface(file_path=file_path, verbose=False)
     >>> metadata = interface.get_metadata()
     >>> # NPM recordings have no embedded start time, so it must be set explicitly.
-    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("US/Pacific"))
+    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("Asia/Tokyo"))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 

--- a/docs/conversion_examples_gallery/fiberphotometry/csv_fp.rst
+++ b/docs/conversion_examples_gallery/fiberphotometry/csv_fp.rst
@@ -88,7 +88,7 @@ and ``data`` columns:
     >>> interface = CSVFiberPhotometryInterface(file_path=csv_signal_channel_path, data_columns="data", timestamps_column="timestamps", metadata_key="calcium_signal", verbose=False)
     >>> metadata = interface.get_metadata()
     >>> # CSV recordings have no embedded start time, so it must be set explicitly.
-    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("US/Pacific"))
+    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("Asia/Tokyo"))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 
@@ -130,7 +130,7 @@ each with ``timestamps`` and ``data`` columns on a common timebase:
     >>> interface = MultiFileCSVFiberPhotometryInterface(file_paths=[csv_signal_channel_path, csv_control_channel_path], data_columns="data", timestamps_column="timestamps", metadata_key="calcium_signal", verbose=False)
     >>> metadata = interface.get_metadata()
     >>> # CSV recordings have no embedded start time, so it must be set explicitly.
-    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("US/Pacific"))
+    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("Asia/Tokyo"))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 

--- a/docs/conversion_examples_gallery/fiberphotometry/doric_fp.rst
+++ b/docs/conversion_examples_gallery/fiberphotometry/doric_fp.rst
@@ -77,7 +77,7 @@ several series sharing one ``FiberPhotometryTable``.
     ...     verbose=False,
     ... )
     >>> metadata = interface.get_metadata()
-    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("US/Eastern"))
+    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("Asia/Tokyo"))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 

--- a/docs/conversion_examples_gallery/fiberphotometry/guppy_fp.rst
+++ b/docs/conversion_examples_gallery/fiberphotometry/guppy_fp.rst
@@ -162,7 +162,7 @@ same origin the raw streams use. A CSV session carries no absolute clock origin,
 
 .. code-block:: python
 
-    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("US/Pacific"))
+    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("Asia/Tokyo"))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 

--- a/docs/conversion_examples_gallery/fiberphotometry/npm_fp.rst
+++ b/docs/conversion_examples_gallery/fiberphotometry/npm_fp.rst
@@ -57,7 +57,7 @@ supplied explicitly in the metadata.
     >>> interface = NPMFiberPhotometryInterface(file_path=file_path, excitation_wavelength_in_nm=415, regions="Region0G", metadata_key="isosbestic_region0", verbose=False)
     >>> metadata = interface.get_metadata()
     >>> # NPM recordings have no embedded start time, so it must be set explicitly.
-    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("US/Pacific"))
+    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("Asia/Tokyo"))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 

--- a/docs/conversion_examples_gallery/fiberphotometry/tdt_fp.rst
+++ b/docs/conversion_examples_gallery/fiberphotometry/tdt_fp.rst
@@ -135,7 +135,7 @@ Convert TDT Fiber Photometry data to NWB using
     >>> # converter to share one FiberPhotometryTable.
     >>> interface = TDTFiberPhotometryInterface(folder_path=folder_path, stream_names="Dv1A", metadata_key="GCaMP", verbose=False)
     >>> metadata = interface.get_metadata()
-    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("US/Pacific"))
+    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("Asia/Tokyo"))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
 
@@ -539,7 +539,7 @@ This metadata can then be easily incorporated into the conversion by updating th
 
     >>> interface = TDTFiberPhotometryInterface(folder_path=folder_path, verbose=False)
     >>> metadata = interface.get_metadata()
-    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("US/Pacific"))
+    >>> metadata["NWBFile"]["session_start_time"] = datetime.now(tz=ZoneInfo("Asia/Tokyo"))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>> metadata = dict_deep_update(metadata, fiber_photometry_metadata)

--- a/docs/conversion_examples_gallery/imaging/brukertiff.rst
+++ b/docs/conversion_examples_gallery/imaging/brukertiff.rst
@@ -24,7 +24,7 @@ describes them. Point :py:class:`~neuroconv.converters.BrukerTiffConverter` at t
     >>> metadata = converter.get_metadata()
     >>> # For data provenance we can add the time zone information to the conversion if missing
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
-    >>> tzinfo = ZoneInfo("US/Pacific")
+    >>> tzinfo = ZoneInfo("Asia/Tokyo")
     >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -66,7 +66,7 @@ The setting has no effect on planar sessions.
     >>>
     >>> metadata = converter.get_metadata()
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
-    >>> tzinfo = ZoneInfo("US/Pacific")
+    >>> tzinfo = ZoneInfo("Asia/Tokyo")
     >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
@@ -91,7 +91,7 @@ yourself. ``channel_name`` selects one channel
     >>>
     >>> metadata = interface.get_metadata()
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
-    >>> tzinfo = ZoneInfo("US/Pacific")
+    >>> tzinfo = ZoneInfo("Asia/Tokyo")
     >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
@@ -116,7 +116,7 @@ microscope stays shared.
     >>>
     >>> metadata = converter.get_metadata()
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
-    >>> tzinfo = ZoneInfo("US/Pacific")
+    >>> tzinfo = ZoneInfo("Asia/Tokyo")
     >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>

--- a/docs/conversion_examples_gallery/imaging/femtonics.rst
+++ b/docs/conversion_examples_gallery/imaging/femtonics.rst
@@ -20,7 +20,7 @@ Convert Femtonics imaging data to NWB using :py:class:`~neuroconv.datainterfaces
     >>>
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/imaging/hdf5imaging.rst
+++ b/docs/conversion_examples_gallery/imaging/hdf5imaging.rst
@@ -21,7 +21,7 @@ Convert HDF5 imaging data to NWB using :py:class:`~neuroconv.datainterfaces.ophy
     >>>
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/imaging/image.rst
+++ b/docs/conversion_examples_gallery/imaging/image.rst
@@ -47,7 +47,7 @@ it, so an LA image stays LA where ``ImageInterface`` would turn it into RGBA.
     >>> interface = ExternalImageInterface(folder_path=path_to_folder_with_images)
     >>>
     >>> metadata = interface.get_metadata()
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -73,7 +73,7 @@ into the NWB file.
     >>>
     >>> # Get metadata from the interface
     >>> metadata = interface.get_metadata()
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -119,7 +119,7 @@ image type alone.
     >>>
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/imaging/inscopix.rst
+++ b/docs/conversion_examples_gallery/imaging/inscopix.rst
@@ -21,7 +21,7 @@ Convert Inscopix imaging data to NWB using :py:class:`~neuroconv.datainterfaces.
     >>>
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/imaging/micromanagertiff.rst
+++ b/docs/conversion_examples_gallery/imaging/micromanagertiff.rst
@@ -23,7 +23,7 @@ Convert Micro-Manager TIFF imaging data to NWB using
     >>> # For data provenance we can add the time zone information to the conversion if missing
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
     >>> if session_start_time.tzinfo is None:
-    ...     tzinfo = ZoneInfo("US/Pacific")
+    ...     tzinfo = ZoneInfo("Asia/Tokyo")
     ...     metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/imaging/miniscope.rst
+++ b/docs/conversion_examples_gallery/imaging/miniscope.rst
@@ -35,7 +35,7 @@ streams into a single NWB conversion. Behavioral video is handled automatically 
     >>>
     >>> metadata = converter.get_metadata()
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
-    >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=ZoneInfo("US/Pacific")))
+    >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=ZoneInfo("Asia/Tokyo")))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
@@ -91,7 +91,7 @@ The interface expects a folder with the following structure:
     >>> metadata = interface.get_metadata()
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
     >>> # For data provenance we can add the time zone information to the conversion
-    >>> metadata["NWBFile"]["session_start_time"] = session_start_time.replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> metadata["NWBFile"]["session_start_time"] = session_start_time.replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
@@ -207,7 +207,7 @@ we need to use ``set_aligned_starting_time()`` to shift the timestamps of the se
     >>> # Configure metadata (session_start_time is automatically extracted from first acquisition)
     >>> metadata = converter.get_metadata()
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
-    >>> metadata["NWBFile"]["session_start_time"] = session_start_time.replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> metadata["NWBFile"]["session_start_time"] = session_start_time.replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>

--- a/docs/conversion_examples_gallery/imaging/scanbox.rst
+++ b/docs/conversion_examples_gallery/imaging/scanbox.rst
@@ -22,7 +22,7 @@ Convert Scanbox imaging data to NWB using
     >>>
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/imaging/scanimage.rst
+++ b/docs/conversion_examples_gallery/imaging/scanimage.rst
@@ -24,7 +24,7 @@ followed from its first file, and a volumetric one is written as a 4D series per
     >>>
     >>> metadata = converter.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -66,7 +66,7 @@ For multi-channel data, you need to specify the channel name, and you can use `p
     ... )
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/imaging/scanimage_legacy.rst
+++ b/docs/conversion_examples_gallery/imaging/scanimage_legacy.rst
@@ -27,7 +27,7 @@ Convert ScanImage TIFF files to NWB using :py:class:`~neuroconv.datainterfaces.o
     >>>
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/imaging/tiff.rst
+++ b/docs/conversion_examples_gallery/imaging/tiff.rst
@@ -26,7 +26,7 @@ Single File, Planar and Single-Channel TIFF conversion
     >>>
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -78,7 +78,7 @@ number of channels, which channel to extract, and number of planes:
     ... )
     >>>
     >>> metadata = interface.get_metadata()
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/recording/axona.rst
+++ b/docs/conversion_examples_gallery/recording/axona.rst
@@ -24,7 +24,7 @@ Convert axona data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.axo
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> tzinfo = ZoneInfo("US/Pacific")
+    >>> tzinfo = ZoneInfo("Asia/Tokyo")
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
     >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
     >>> # Add subject information (required for DANDI upload)

--- a/docs/conversion_examples_gallery/recording/biocam.rst
+++ b/docs/conversion_examples_gallery/recording/biocam.rst
@@ -23,7 +23,7 @@ Convert Biocam data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.bi
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/recording/blackrock.rst
+++ b/docs/conversion_examples_gallery/recording/blackrock.rst
@@ -26,7 +26,7 @@ Convert Blackrock data to NWB using
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime.fromisoformat(metadata["NWBFile"]["session_start_time"])
-    >>> session_start_time = session_start_time.replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = session_start_time.replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/recording/edf.rst
+++ b/docs/conversion_examples_gallery/recording/edf.rst
@@ -45,7 +45,7 @@ streams and is read one stream at a time: list them with
     # Extract what metadata we can from the source files
     metadata = interface.get_metadata()
     # For data provenance we add the time zone information to the conversion
-    session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     metadata["NWBFile"].update(session_start_time=session_start_time)
     # Add subject information (required for DANDI upload)
     metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -85,7 +85,7 @@ you'll need to create separate EDFAnalogInterface instances for each unit type:
     # Extract metadata and add timezone information
     metadata = interface.get_metadata()
     # For data provenance we add the time zone information to the conversion
-    session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     metadata["NWBFile"].update(session_start_time=session_start_time)
     # Add subject information (required for DANDI upload)
     metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -164,7 +164,7 @@ Remember to group auxiliary channels by their unit types:
     # Extract metadata and add timezone information
     metadata = converter.get_metadata()
     # For data provenance we add the time zone information to the conversion
-    session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     metadata["NWBFile"].update(session_start_time=session_start_time)
     # Add subject information (required for DANDI upload)
     metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/recording/intan.rst
+++ b/docs/conversion_examples_gallery/recording/intan.rst
@@ -52,7 +52,7 @@ sub-interface, so a single call writes them all to NWB.
     >>> converter = IntanConverter(file_path=file_path, verbose=False)
     >>>
     >>> metadata = converter.get_metadata()
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
@@ -82,7 +82,7 @@ This interface handles the primary neural recordings from the RHD2000 or RHS2000
     >>> metadata = interface.get_metadata()
     >>> # session_start_time is required for conversion. If it cannot be inferred
     >>> # automatically from the source files you must supply one.
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -126,7 +126,7 @@ USB board ADC input channels
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # session_start_time is required but not available on intan
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -160,7 +160,7 @@ You can also convert auxiliary input channels (e.g., accelerometer data):
     >>> # Extract what metadata we can from the source files
     >>> metadata_aux = interface_aux.get_metadata()
     >>> # session_start_time is required but not available on intan
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata_aux["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata_aux["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -194,7 +194,7 @@ For RHS systems, you can also convert DC amplifier channels:
     >>> # Extract what metadata we can from the source files
     >>> metadata_dc = interface_dc.get_metadata()
     >>> # session_start_time is required but not available on intan
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata_dc["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata_dc["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -229,7 +229,7 @@ For RHS systems, you can also convert ADC output channels:
     >>> metadata_output = interface_output.get_metadata()
     >>> # session_start_time is required for conversion. If it cannot be inferred
     >>> # automatically from the source files you must supply one.
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata_output["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata_output["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -265,7 +265,7 @@ with the conversion factor derived automatically from the ``stim_step_size`` in 
     >>> # Extract what metadata we can from the source files
     >>> metadata_stim = interface_stim.get_metadata()
     >>> # session_start_time is required but not available on intan
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata_stim["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata_stim["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -307,7 +307,7 @@ that was recorded but never toggles is still written, as an empty table.
     >>>
     >>> metadata_digital = interface_digital.get_metadata()
     >>> # session_start_time is required but not available on intan
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata_digital["NWBFile"].update(session_start_time=session_start_time)
     >>> metadata_digital["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>
@@ -375,7 +375,7 @@ timestamps make lexicographic order match chronological order):
     ... )
     >>>
     >>> metadata_split = interface_split.get_metadata()
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata_split["NWBFile"].update(session_start_time=session_start_time)
     >>> metadata_split["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
     >>>

--- a/docs/conversion_examples_gallery/recording/maxwell.rst
+++ b/docs/conversion_examples_gallery/recording/maxwell.rst
@@ -28,7 +28,7 @@ Convert MaxOne data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.ma
     # Extract what metadata we can from the source files
     metadata = interface.get_metadata()
     # For data provenance we add the time zone information to the conversion
-    session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     metadata["NWBFile"].update(session_start_time=session_start_time)
     # Add subject information (required for DANDI upload)
     metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/recording/mcsraw.rst
+++ b/docs/conversion_examples_gallery/recording/mcsraw.rst
@@ -23,7 +23,7 @@ Convert MCSRaw data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.mc
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/recording/mearec.rst
+++ b/docs/conversion_examples_gallery/recording/mearec.rst
@@ -23,7 +23,7 @@ Convert MEArec data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.me
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/recording/neuralynx.rst
+++ b/docs/conversion_examples_gallery/recording/neuralynx.rst
@@ -27,7 +27,7 @@ Convert Neuralynx data to NWB using
     >>> # session_start_time is required for conversion. If it cannot be inferred
     >>> # automatically from the source files you must supply one.
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
-    >>> session_start_time = session_start_time.replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = session_start_time.replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"]["session_start_time"] = session_start_time
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/recording/neuroscope.rst
+++ b/docs/conversion_examples_gallery/recording/neuroscope.rst
@@ -26,7 +26,7 @@ Convert NeuroScope data to NWB using
     >>> metadata = interface.get_metadata()
     >>> # session_start_time is required for conversion. If it cannot be inferred
     >>> # automatically from the source files you must supply one.
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/recording/openephys.rst
+++ b/docs/conversion_examples_gallery/recording/openephys.rst
@@ -29,7 +29,7 @@ Convert OpenEphys data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys
     >>> metadata = interface.get_metadata()
     >>> # session_start_time is required for conversion. If it cannot be inferred
     >>> # automatically from the source files you must supply one.
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -58,7 +58,7 @@ table rows between them.
     >>> # Extract what metadata we can from the source files
     >>> metadata = converter.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/recording/plexon.rst
+++ b/docs/conversion_examples_gallery/recording/plexon.rst
@@ -23,7 +23,7 @@ Convert Plexon recording data to NWB using :py:class:`~neuroconv.datainterfaces.
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/recording/plexon2.rst
+++ b/docs/conversion_examples_gallery/recording/plexon2.rst
@@ -26,7 +26,7 @@ Convert Plexon2 recording data to NWB using :py:class:`~neuroconv.datainterfaces
     # Extract what metadata we can from the source files
     metadata = interface.get_metadata()
     # For data provenance we add the time zone information to the conversion
-    tzinfo = ZoneInfo("US/Pacific")
+    tzinfo = ZoneInfo("Asia/Tokyo")
     session_start_time = metadata["NWBFile"]["session_start_time"]
     metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
     # Add subject information (required for DANDI upload)

--- a/docs/conversion_examples_gallery/recording/spike2.rst
+++ b/docs/conversion_examples_gallery/recording/spike2.rst
@@ -34,7 +34,7 @@ Convert Spike2 data to NWB using
     # Extract what metadata we can from the source files
     metadata = interface.get_metadata()
     # For data provenance we add the time zone information to the conversion
-    session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     metadata["NWBFile"].update(session_start_time=session_start_time)
     # Add subject information (required for DANDI upload)
     metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/recording/spikegadgets.rst
+++ b/docs/conversion_examples_gallery/recording/spikegadgets.rst
@@ -25,7 +25,7 @@ Convert spikegadgets data to NWB using
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/recording/spikeglx.rst
+++ b/docs/conversion_examples_gallery/recording/spikeglx.rst
@@ -27,7 +27,7 @@ We can easily convert all data stored in the native SpikeGLX folder structure to
     >>> # Extract what metadata we can from the source files
     >>> metadata = converter.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -61,7 +61,7 @@ Defining a 'stream' as a single band on a single NeuroPixels probe, we can conve
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -92,7 +92,7 @@ can be used to convert these streams to NWB.
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -272,7 +272,7 @@ preferring AP over LF when both are available). For more control over the additi
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>>
     >>> # Choose a path for saving the nwb file and run the conversion

--- a/docs/conversion_examples_gallery/recording/tdt.rst
+++ b/docs/conversion_examples_gallery/recording/tdt.rst
@@ -25,7 +25,7 @@ Convert TDT data to NWB using :py:class:`~neuroconv.datainterfaces.ecephys.tdt.t
     >>> metadata = interface.get_metadata()
     >>> # session_start_time is required for conversion. If it cannot be inferred
     >>> # automatically from the source files you must supply one.
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/recording/whitematter.rst
+++ b/docs/conversion_examples_gallery/recording/whitematter.rst
@@ -31,7 +31,7 @@ Convert WhiteMatter data to NWB using :py:class:`~neuroconv.datainterfaces.eceph
     >>> metadata = interface.get_metadata()
     >>> # session_start_time is required for conversion. If it cannot be inferred
     >>> # automatically from the source files you must supply one.
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -101,7 +101,7 @@ This metadata can then be easily incorporated into the conversion by updating th
     >>> metadata = interface.get_metadata()
     >>> # session_start_time is required for conversion. If it cannot be inferred
     >>> # automatically from the source files you must supply one.
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/segmentation/caiman.rst
+++ b/docs/conversion_examples_gallery/segmentation/caiman.rst
@@ -21,7 +21,7 @@ Convert CaImAn segmentation data to NWB using :py:class:`~neuroconv.datainterfac
     >>>
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/segmentation/cnmfe.rst
+++ b/docs/conversion_examples_gallery/segmentation/cnmfe.rst
@@ -22,7 +22,7 @@ Convert CNMFE segmentation data to NWB using :py:class:`~neuroconv.datainterface
     >>>
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/segmentation/extract.rst
+++ b/docs/conversion_examples_gallery/segmentation/extract.rst
@@ -22,7 +22,7 @@ Convert EXTRACT segmentation data to NWB using :py:class:`~neuroconv.datainterfa
     >>>
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/segmentation/inscopix.rst
+++ b/docs/conversion_examples_gallery/segmentation/inscopix.rst
@@ -21,7 +21,7 @@ Convert Inscopix segmentation data to NWB using :py:class:`~neuroconv.datainterf
     >>>
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/segmentation/minian.rst
+++ b/docs/conversion_examples_gallery/segmentation/minian.rst
@@ -44,7 +44,7 @@ Minian does not store sampling frequency information in its native output. For N
     >>>
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/segmentation/suite2p.rst
+++ b/docs/conversion_examples_gallery/segmentation/suite2p.rst
@@ -24,7 +24,7 @@ folder containing them.
     >>>
     >>> metadata = converter.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -66,7 +66,7 @@ first plane and channel are used.
     >>>
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/sorting/blackrock.rst
+++ b/docs/conversion_examples_gallery/sorting/blackrock.rst
@@ -25,7 +25,7 @@ Convert Blackrock sorting data to NWB using
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
     >>> session_start_time = datetime.fromisoformat(metadata["NWBFile"]["session_start_time"])
-    >>> session_start_time = session_start_time.replace(tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = session_start_time.replace(tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/sorting/cellexplorer.rst
+++ b/docs/conversion_examples_gallery/sorting/cellexplorer.rst
@@ -24,8 +24,8 @@ Convert CellExplorer sorting data to NWB using :py:class:`~neuroconv.datainterfa
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> tzinfo = ZoneInfo("US/Pacific")
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific")).isoformat()
+    >>> tzinfo = ZoneInfo("Asia/Tokyo")
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo")).isoformat()
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/sorting/kilosort.rst
+++ b/docs/conversion_examples_gallery/sorting/kilosort.rst
@@ -23,7 +23,7 @@ Convert KiloSort data to NWB using
     >>> interface = KiloSortSortingInterface(folder_path=folder_path, verbose=False)
     >>>
     >>> metadata = interface.get_metadata()
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/sorting/mda.rst
+++ b/docs/conversion_examples_gallery/sorting/mda.rst
@@ -29,7 +29,7 @@ instead and are not served by this interface.
     >>> interface = MdaSortingInterface(file_path=mda_firings_path, sampling_frequency=mda_sampling_frequency, verbose=False)
     >>>
     >>> metadata = interface.get_metadata()
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/sorting/neuralynx.rst
+++ b/docs/conversion_examples_gallery/sorting/neuralynx.rst
@@ -24,7 +24,7 @@ Convert Neuralynx data to NWB using
     >>> interface = NeuralynxSortingInterface(folder_path=folder_path, verbose=False, stream_id="0")
     >>>
     >>> metadata = interface.get_metadata()
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific")).isoformat()
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo")).isoformat()
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/sorting/neuroscope.rst
+++ b/docs/conversion_examples_gallery/sorting/neuroscope.rst
@@ -26,7 +26,7 @@ Convert NeuroScope sorting data to NWB using
     >>> metadata = interface.get_metadata()
     >>> # session_start_time is required for conversion. If it cannot be inferred
     >>> # automatically from the source files you must supply one.
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/sorting/phy.rst
+++ b/docs/conversion_examples_gallery/sorting/phy.rst
@@ -22,7 +22,7 @@ Convert Phy data to NWB using :py:class:`~.neuroconv.datainterfaces.ecephys.phy.
     >>> interface = PhySortingInterface(folder_path=folder_path, verbose=False)
     >>>
     >>> metadata = interface.get_metadata()
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/sorting/plexon.rst
+++ b/docs/conversion_examples_gallery/sorting/plexon.rst
@@ -23,7 +23,7 @@ Convert Plexon spiking data (.plx) to NWB using :py:class:`~.neuroconv.datainter
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> tzinfo = ZoneInfo("US/Pacific")
+    >>> tzinfo = ZoneInfo("Asia/Tokyo")
     >>> session_start_time = metadata["NWBFile"]["session_start_time"]
     >>> metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=tzinfo))
     >>> # Add subject information (required for DANDI upload)

--- a/docs/conversion_examples_gallery/sorting/xclust.rst
+++ b/docs/conversion_examples_gallery/sorting/xclust.rst
@@ -25,7 +25,7 @@ Convert XClust sorting data to NWB using :py:class:`~neuroconv.datainterfaces.ec
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # For data provenance we add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific")).isoformat()
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo")).isoformat()
     >>> metadata["NWBFile"].update(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/text/csv.rst
+++ b/docs/conversion_examples_gallery/text/csv.rst
@@ -68,7 +68,7 @@ The following example demonstrates basic conversion of a CSV file containing int
     >>> # Extract metadata from the source file
     >>> metadata = interface.get_metadata()
     >>> # Add the required time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"] = dict(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")
@@ -152,7 +152,7 @@ CSVs with non-standard column names (e.g., ``start`` instead of ``start_time``):
     ... )
     >>>
     >>> metadata = interface.get_metadata()
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"] = dict(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/conversion_examples_gallery/text/excel.rst
+++ b/docs/conversion_examples_gallery/text/excel.rst
@@ -27,7 +27,7 @@ The Excel data will be saved as trials in the NWB file.
     >>> # Extract what metadata we can from the source files
     >>> metadata = interface.get_metadata()
     >>> # Add the time zone information to the conversion
-    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("US/Pacific"))
+    >>> session_start_time = datetime(2020, 1, 1, 12, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
     >>> metadata["NWBFile"] = dict(session_start_time=session_start_time)
     >>> # Add subject information (required for DANDI upload)
     >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="M", age="P30D")

--- a/docs/how_to/add_behavioral_and_sensor_data.rst
+++ b/docs/how_to/add_behavioral_and_sensor_data.rst
@@ -176,7 +176,7 @@ or the Converter method :py:meth:`~neuroconv.nwbconverter.NWBConverter.create_nw
     nwbfile = NWBFile(
         session_description="Spatial navigation task in open field",
         identifier=str(uuid4()),  # Generate globally unique identifier
-        session_start_time=datetime(2025, 1, 15, 10, 30, 0, tzinfo=ZoneInfo("US/Pacific")),
+        session_start_time=datetime(2025, 1, 15, 10, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo")),
     )
 
 These three fields are required. The ``identifier`` must be globally unique - using :py:func:`uuid.uuid4` ensures this.
@@ -461,7 +461,7 @@ and behavioral data (using the SpikeInterface integration) from the same Intan r
         "NWBFile": {
             "session_description": "Visual discrimination task with lick response and wheel running",
             "identifier": str(uuid4()),
-            "session_start_time": datetime(2025, 3, 20, 14, 30, 0, tzinfo=ZoneInfo("US/Pacific")),  # Note: Intan does not store session start time
+            "session_start_time": datetime(2025, 3, 20, 14, 30, 0, tzinfo=ZoneInfo("Asia/Tokyo")),  # Note: Intan does not store session start time
             "lab": "Systems Neuroscience Lab",
             "institution": "University",
         },

--- a/docs/user_guide/datainterfaces.rst
+++ b/docs/user_guide/datainterfaces.rst
@@ -92,7 +92,7 @@ If it is not found, you must add it:
     from datetime import datetime
     from zoneinfo import ZoneInfo
 
-    metadata["NWBFile"]["session_start_time"] = datetime(2021, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("US/Pacific"))
+    metadata["NWBFile"]["session_start_time"] = datetime(2021, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
 
 You can use ``tz.tzlocal()`` to get the local timezone.
 
@@ -101,7 +101,7 @@ This is not required but is a recommended best practice. Here is how you would a
 
 .. code-block:: python
 
-    metadata["NWBFile"]["session_start_time"] = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("US/Pacific"))
+    metadata["NWBFile"]["session_start_time"] = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
 
 NWB Best Practices also recommends several other fields that are rarely present in the extracted metadata.
 The metadata dictionary is the place to add this information:

--- a/tests/test_minimal/test_tools/test_nwb_helpers.py
+++ b/tests/test_minimal/test_tools/test_nwb_helpers.py
@@ -47,7 +47,7 @@ class TestNWBHelpers(TestCase):
 
     def test_metadata_integrity(self):
         """Test that the original metadata is not modified."""
-        session_start_time = datetime(2023, 6, 22, 9, 0, 0, tzinfo=ZoneInfo("America/New_York"))
+        session_start_time = datetime(2023, 6, 22, 9, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
         session_description = "Original description"
         identifier = "original_identifier"
         metadata = dict(

--- a/tests/test_modalities/test_behavior/test_audio_interface.py
+++ b/tests/test_modalities/test_behavior/test_audio_interface.py
@@ -46,7 +46,7 @@ class TestAudioInterface(AudioInterfaceTestMixin):
     @classmethod
     def setup_test(cls, tmp_path_factory):
 
-        cls.session_start_time = datetime.now(tz=gettz(name="US/Pacific"))
+        cls.session_start_time = datetime.now(tz=gettz(name="Asia/Tokyo"))
         cls.num_frames = int(1e7)
         cls.num_audio_files = 3
         cls.sampling_rate = 500

--- a/tests/test_modalities/test_behavior/test_external_video_interface.py
+++ b/tests/test_modalities/test_behavior/test_external_video_interface.py
@@ -151,7 +151,7 @@ def nwb_converter(video_files):
 def metadata(nwb_converter):
     """Get and return metadata for the test converter."""
     metadata = nwb_converter.get_metadata()
-    metadata["NWBFile"].update(session_start_time=datetime.now(tz=gettz(name="US/Pacific")))
+    metadata["NWBFile"].update(session_start_time=datetime.now(tz=gettz(name="Asia/Tokyo")))
     return metadata
 
 

--- a/tests/test_modalities/test_behavior/test_internal_video_interface.py
+++ b/tests/test_modalities/test_behavior/test_internal_video_interface.py
@@ -72,7 +72,7 @@ def nwb_converter(video_files):
 def metadata(nwb_converter):
     """Get and return metadata for the test converter."""
     metadata = nwb_converter.get_metadata()
-    metadata["NWBFile"].update(session_start_time=datetime.now(tz=gettz(name="US/Pacific")))
+    metadata["NWBFile"].update(session_start_time=datetime.now(tz=gettz(name="Asia/Tokyo")))
     return metadata
 
 

--- a/tests/test_modalities/test_behavior/test_tools_audio.py
+++ b/tests/test_modalities/test_behavior/test_tools_audio.py
@@ -12,7 +12,7 @@ from neuroconv.tools.nwb_helpers import make_nwbfile_from_metadata
 class TestAddAcousticWaveformSeries(TestCase):
     @classmethod
     def setUpClass(cls):
-        session_start_time = datetime.now(tz=gettz(name="US/Pacific"))
+        session_start_time = datetime.now(tz=gettz(name="Asia/Tokyo"))
         cls.num_frames = 1000
         cls.sampling_rate = 500.0
 


### PR DESCRIPTION
When running the gallery doctests in a fresh environment I found that `ZoneInfo("US/Pacific")` throws `ZoneInfoNotFoundError` on Ubuntu 24.04 as it ships legacy aliases like `US/Pacific` only in the optional `tzdata-legacy` package. This PR replaces every named time zone in the docs and tests with `Asia/Tokyo`, a canonical name that every install has and that makes the examples less US-centric.