### PR TITLE
Add EthoVision data interface

### DIFF
--- a/changelog_entries/2054.feature.md
+++ b/changelog_entries/2054.feature.md
@@ -1,0 +1,1 @@
+Added `EthoVisionDataInterface`, which reads one Noldus EthoVision XT Track from Excel, CSV or TXT, writes its position and derived channels as core NWB series, and converts Excel Manual Scoring rows into an `EventsTable`, `Ethogram` and `EthogramBouts`.

--- a/docs/conversion_examples_gallery/behavior/ethovision.rst
+++ b/docs/conversion_examples_gallery/behavior/ethovision.rst
@@ -1,0 +1,114 @@
+EthoVision data conversion
+--------------------------
+
+Install NeuroConv with the dependencies needed for Noldus EthoVision XT exports.
+
+.. code-block:: bash
+
+    pip install "neuroconv[ethovision]"
+
+EthoVision exports the same Track model as Excel, CSV, or TXT. One Track is one subject's
+sampled data in one arena. :py:class:`~neuroconv.datainterfaces.behavior.ethovision.ethovisiondatainterface.EthoVisionDataInterface`
+reads exactly one Track from any of those containers.
+
+Convert one Track
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    >>> from zoneinfo import ZoneInfo
+
+    >>> from neuroconv.datainterfaces import EthoVisionDataInterface
+
+    >>> file_path = BEHAVIOR_DATA_PATH / "ethovision" / "excel" / "single_arena_single_subject" / "track_and_manual_scoring" / "two_c57.xlsx"
+
+    >>> # A workbook can hold many Tracks, so pick one by its arena and subject.
+    >>> interface = EthoVisionDataInterface(file_path=file_path, arena_name="Arena 1", subject_name="Subject 1")
+
+    >>> metadata = interface.get_metadata()
+
+    >>> # For data provenance we add the time zone information to the conversion
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
+    >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+
+    >>> # Add subject information (required for DANDI upload)
+    >>> metadata["Subject"] = dict(subject_id="subject1", species="Mus musculus", sex="U")
+
+    >>> # Choose a path for saving the nwb file and run the conversion
+    >>> interface.run_conversion(nwbfile_path=path_to_save_nwbfile, metadata=metadata, overwrite=True)
+
+``arena_name`` and ``subject_name`` identify the Track by its semantic arena-subject pair rather
+than by an Excel worksheet name. They are optional when the source contains exactly one Track,
+because that identity is unambiguous, but required when an Excel workbook contains several Tracks.
+Use :meth:`~neuroconv.datainterfaces.behavior.ethovision.ethovisiondatainterface.EthoVisionDataInterface.get_available_tracks`
+to discover the valid pairs.
+
+The selected Track is mapped to NWB as follows:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 45 55
+
+    * - EthoVision source
+      - NWB representation
+    * - ``X center`` and ``Y center``
+      - One :py:class:`~pynwb.behavior.SpatialSeries`
+    * - Every other Track channel
+      - One :py:class:`~pynwb.base.TimeSeries` per channel
+    * - Manual Scoring behavior labels
+      - One `Ethogram <https://github.com/catalystneuro/ndx-ethogram#ethogram>`_
+    * - Manual Scoring occurrences
+      - One :py:class:`~pynwb.event.EventsTable`
+    * - Matching ``state start`` and ``state stop`` rows
+      - One row in `EthogramBouts <https://github.com/catalystneuro/ndx-ethogram#ethogrambouts>`_
+
+A ``point event`` or ``state start`` without a matching stop remains in the events table only.
+
+NeuroConv preserves the behavior labels and occurrences present in the Manual Scoring export.
+Descriptions, categories, and the experimental meaning of those behaviors may not be present in the
+source. Follow :ref:`the events how-to <annotate_events_metadata>` to add that context to the event
+and ethogram metadata before conversion.
+
+Combine same-session Tracks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An Excel workbook can contain several arenas and subjects from one acquisition trial. NeuroConv
+does not automatically decide which Tracks belong in the same NWB file. Discover the complete
+Track identities, select one arena, and compose its Tracks explicitly:
+
+.. code-block:: python
+
+    >>> from zoneinfo import ZoneInfo
+
+    >>> from neuroconv import ConverterPipe
+    >>> from neuroconv.datainterfaces import EthoVisionDataInterface
+
+    >>> file_path = BEHAVIOR_DATA_PATH / "ethovision" / "excel" / "single_arena_multiple_subjects" / "hardware_and_trial_control" / "two_subjects_missing_samples.xlsx"
+    >>> available_tracks = EthoVisionDataInterface.get_available_tracks(file_path=file_path)
+    >>> available_tracks
+    [{'arena_name': 'Rat Arena 1a', 'subject_name': 'Subject 1'}, {'arena_name': 'Rat Arena 1a', 'subject_name': 'Subject 2'}]
+    >>> arena_name = "Rat Arena 1a"
+    >>> subject_1_interface = EthoVisionDataInterface(file_path=file_path, arena_name=arena_name, subject_name="Subject 1")
+    >>> subject_2_interface = EthoVisionDataInterface(file_path=file_path, arena_name=arena_name, subject_name="Subject 2")
+    >>> converter = ConverterPipe(data_interfaces=[subject_1_interface, subject_2_interface])
+
+    >>> metadata = converter.get_metadata()
+    >>> session_start_time = metadata["NWBFile"]["session_start_time"].replace(tzinfo=ZoneInfo("Asia/Tokyo"))
+    >>> metadata["NWBFile"].update(session_start_time=session_start_time)
+
+    >>> converter.run_conversion(
+    ...     nwbfile_path=path_to_save_nwbfile,
+    ...     metadata=metadata,
+    ...     overwrite=True,
+    ... )
+
+When same-arena subject interfaces are composed, their subject-filtered Manual Scoring rows
+contribute to one arena-level ``Ethogram``, ``EventsTable``, and ``EthogramBouts`` table. The
+occurrence tables distinguish subjects with their ``subject`` columns.
+
+Subjects recorded together in one arena normally belong in the same NWB file. Separate arenas
+should remain separate unless the experiment establishes that they are one session.
+
+CSV and TXT contain one Track per file rather than several worksheets. Construct one interface per
+file and pass those interfaces through the same ``ConverterPipe`` pattern. The explicit file list
+records that the separate exports belong to the same session.

--- a/docs/conversion_examples_gallery/extras_by_gallery_entry.json
+++ b/docs/conversion_examples_gallery/extras_by_gallery_entry.json
@@ -5,6 +5,9 @@
   "behavior/boris.rst": {
     "extra": "boris"
   },
+  "behavior/ethovision.rst": {
+    "extra": "ethovision"
+  },
   "behavior/deeplabcut.rst": {
     "extra": "deeplabcut"
   },

--- a/docs/conversion_examples_gallery/index.rst
+++ b/docs/conversion_examples_gallery/index.rst
@@ -141,6 +141,7 @@ Behavior
 
     Audio <behavior/audio>
     BORIS <behavior/boris>
+    EthoVision <behavior/ethovision>
     FicTrac <behavior/fictrac>
     Neuralynx NVT <behavior/neuralynx_nvt>
     Videos <behavior/video>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,8 +130,13 @@ vame = [
 boris = [
     "ndx-ethogram>=0.1.0",  # a BORIS project is a coding scheme plus its events, and the scheme is an Ethogram
 ]
+ethovision = [
+    "openpyxl",  # Excel is one of EthoVision's three Track-export containers
+    "ndx-ethogram>=0.1.0",  # manual-scoring rows also produce an Ethogram and EthogramBouts
+]
 behavior = [
     "neuroconv[boris]",
+    "neuroconv[ethovision]",
     "neuroconv[sleap]",
     "neuroconv[audio]",
     "neuroconv[deeplabcut]",

--- a/src/neuroconv/datainterfaces/__init__.py
+++ b/src/neuroconv/datainterfaces/__init__.py
@@ -2,6 +2,7 @@
 from .behavior.audio.audiointerface import AudioInterface
 from .behavior.boris.borisdatainterface import BORISInterface
 from .behavior.deeplabcut.deeplabcutdatainterface import DeepLabCutInterface
+from .behavior.ethovision.ethovisiondatainterface import EthoVisionDataInterface
 from .behavior.fictrac.fictracdatainterface import FicTracDataInterface
 from .behavior.lightningpose.lightningposedatainterface import (
     LightningPoseDataInterface,
@@ -239,6 +240,7 @@ interface_list = [
     SLEAPInterface,
     MiniscopeBehaviorInterface,
     MiniscopeHeadOrientationInterface,
+    EthoVisionDataInterface,
     FicTracDataInterface,
     NeuralynxNvtInterface,
     LightningPoseDataInterface,
@@ -309,6 +311,7 @@ interfaces_by_category = dict(
         InternalVideo=InternalVideoInterface,
         DeepLabCut=DeepLabCutInterface,
         SLEAP=SLEAPInterface,
+        EthoVision=EthoVisionDataInterface,
         FicTrac=FicTracDataInterface,
         LightningPose=LightningPoseDataInterface,
         Vame=VameInterface,

--- a/src/neuroconv/datainterfaces/behavior/ethovision/__init__.py
+++ b/src/neuroconv/datainterfaces/behavior/ethovision/__init__.py
@@ -1,0 +1,3 @@
+from .ethovisiondatainterface import EthoVisionDataInterface
+
+__all__ = ["EthoVisionDataInterface"]

--- a/src/neuroconv/datainterfaces/behavior/ethovision/_ethovision_reader.py
+++ b/src/neuroconv/datainterfaces/behavior/ethovision/_ethovision_reader.py
@@ -1,0 +1,289 @@
+"""Read Noldus EthoVision XT Track exports across Excel, CSV, and TXT containers."""
+
+import csv
+import io
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+TRACK_SHEET_PATTERN = re.compile(r"^Track-(?P<arena>.+)-Subject (?P<subject>.+)$")
+SUPPORTED_SUFFIXES = (".xlsx", ".csv", ".txt")
+
+TRIAL_TIME_COLUMN = "Trial time"
+RECORDING_TIME_COLUMN = "Recording time"
+
+
+@dataclass(frozen=True)
+class EthoVisionTrackSource:
+    """The identity and container-local name of one EthoVision Track."""
+
+    arena: str
+    subject: str
+    source_name: str
+
+
+@dataclass
+class EthoVisionTrackData:
+    """One Track's header fields, time vectors, units, and per-frame channels."""
+
+    header: dict[str, str | None]
+    units: dict[str, str | None]
+    trial_time: np.ndarray
+    recording_time: np.ndarray
+    channels: dict[str, np.ndarray] = field(default_factory=dict)
+
+
+@dataclass
+class EthoVisionScoringEvent:
+    """One manual-scoring point event or paired state bout."""
+
+    subject: str
+    behavior: str
+    onset: float
+    duration: float | None
+
+
+def get_available_tracks(file_path) -> list[dict[str, str]]:
+    """Return the complete selector arguments for every available Track."""
+    return [
+        {"arena_name": source.arena, "subject_name": source.subject}
+        for source in _get_track_sources(file_path=file_path)
+    ]
+
+
+def select_track_source(
+    file_path,
+    *,
+    arena_name: str | None = None,
+    subject_name: str | None = None,
+) -> EthoVisionTrackSource:
+    """Resolve exactly one Track, inferring selectors only when the result is unambiguous."""
+    available = _get_track_sources(file_path=file_path)
+    selected = [
+        source
+        for source in available
+        if (arena_name is None or source.arena == arena_name)
+        and (subject_name is None or source.subject == subject_name)
+    ]
+    if len(selected) == 1:
+        return selected[0]
+
+    available_identities = [(source.arena, source.subject) for source in available]
+    if not selected:
+        raise ValueError(
+            f"No EthoVision Track matches arena_name={arena_name!r}, subject_name={subject_name!r} "
+            f"in '{file_path}'. Available tracks: {available_identities}."
+        )
+    raise ValueError(
+        f"arena_name={arena_name!r}, subject_name={subject_name!r} does not identify one Track in "
+        f"'{file_path}'. Matching tracks: {[(source.arena, source.subject) for source in selected]}."
+    )
+
+
+def read_track(file_path, *, source: EthoVisionTrackSource) -> EthoVisionTrackData:
+    """Read one selected Track using the loader for its source container."""
+    path = _validate_file_path(file_path=file_path)
+    if path.suffix.lower() == ".xlsx":
+        rows = _read_excel_rows(file_path=path, sheet_name=source.source_name)
+    else:
+        rows = _read_delimited_rows(file_path=path)
+    return _track_data_from_rows(rows=rows, source_name=source.source_name)
+
+
+def read_scoring_events(file_path, *, arena_name: str) -> list[EthoVisionScoringEvent]:
+    """Read an arena's Manual Scoring sheet when the source is an Excel workbook."""
+    path = _validate_file_path(file_path=file_path)
+    if path.suffix.lower() != ".xlsx":
+        return []
+
+    sheet_name = f"Manual Scoring-{arena_name}"
+    workbook = _load_workbook(file_path=path)
+    try:
+        if sheet_name not in workbook.sheetnames:
+            return []
+        rows = [list(row) for row in workbook[sheet_name].iter_rows(values_only=True)]
+    finally:
+        workbook.close()
+    return _scoring_events_from_rows(rows=rows, source_name=sheet_name)
+
+
+def _get_track_sources(file_path) -> list[EthoVisionTrackSource]:
+    path = _validate_file_path(file_path=file_path)
+    if path.suffix.lower() == ".xlsx":
+        workbook = _load_workbook(file_path=path)
+        try:
+            sources = []
+            for sheet_name in workbook.sheetnames:
+                match = TRACK_SHEET_PATTERN.match(sheet_name)
+                if match is not None:
+                    sources.append(
+                        EthoVisionTrackSource(
+                            arena=match.group("arena"),
+                            subject=f"Subject {match.group('subject')}",
+                            source_name=sheet_name,
+                        )
+                    )
+            return sources
+        finally:
+            workbook.close()
+
+    rows = _read_delimited_rows(file_path=path)
+    header, column_names, _units, _data_rows = _split_header_and_table(rows=rows, source_name=path.name)
+    _validate_track_columns(column_names=column_names, source_name=path.name)
+    arena = header.get("Arena name")
+    subject = header.get("Subject name")
+    if not arena or not subject:
+        raise ValueError(f"'{path}' does not declare both 'Arena name' and 'Subject name' in its header.")
+    return [EthoVisionTrackSource(arena=str(arena), subject=str(subject), source_name=path.name)]
+
+
+def _track_data_from_rows(rows: list[list], *, source_name: str) -> EthoVisionTrackData:
+    header, column_names, units, data_rows = _split_header_and_table(rows=rows, source_name=source_name)
+    _validate_track_columns(column_names=column_names, source_name=source_name)
+    columns = {
+        name: np.asarray(
+            [_parse_track_value(row[index] if index < len(row) else None) for row in data_rows],
+            dtype=float,
+        )
+        for index, name in enumerate(column_names)
+    }
+    trial_time = columns.pop(TRIAL_TIME_COLUMN)
+    recording_time = columns.pop(RECORDING_TIME_COLUMN)
+    return EthoVisionTrackData(
+        header=header,
+        units={name: _normalize_unit(units.get(name)) for name in columns},
+        trial_time=trial_time,
+        recording_time=recording_time,
+        channels=columns,
+    )
+
+
+def _scoring_events_from_rows(rows: list[list], *, source_name: str) -> list[EthoVisionScoringEvent]:
+    _header, column_names, _units, data_rows = _split_header_and_table(rows=rows, source_name=source_name)
+    required_columns = {RECORDING_TIME_COLUMN, "Subject", "Behavior", "Event"}
+    missing_columns = required_columns.difference(column_names)
+    if missing_columns:
+        raise ValueError(f"'{source_name}' is missing Manual Scoring columns: {sorted(missing_columns)}.")
+
+    subject_index = column_names.index("Subject")
+    behavior_index = column_names.index("Behavior")
+    event_index = column_names.index("Event")
+    recording_time_index = column_names.index(RECORDING_TIME_COLUMN)
+
+    events: list[EthoVisionScoringEvent] = []
+    open_bouts: dict[tuple[str, str], float] = {}
+    for row in data_rows:
+        subject, behavior, event = row[subject_index], row[behavior_index], row[event_index]
+        onset = float(row[recording_time_index])
+        key = (subject, behavior)
+        if event == "point event":
+            events.append(EthoVisionScoringEvent(subject=subject, behavior=behavior, onset=onset, duration=None))
+        elif event == "state start":
+            open_bouts[key] = onset
+        elif event == "state stop":
+            if key not in open_bouts:
+                raise ValueError(
+                    f"'{source_name}' has a 'state stop' for subject '{subject}', behavior '{behavior}' "
+                    f"at {RECORDING_TIME_COLUMN}={onset} with no preceding 'state start' to close."
+                )
+            start = open_bouts.pop(key)
+            events.append(
+                EthoVisionScoringEvent(subject=subject, behavior=behavior, onset=start, duration=onset - start)
+            )
+        else:
+            raise ValueError(f"'{source_name}' has an unrecognized Event value '{event}'.")
+
+    for (subject, behavior), onset in open_bouts.items():
+        events.append(EthoVisionScoringEvent(subject=subject, behavior=behavior, onset=onset, duration=np.nan))
+    return events
+
+
+def _validate_file_path(file_path) -> Path:
+    path = Path(file_path)
+    suffix = path.suffix.lower()
+    if suffix not in SUPPORTED_SUFFIXES:
+        raise ValueError(f"Unsupported EthoVision suffix '{path.suffix}'. Expected one of {SUPPORTED_SUFFIXES}.")
+    return path
+
+
+def _load_workbook(file_path: Path):
+    import openpyxl
+
+    return openpyxl.load_workbook(file_path, read_only=True, data_only=True)
+
+
+def _read_excel_rows(file_path: Path, *, sheet_name: str) -> list[list]:
+    workbook = _load_workbook(file_path=file_path)
+    try:
+        if sheet_name not in workbook.sheetnames:
+            raise ValueError(f"'{sheet_name}' is not a sheet in this file. Found: {workbook.sheetnames}")
+        return [list(row) for row in workbook[sheet_name].iter_rows(values_only=True)]
+    finally:
+        workbook.close()
+
+
+def _read_delimited_rows(file_path: Path) -> list[list[str | None]]:
+    raw = file_path.read_bytes()
+    if raw.startswith((b"\xff\xfe", b"\xfe\xff")):
+        text = raw.decode("utf-16")
+    else:
+        try:
+            text = raw.decode("utf-8-sig")
+        except UnicodeDecodeError:
+            text = raw.decode("cp1252")
+
+    delimiter = "," if file_path.suffix.lower() == ".csv" else _detect_delimiter(text=text, file_path=file_path)
+    rows = []
+    for row in csv.reader(io.StringIO(text), delimiter=delimiter):
+        rows.append([value if value != "" else None for value in row])
+    return rows
+
+
+def _detect_delimiter(*, text: str, file_path: Path) -> str:
+    sample = "\n".join(text.splitlines()[:50])
+    try:
+        return csv.Sniffer().sniff(sample, delimiters=";\t,").delimiter
+    except csv.Error as exception:
+        raise ValueError(f"Could not determine the delimiter used by '{file_path}'.") from exception
+
+
+def _split_header_and_table(rows: list[list], *, source_name: str):
+    """Split self-declaring EthoVision rows into header, names, units, and data."""
+    if not rows or len(rows[0]) < 2 or rows[0][0] != "Number of header lines:":
+        raise ValueError(f"'{source_name}' does not begin with an EthoVision 'Number of header lines:' row.")
+    try:
+        header_lines = int(rows[0][1])
+    except (TypeError, ValueError) as exception:
+        raise ValueError(f"'{source_name}' has an invalid Number of header lines value: {rows[0][1]!r}.") from exception
+    if len(rows) < header_lines:
+        raise ValueError(f"'{source_name}' declares {header_lines} header lines but contains only {len(rows)} rows.")
+
+    header = {
+        row[0]: (row[1] if len(row) > 1 else None) for row in rows[1 : header_lines - 2] if row and row[0] is not None
+    }
+    column_names = [name for name in rows[header_lines - 2] if name is not None]
+    units_row = rows[header_lines - 1]
+    units = {name: units_row[index] if index < len(units_row) else None for index, name in enumerate(column_names)}
+    return header, column_names, units, rows[header_lines:]
+
+
+def _validate_track_columns(*, column_names: list[str], source_name: str) -> None:
+    missing_columns = {TRIAL_TIME_COLUMN, RECORDING_TIME_COLUMN}.difference(column_names)
+    if missing_columns:
+        raise ValueError(f"'{source_name}' is not a Track export; missing columns: {sorted(missing_columns)}.")
+
+
+def _parse_track_value(value) -> float:
+    """Parse a numeric Track value, preserving missing samples as ``numpy.nan``."""
+    if value is None or value in {"-", "NA"}:
+        return np.nan
+    return float(value)
+
+
+def _normalize_unit(unit: str | None) -> str | None:
+    """Normalize the optional parentheses used around units in delimited exports."""
+    if unit is None:
+        return None
+    return unit[1:-1] if unit.startswith("(") and unit.endswith(")") else unit

--- a/src/neuroconv/datainterfaces/behavior/ethovision/ethovisiondatainterface.py
+++ b/src/neuroconv/datainterfaces/behavior/ethovision/ethovisiondatainterface.py
@@ -1,0 +1,364 @@
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+from pydantic import FilePath, validate_call
+from pynwb import TimeSeries
+from pynwb.behavior import SpatialSeries
+from pynwb.file import NWBFile
+
+from ._ethovision_reader import (
+    get_available_tracks,
+    read_scoring_events,
+    read_track,
+    select_track_source,
+)
+from ...events.baseeventsinterface import BaseEventsInterface, _EventsData
+from ....tools import get_module
+from ....utils import DeepDict, calculate_regular_series_rate, to_camel_case, to_snake_case
+
+X_COLUMN = "X center"
+Y_COLUMN = "Y center"
+
+
+class EthoVisionDataInterface(BaseEventsInterface):
+    """Interface for one Track in a Noldus EthoVision XT export.
+
+    Excel, CSV, and TXT are container variants of the same Track model. An Excel workbook
+    can contain several Tracks; ``arena_name`` and ``subject_name`` select one. A matching
+    Excel Manual Scoring sheet can contain several subjects, so only the selected subject's
+    events are retained.
+
+    The selected source content is mapped to NWB as follows:
+
+    * ``X center`` and ``Y center`` -> one :class:`~pynwb.behavior.SpatialSeries`.
+    * Every other Track channel -> one :class:`~pynwb.base.TimeSeries`.
+    * Manual Scoring rows for the selected subject -> one :class:`~pynwb.event.EventsTable`.
+    * Manual Scoring behavior labels -> one ``ndx-ethogram`` ``Ethogram``.
+    * Matching ``state start`` and ``state stop`` rows -> one ``EthogramBouts`` table.
+
+    These objects are written directly to the ``behavior`` processing module.
+    """
+
+    display_name = "EthoVision"
+    keywords = ("EthoVision", "Noldus", "tracking", "behavior", "events", "ethogram")
+    associated_suffixes = (".xlsx", ".csv", ".txt")
+    info = "Interface for Noldus EthoVision XT Track exports."
+
+    @staticmethod
+    def get_available_tracks(file_path: FilePath) -> list[dict[str, str]]:
+        """Return the complete selector arguments for every available Track."""
+        return get_available_tracks(file_path=file_path)
+
+    @validate_call
+    def __init__(
+        self,
+        file_path: FilePath,
+        *,
+        arena_name: str | None = None,
+        subject_name: str | None = None,
+        metadata_key: str | None = None,
+        verbose: bool = False,
+    ):
+        """Initialize an interface for one EthoVision Track.
+
+        Parameters
+        ----------
+        file_path : FilePath
+            Path to an EthoVision ``.xlsx``, ``.csv``, or ``.txt`` Track export.
+        arena_name : str, optional
+            Arena to select. Inferred when the source contains only one matching arena.
+        subject_name : str, optional
+            Subject to select. Inferred when the source contains only one matching subject.
+        metadata_key : str, optional
+            The key for this track's metadata and events blocks. By default it is derived from
+            the Track sheet's arena and subject so several interfaces can share an NWB file.
+        verbose : bool, default: False
+            Whether to print progress.
+        """
+        self.file_path = Path(file_path)
+        self.track_source = select_track_source(
+            file_path=file_path,
+            arena_name=arena_name,
+            subject_name=subject_name,
+        )
+        self.arena = self.track_source.arena
+        self.subject = self.track_source.subject
+        self.metadata_key = metadata_key or f"ethovision_{to_snake_case(f'{self.arena}_{self.subject}')}"
+        self._manual_scoring_metadata_key = f"ethovision_{to_snake_case(self.arena)}_manual_scoring"
+        self.verbose = verbose
+        super().__init__(
+            file_path=file_path,
+            arena_name=self.arena,
+            subject_name=self.subject,
+            metadata_key=self.metadata_key,
+            verbose=verbose,
+        )
+
+        self._track = read_track(file_path=self.file_path, source=self.track_source)
+        self._time_series_metadata_keys = {
+            channel_name: f"{self.metadata_key}_{to_snake_case(channel_name)}"
+            for channel_name in self._track.channels
+            if channel_name not in (X_COLUMN, Y_COLUMN)
+        }
+        if len(set(self._time_series_metadata_keys.values())) != len(self._time_series_metadata_keys):
+            raise ValueError(
+                "EthoVision channel names must remain distinct after conversion to metadata keys. "
+                f"Derived keys: {self._time_series_metadata_keys}."
+            )
+        self.alignment._register_series(key=self.metadata_key, get_native_times=lambda: self._track.recording_time)
+
+        scoring_events = read_scoring_events(file_path=self.file_path, arena_name=self.arena)
+        self._scoring_occurrences = [(self.arena, event) for event in scoring_events if event.subject == self.subject]
+        self._event_onsets_alignment_key = f"{self.metadata_key}_manual_scoring_onsets"
+        self._event_offsets_alignment_key = f"{self.metadata_key}_manual_scoring_offsets"
+        if self._scoring_occurrences:
+            self.alignment._register_series(
+                key=self._event_onsets_alignment_key,
+                get_native_times=lambda: np.asarray(
+                    [event.onset for _, event in self._scoring_occurrences], dtype=float
+                ),
+            )
+            self.alignment._register_series(
+                key=self._event_offsets_alignment_key,
+                get_native_times=self._get_native_event_offsets,
+            )
+
+    def _get_native_event_offsets(self) -> np.ndarray:
+        return np.asarray(
+            [
+                event.onset + event.duration if event.duration is not None and not np.isnan(event.duration) else np.nan
+                for _, event in self._scoring_occurrences
+            ],
+            dtype=float,
+        )
+
+    def get_metadata_schema(self) -> dict:
+        metadata_schema = super().get_metadata_schema()
+        named_series_schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "description": {"type": "string"},
+                "unit": {"type": "string"},
+            },
+            "required": ["name", "description", "unit"],
+            "additionalProperties": True,
+        }
+        spatial_series_schema = {
+            "type": "object",
+            "properties": {
+                **named_series_schema["properties"],
+                "reference_frame": {"type": "string"},
+            },
+            "required": [*named_series_schema["required"], "reference_frame"],
+            "additionalProperties": True,
+        }
+        metadata_schema["properties"]["SpatialSeries"] = {
+            "type": "object",
+            "additionalProperties": spatial_series_schema,
+        }
+        metadata_schema["properties"]["TimeSeries"] = {
+            "type": "object",
+            "additionalProperties": named_series_schema,
+        }
+        metadata_schema["properties"]["Behavior"] = {
+            "type": "object",
+            "properties": {
+                "Ethograms": {"type": "object", "additionalProperties": {"type": "object"}},
+            },
+            "additionalProperties": True,
+        }
+        return metadata_schema
+
+    def get_metadata(self) -> DeepDict:
+        metadata = super().get_metadata()
+        start_time = self._track.header.get("Start time")
+        if start_time:
+            metadata["NWBFile"]["session_start_time"] = _parse_start_time(start_time=start_time)
+
+        object_suffix = to_camel_case(to_snake_case(f"{self.arena} {self.subject}"))
+        metadata["SpatialSeries"][self.metadata_key] = dict(
+            name=f"EthoVisionPosition{object_suffix}",
+            description=f"Center position for {self.subject} in {self.arena}, from EthoVision.",
+            unit=self._track.units.get(X_COLUMN) or "n/a",
+            reference_frame="Arena, as EthoVision's own calibration defines it.",
+        )
+        metadata["TimeSeries"] = {
+            self._time_series_metadata_keys[channel_name]: dict(
+                name=(f"EthoVision{to_camel_case(to_snake_case(channel_name))}{object_suffix}"),
+                description=f"'{channel_name}' channel from an EthoVision Track sheet.",
+                unit=self._track.units.get(channel_name) or "n/a",
+            )
+            for channel_name in self._track.channels
+            if channel_name not in (X_COLUMN, Y_COLUMN)
+        }
+
+        if self._scoring_occurrences:
+            arena_suffix = to_camel_case(to_snake_case(self.arena))
+            metadata["Behavior"]["Ethograms"][self._manual_scoring_metadata_key] = {
+                "Ethogram": {
+                    "name": f"EthoVisionEthogram{arena_suffix}",
+                    "description": "Behavior catalogue inferred from EthoVision manual-scoring rows.",
+                },
+                "EthogramBouts": {
+                    "name": f"EthoVisionEthogramBouts{arena_suffix}",
+                    "description": "Closed state bouts from EthoVision manual scoring.",
+                },
+            }
+            metadata["Events"]["EventTables"][self._manual_scoring_metadata_key] = {
+                "table_name": f"EthoVisionManualScoring{arena_suffix}",
+                "description": "Manual-scoring events from an EthoVision export.",
+            }
+            event_types = metadata["Events"][self.metadata_key]["event_types"]
+            for source_id, events_data in self._get_events_data_dict().items():
+                event_types[source_id] = {
+                    "event_name": source_id.split(":", maxsplit=1)[1],
+                    "table_metadata_key": self._manual_scoring_metadata_key,
+                    "columns": {
+                        "subject": {
+                            "column_name": "subject",
+                            "description": "The subject the event was scored on.",
+                        },
+                        "arena": {
+                            "column_name": "arena",
+                            "description": "The EthoVision arena in which the event was scored.",
+                        },
+                    },
+                }
+        return metadata
+
+    def _get_events_data_dict(self) -> dict[str, _EventsData]:
+        if not self._scoring_occurrences:
+            return {}
+
+        current_onsets = self.alignment[self._event_onsets_alignment_key].get_times() - self.alignment.offset
+        current_offsets = self.alignment[self._event_offsets_alignment_key].get_times() - self.alignment.offset
+        grouped_indices: dict[str, list[int]] = {}
+        for index, (_, event) in enumerate(self._scoring_occurrences):
+            event_kind = "point" if event.duration is None else "state"
+            grouped_indices.setdefault(f"{event_kind}:{event.behavior}", []).append(index)
+
+        events_data_dict = {}
+        for source_id, indices in grouped_indices.items():
+            is_point = source_id.startswith("point:")
+            durations = None if is_point else current_offsets[indices] - current_onsets[indices]
+            events_data_dict[source_id] = _EventsData(
+                event_type_source_id=source_id,
+                timestamps=current_onsets[indices],
+                durations=durations,
+                payload={
+                    "subject": np.asarray(
+                        [self._scoring_occurrences[index][1].subject for index in indices], dtype=object
+                    ),
+                    "arena": np.asarray([self._scoring_occurrences[index][0] for index in indices], dtype=object),
+                },
+            )
+        return events_data_dict
+
+    def add_to_nwbfile(self, nwbfile: NWBFile, metadata: dict | None = None) -> None:
+        """Write one track and its subject-specific manual-scoring events."""
+        resolved_metadata = DeepDict(self.get_metadata())
+        if metadata is not None:
+            resolved_metadata.deep_update(metadata)
+        processing_module = get_module(nwbfile=nwbfile, name="behavior", description="Processed behavioral data.")
+
+        timestamps = self.alignment[self.metadata_key].get_times()
+        rate = calculate_regular_series_rate(series=timestamps)
+        time_kwargs = dict(rate=rate, starting_time=timestamps[0]) if rate else dict(timestamps=timestamps)
+
+        position_metadata = dict(resolved_metadata["SpatialSeries"][self.metadata_key])
+        position_data = np.column_stack([self._track.channels[X_COLUMN], self._track.channels[Y_COLUMN]])
+        spatial_series = SpatialSeries(
+            data=position_data,
+            unit=position_metadata.pop("unit"),
+            reference_frame=position_metadata.pop("reference_frame"),
+            description=position_metadata.pop("description", ""),
+            **time_kwargs,
+            **position_metadata,
+        )
+        processing_module.add(spatial_series)
+
+        for source_channel_name, time_series_metadata_key in self._time_series_metadata_keys.items():
+            series_metadata = resolved_metadata["TimeSeries"][time_series_metadata_key]
+            time_series = TimeSeries(
+                data=self._track.channels[source_channel_name],
+                **series_metadata,
+                **time_kwargs,
+            )
+            processing_module.add(time_series)
+
+        if self._scoring_occurrences:
+            super().add_to_nwbfile(nwbfile=nwbfile, metadata=resolved_metadata)
+            self._add_ethogram_to_nwbfile(nwbfile=nwbfile, metadata=resolved_metadata)
+
+    def _add_ethogram_to_nwbfile(self, *, nwbfile: NWBFile, metadata: dict) -> None:
+        # TODO: Unify Ethogram/EthogramBouts construction with BORIS and the VAME/MoSeq label-based
+        # helper once the shared API accepts already formed intervals, catalogue rows, and extra columns.
+        from ndx_ethogram import Ethogram, EthogramBouts
+
+        ethogram_metadata = metadata["Behavior"]["Ethograms"][self._manual_scoring_metadata_key]
+        processing_module = get_module(nwbfile=nwbfile, name="behavior", description="Processed behavioral data.")
+        catalogue_name = ethogram_metadata["Ethogram"]["name"]
+        catalogue = processing_module.data_interfaces.get(catalogue_name)
+        if catalogue is None:
+            catalogue = Ethogram(**ethogram_metadata["Ethogram"], exclusive=False)
+            processing_module.add(catalogue)
+        elif not isinstance(catalogue, Ethogram):
+            raise TypeError(f"Behavior object '{catalogue_name}' exists but is not an Ethogram.")
+
+        behavior_types = {}
+        for _, event in self._scoring_occurrences:
+            behavior_type = "point" if event.duration is None else "state"
+            previous = behavior_types.setdefault(event.behavior, behavior_type)
+            if previous != behavior_type:
+                raise ValueError(f"EthoVision behavior '{event.behavior}' appears as both a point and state behavior.")
+        existing_behaviors = {row["behavior"]: row["behavior_type"] for _, row in catalogue.to_dataframe().iterrows()}
+        for behavior, behavior_type in behavior_types.items():
+            if behavior in existing_behaviors:
+                if existing_behaviors[behavior] != behavior_type:
+                    raise ValueError(
+                        f"EthoVision behavior '{behavior}' is already catalogued as "
+                        f"'{existing_behaviors[behavior]}', not '{behavior_type}'."
+                    )
+                continue
+            catalogue.add_row(behavior=behavior, definition="", behavior_type=behavior_type, category="")
+
+        current_onsets = self.alignment[self._event_onsets_alignment_key].get_times()
+        current_offsets = self.alignment[self._event_offsets_alignment_key].get_times()
+        closed_indices = [
+            index
+            for index, (_, event) in enumerate(self._scoring_occurrences)
+            if event.duration is not None and not np.isnan(event.duration)
+        ]
+        if not closed_indices:
+            return
+
+        bouts_name = ethogram_metadata["EthogramBouts"]["name"]
+        bouts = processing_module.data_interfaces.get(bouts_name)
+        if bouts is None:
+            bouts = EthogramBouts(
+                **ethogram_metadata["EthogramBouts"],
+                labeling_method="manual",
+                source_software="Noldus EthoVision XT",
+                ethogram=catalogue,
+            )
+            bouts.add_column(name="subject", description="The subject the bout was scored on.")
+            bouts.add_column(name="arena", description="The EthoVision arena in which the bout was scored.")
+            processing_module.add(bouts)
+        elif not isinstance(bouts, EthogramBouts):
+            raise TypeError(f"Behavior object '{bouts_name}' exists but is not an EthogramBouts table.")
+        for index in closed_indices:
+            arena, event = self._scoring_occurrences[index]
+            bouts.add_interval(
+                start_time=current_onsets[index],
+                stop_time=current_offsets[index],
+                label=event.behavior,
+                subject=event.subject,
+                arena=arena,
+            )
+
+
+def _parse_start_time(*, start_time: str) -> datetime:
+    """Parse EthoVision timestamps, whose fractional separator can be a period or comma."""
+    return datetime.strptime(start_time.replace(",", "."), "%m/%d/%Y %H:%M:%S.%f")

--- a/src/neuroconv/utils/str_utils.py
+++ b/src/neuroconv/utils/str_utils.py
@@ -3,7 +3,7 @@ import re
 
 
 def to_snake_case(name: str) -> str:
-    """Convert a CamelCase, hyphenated or spaced string to snake_case.
+    """Convert a name with mixed casing or separators to snake_case.
 
     The inverse of :func:`to_camel_case`, for turning a name a device or file reports into the
     snake_case key a metadata registry is keyed by.
@@ -28,8 +28,10 @@ def to_snake_case(name: str) -> str:
     'miniscope_v4_bno'
     >>> to_snake_case("MyDeviceName")
     'my_device_name'
+    >>> to_snake_case("In zone(Arena / center-point)")
+    'in_zone_arena_center_point'
     """
-    name = re.sub(r"[\s-]+", "_", name.strip())
+    name = re.sub(r"[^\w]+", "_", name.strip(), flags=re.UNICODE)
     # Split runs of words written without separators: 'miniscopeV4' and 'HPCMiniscope' both split.
     name = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name)
     name = re.sub(r"(?<=[A-Z])(?=[A-Z][a-z])", "_", name)

--- a/tests/test_minimal/test_utils/test_str_utils.py
+++ b/tests/test_minimal/test_utils/test_str_utils.py
@@ -11,6 +11,7 @@ from neuroconv.utils.str_utils import human_readable_size, to_snake_case
         ("Miniscope_V4_BNO", "miniscope_v4_bno"),  # a hardware design name
         ("MyDeviceName", "my_device_name"),  # written without separators
         ("my-device name", "my_device_name"),  # hyphen and space are separators
+        ("In zone(Arena / center-point)", "in_zone_arena_center_point"),  # punctuation is a separator
     ],
 )
 def test_to_snake_case(name, expected):

--- a/tests/test_on_data/behavior/test_ethovision_interface.py
+++ b/tests/test_on_data/behavior/test_ethovision_interface.py
@@ -1,0 +1,439 @@
+"""Tests for EthoVisionDataInterface and same-session Track composition.
+
+These fixtures are on the unmerged ``behavior_testing_data`` branch, so their source paths remain
+local until that data branch is published and the test-data checkout can provide them.
+"""
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+from pynwb import NWBFile, read_nwb
+
+from neuroconv import ConverterPipe
+from neuroconv.datainterfaces.behavior.ethovision.ethovisiondatainterface import EthoVisionDataInterface
+from neuroconv.tools.testing.data_interface_mixins import DataInterfaceTestMixin
+
+try:
+    from ..setup_paths import OUTPUT_PATH
+except ImportError:
+    from setup_paths import OUTPUT_PATH
+
+ETHOVISION_FOLDER_PATH = Path("/home/heberto/data/ethovision")
+
+
+class TestEthoVisionTwoC57(DataInterfaceTestMixin):
+    """The `two_c57` stub: one subject, one arena, a Manual Scoring sheet with point and state events."""
+
+    FILE_PATH = ETHOVISION_FOLDER_PATH / "stubs/excel/track_and_manual_scoring/two_c57.xlsx"
+    data_interface_cls = EthoVisionDataInterface
+    interface_kwargs = dict(file_path=FILE_PATH)
+    save_directory = OUTPUT_PATH
+
+    def check_extracted_metadata(self, metadata: dict):
+        assert metadata["NWBFile"]["session_start_time"] == datetime(2022, 1, 25, 19, 38, 10)
+
+    def check_read_nwb(self, nwbfile_path: str):
+        nwbfile = read_nwb(nwbfile_path)
+        behavior_module = nwbfile.processing["behavior"]
+
+        position = behavior_module["EthoVisionPositionArena1Subject1"]
+        assert position.data.shape == (9080, 2)
+        assert position.unit == "cm"
+
+        expected_channel_names = {
+            "EthoVisionAreaArena1Subject1",
+            "EthoVisionAreachangeArena1Subject1",
+            "EthoVisionElongationArena1Subject1",
+            "EthoVisionSniffArena1Subject1",
+            "EthoVisionAttackArena1Subject1",
+            "EthoVisionAggressiveGroomArena1Subject1",
+            "EthoVisionGroomArena1Subject1",
+            "EthoVisionRetrieveArena1Subject1",
+            "EthoVisionRetrieve2Arena1Subject1",
+            "EthoVisionNestBuildingArena1Subject1",
+            "EthoVisionStartArena1Subject1",
+            "EthoVisionDiggingArena1Subject1",
+            "EthoVisionInterruptionArena1Subject1",
+            "EthoVisionCarryArena1Subject1",
+            "EthoVisionAnogenitalArena1Subject1",
+            "EthoVisionBackMountArena1Subject1",
+            "EthoVisionSideMountArena1Subject1",
+            "EthoVisionResult1Arena1Subject1",
+        }
+        assert set(behavior_module.data_interfaces) == {
+            "EthoVisionPositionArena1Subject1",
+            "EthoVisionEthogramArena1",
+            "EthoVisionEthogramBoutsArena1",
+            *expected_channel_names,
+        }
+
+        events = nwbfile.events["EthoVisionManualScoringArena1"].to_dataframe()
+        assert len(events) == 35
+
+        # Two behaviors the sheet scores as bouts never close within this stub's episode boundary,
+        # so a reader relying only on the Track sheet's per-frame indicator columns for these two
+        # names would find nothing: 'attacking' has no matching Track column at all ('Attack' does,
+        # but under a different string), and 'tail rattle' is scored only as a point event with no
+        # Track column whatsoever.
+        expected_event_types = {
+            "Sniff",
+            "aggressive groom",
+            "attacking",
+            "carry",
+            "digging",
+            "groom",
+            "start",
+            "tail rattle",
+        }
+        assert set(events["event_type"]) == expected_event_types
+        assert "EthoVisionAttackingArena1Subject1" not in behavior_module.data_interfaces
+        assert "EthoVisionTailRattleArena1Subject1" not in behavior_module.data_interfaces
+
+        # The two 'start' point events bracket the stub's retained episode and carry no duration.
+        start_rows = events[events["event_type"] == "start"]
+        assert len(start_rows) == 2
+        assert start_rows["duration"].isna().all()
+
+        # Every state bout in this stub closes: nothing here exercises the NaN-duration,
+        # never-closed-bout path that a messier file would. 'start' and 'tail rattle' are point
+        # events (no extent to record), so they are excluded rather than expected to close.
+        state_rows = events[~events["event_type"].isin(["start", "tail rattle"])]
+        assert not state_rows["duration"].isna().any()
+
+        ethogram = behavior_module["EthoVisionEthogramArena1"].to_dataframe()
+        assert set(ethogram["behavior"]) == set(events["event_type"])
+        assert set(ethogram["behavior_type"]) == {"point", "state"}
+
+        bouts = behavior_module["EthoVisionEthogramBoutsArena1"].to_dataframe()
+        assert len(bouts) == 31
+        assert set(bouts["subject"]) == {"Subject 1"}
+        assert set(bouts["arena"]) == {"Arena 1"}
+        assert set(bouts["label"]).isdisjoint({"start", "tail rattle"})
+
+    def test_available_tracks(self):
+        expected_tracks = [{"arena_name": "Arena 1", "subject_name": "Subject 1"}]
+        assert EthoVisionDataInterface.get_available_tracks(self.FILE_PATH) == expected_tracks
+
+    def test_nonlinear_alignment_remaps_tracks_events_and_bouts(self):
+        interface = EthoVisionDataInterface(file_path=self.FILE_PATH)
+        interface.alignment.remap_times(
+            local_sync_times=np.array([0.0, 200.0]),
+            reference_sync_times=np.array([10.0, 410.0]),
+        )
+
+        nwbfile = NWBFile(
+            session_description="alignment test",
+            identifier="alignment test",
+            session_start_time=datetime.now(timezone.utc),
+        )
+        interface.add_to_nwbfile(nwbfile=nwbfile)
+
+        position = nwbfile.processing["behavior"]["EthoVisionPositionArena1Subject1"]
+        assert np.isclose(position.timestamps[0], 10.0)
+        assert np.isclose(position.timestamps[1] - position.timestamps[0], 0.068)
+
+        events = nwbfile.events["EthoVisionManualScoringArena1"].to_dataframe()
+        first_sniff = events[events["event_type"] == "Sniff"].iloc[0]
+        assert np.isclose(first_sniff["timestamp"], 110.466)
+        assert np.isclose(first_sniff["duration"], 6.134)
+
+        bouts = nwbfile.processing["behavior"]["EthoVisionEthogramBoutsArena1"].to_dataframe()
+        first_sniff_bout = bouts[bouts["label"] == "Sniff"].iloc[0]
+        assert np.isclose(first_sniff_bout["start_time"], 110.466)
+        assert np.isclose(first_sniff_bout["stop_time"], 116.6)
+
+
+class TestEthoVisionMissingSamples(DataInterfaceTestMixin):
+    """A public CC0 file with the real 'subject not found' `-` sentinel and no Manual Scoring sheet.
+
+    Two subjects share the workbook (`Track-Rat Arena 1a-Subject 1/2`); this interface selects
+    one of them. The composition test below combines both. The arena label contains spaces and
+    does not start with the word "Arena", which the sheet-name pattern has to accept.
+    """
+
+    FILE_PATH = ETHOVISION_FOLDER_PATH / "stubs/excel/hardware_and_trial_control/two_subjects_missing_samples.xlsx"
+    data_interface_cls = EthoVisionDataInterface
+    interface_kwargs = dict(
+        file_path=FILE_PATH,
+        arena_name="Rat Arena 1a",
+        subject_name="Subject 1",
+    )
+    save_directory = OUTPUT_PATH
+
+    def check_extracted_metadata(self, metadata: dict):
+        assert metadata["NWBFile"]["session_start_time"] == datetime(2023, 3, 22, 14, 30, 22, 300000)
+
+    def check_read_nwb(self, nwbfile_path: str):
+        nwbfile = read_nwb(nwbfile_path)
+        behavior_module = nwbfile.processing["behavior"]
+
+        # No Manual Scoring sheet in this file: the more common real-world shape, per the format
+        # survey, and unexercised by the two_c57 stub.
+        assert not nwbfile.events
+
+        expected_channel_stems = {
+            "XNose",
+            "YNose",
+            "XTail",
+            "YTail",
+            "Area",
+            "Areachange",
+            "Elongation",
+            "Direction",
+            "HeadDirectedToObject1",
+            "HeadDirectedToObject2",
+            "Control",
+        }
+        assert set(behavior_module.data_interfaces) == {
+            "EthoVisionPositionRatArena1aSubject1",
+            *(f"EthoVision{stem}RatArena1aSubject1" for stem in expected_channel_stems),
+        }
+        position = behavior_module["EthoVisionPositionRatArena1aSubject1"]
+        assert position.data.shape == (552, 2)
+
+        # 'Subject not found' frames dash X/Y (and every other value column) together. Subject 1
+        # exercises 63 such rows in this stub.
+        subject_1_position = behavior_module["EthoVisionPositionRatArena1aSubject1"]
+        assert np.isnan(subject_1_position.data[:, 0]).sum() == 63
+        assert np.isnan(subject_1_position.data[:, 1]).sum() == 63
+
+        # 'Control' is never populated anywhere in this sheet: the source spreadsheet stores no
+        # cell at all for it on any row, rather than a stored 0 or a '-' sentinel, so every row
+        # comes back shorter than the declared column count for this channel specifically.
+        control = behavior_module["EthoVisionControlRatArena1aSubject1"].data[:]
+        assert np.isnan(control).all()
+
+    def test_available_tracks(self):
+        expected_tracks = [
+            {"arena_name": "Rat Arena 1a", "subject_name": "Subject 1"},
+            {"arena_name": "Rat Arena 1a", "subject_name": "Subject 2"},
+        ]
+        assert EthoVisionDataInterface.get_available_tracks(self.FILE_PATH) == expected_tracks
+
+    def test_metadata_keys_control_written_names(self):
+        interface = EthoVisionDataInterface(
+            file_path=self.FILE_PATH,
+            arena_name="Rat Arena 1a",
+            subject_name="Subject 1",
+        )
+        metadata = interface.get_metadata()
+        metadata_key = "ethovision_rat_arena_1a_subject_1"
+        control_metadata_key = f"{metadata_key}_control"
+        assert "EthoVision" not in metadata.get("Behavior", {})
+        assert set(metadata["SpatialSeries"]) == {metadata_key}
+        assert control_metadata_key in metadata["TimeSeries"]
+
+        metadata["SpatialSeries"][metadata_key]["name"] = "MouseOneCenter"
+        metadata["TimeSeries"][control_metadata_key]["name"] = "MouseOneControl"
+
+        nwbfile = NWBFile(
+            session_description="metadata naming test",
+            identifier="metadata naming test",
+            session_start_time=datetime.now(timezone.utc),
+        )
+        interface.add_to_nwbfile(nwbfile=nwbfile, metadata=metadata)
+
+        behavior_module = nwbfile.processing["behavior"]
+        assert "MouseOneCenter" in behavior_module.data_interfaces
+        assert "MouseOneControl" in behavior_module.data_interfaces
+
+    def test_interface_requires_one_track(self):
+        expected_error = (
+            f"arena_name=None, subject_name=None does not identify one Track in '{self.FILE_PATH}'. "
+            "Matching tracks: [('Rat Arena 1a', 'Subject 1'), ('Rat Arena 1a', 'Subject 2')]."
+        )
+        with pytest.raises(ValueError, match=re.escape(expected_error)):
+            EthoVisionDataInterface(file_path=self.FILE_PATH)
+
+    def test_interface_rejects_a_nonexistent_track_identity(self):
+        expected_error = (
+            "No EthoVision Track matches arena_name='Rat Arena 1a', subject_name='Subject 3' "
+            f"in '{self.FILE_PATH}'. Available tracks: "
+            "[('Rat Arena 1a', 'Subject 1'), ('Rat Arena 1a', 'Subject 2')]."
+        )
+        with pytest.raises(ValueError, match=re.escape(expected_error)):
+            EthoVisionDataInterface(
+                file_path=self.FILE_PATH,
+                arena_name="Rat Arena 1a",
+                subject_name="Subject 3",
+            )
+
+
+class TestEthoVisionConverterPipeMultiSubject:
+    FILE_PATH = ETHOVISION_FOLDER_PATH / "stubs/excel/hardware_and_trial_control/two_subjects_missing_samples.xlsx"
+
+    def test_converter_pipe_combines_all_subject_tracks_in_one_arena(self):
+        arena_name = "Rat Arena 1a"
+        available_tracks = EthoVisionDataInterface.get_available_tracks(self.FILE_PATH)
+        interfaces = [
+            EthoVisionDataInterface(file_path=self.FILE_PATH, **track)
+            for track in available_tracks
+            if track["arena_name"] == arena_name
+        ]
+        converter = ConverterPipe(data_interfaces={interface.metadata_key: interface for interface in interfaces})
+        assert set(converter.data_interface_objects) == {
+            "ethovision_rat_arena_1a_subject_1",
+            "ethovision_rat_arena_1a_subject_2",
+        }
+
+        nwbfile = NWBFile(
+            session_description="converter test",
+            identifier="converter test",
+            session_start_time=datetime.now(timezone.utc),
+        )
+        converter.add_to_nwbfile(nwbfile=nwbfile)
+
+        behavior_module = nwbfile.processing["behavior"]
+        expected_names = {
+            "EthoVisionPositionRatArena1aSubject1",
+            "EthoVisionXNoseRatArena1aSubject1",
+            "EthoVisionYNoseRatArena1aSubject1",
+            "EthoVisionXTailRatArena1aSubject1",
+            "EthoVisionYTailRatArena1aSubject1",
+            "EthoVisionAreaRatArena1aSubject1",
+            "EthoVisionAreachangeRatArena1aSubject1",
+            "EthoVisionElongationRatArena1aSubject1",
+            "EthoVisionDirectionRatArena1aSubject1",
+            "EthoVisionHeadDirectedToObject1RatArena1aSubject1",
+            "EthoVisionHeadDirectedToObject2RatArena1aSubject1",
+            "EthoVisionControlRatArena1aSubject1",
+            "EthoVisionPositionRatArena1aSubject2",
+            "EthoVisionXNoseRatArena1aSubject2",
+            "EthoVisionYNoseRatArena1aSubject2",
+            "EthoVisionXTailRatArena1aSubject2",
+            "EthoVisionYTailRatArena1aSubject2",
+            "EthoVisionAreaRatArena1aSubject2",
+            "EthoVisionAreachangeRatArena1aSubject2",
+            "EthoVisionElongationRatArena1aSubject2",
+            "EthoVisionDirectionRatArena1aSubject2",
+            "EthoVisionHeadDirectedToObject1RatArena1aSubject2",
+            "EthoVisionHeadDirectedToObject2RatArena1aSubject2",
+            "EthoVisionControlRatArena1aSubject2",
+        }
+        assert set(behavior_module.data_interfaces) == expected_names
+
+
+class TestEthoVisionCsv(DataInterfaceTestMixin):
+    FILE_PATH = ETHOVISION_FOLDER_PATH / "stubs/csv/track_only/morris_water_maze.csv"
+    data_interface_cls = EthoVisionDataInterface
+    interface_kwargs = dict(file_path=FILE_PATH)
+    save_directory = OUTPUT_PATH
+
+    def check_extracted_metadata(self, metadata: dict):
+        assert metadata["NWBFile"]["session_start_time"] == datetime(2020, 1, 1, 9, 0)
+
+    def check_read_nwb(self, nwbfile_path: str):
+        nwbfile = read_nwb(nwbfile_path)
+        behavior_module = nwbfile.processing["behavior"]
+
+        position = behavior_module["EthoVisionPositionArena1Subject1"]
+        assert position.data.shape == (1500, 2)
+        assert position.unit == "cm"
+        assert np.isnan(position.data[:, 0]).sum() == 33
+        expected_names = {
+            "EthoVisionPositionArena1Subject1",
+            "EthoVisionAreaArena1Subject1",
+            "EthoVisionAreachangeArena1Subject1",
+            "EthoVisionElongationArena1Subject1",
+            "EthoVisionDistanceMovedArena1Subject1",
+            "EthoVisionVelocityArena1Subject1",
+            "EthoVisionInZoneArenaCenterPointArena1Subject1",
+            "EthoVisionInZonePeripheryCenterPointArena1Subject1",
+            "EthoVisionInZoneZone1CenterPointArena1Subject1",
+            "EthoVisionInZoneZone2CenterPointArena1Subject1",
+            "EthoVisionInZoneZone3CenterPointArena1Subject1",
+            "EthoVisionMovementMovingCenterPointArena1Subject1",
+            "EthoVisionMovementNotMovingCenterPointArena1Subject1",
+            "EthoVisionDistanceToPointArena1Subject1",
+            "EthoVisionResult1Arena1Subject1",
+        }
+        assert set(behavior_module.data_interfaces) == expected_names
+
+    def test_available_tracks(self):
+        expected_tracks = [{"arena_name": "Arena 1", "subject_name": "Subject 1"}]
+        assert EthoVisionDataInterface.get_available_tracks(self.FILE_PATH) == expected_tracks
+
+
+class TestEthoVisionTxt(DataInterfaceTestMixin):
+    FILE_PATH = ETHOVISION_FOLDER_PATH / "stubs/txt/track_only/termites.txt"
+    data_interface_cls = EthoVisionDataInterface
+    interface_kwargs = dict(file_path=FILE_PATH)
+    save_directory = OUTPUT_PATH
+
+    def check_extracted_metadata(self, metadata: dict):
+        assert metadata["NWBFile"]["session_start_time"] == datetime(2014, 2, 9, 18, 4, 58, 400000)
+
+    def check_read_nwb(self, nwbfile_path: str):
+        nwbfile = read_nwb(nwbfile_path)
+        behavior_module = nwbfile.processing["behavior"]
+        position = behavior_module["EthoVisionPositionArena1Subject1"]
+        assert position.data.shape == (1877, 2)
+        assert position.unit == "mm"
+        assert position.timestamps[0] == 0.0
+
+        distance_moved = behavior_module["EthoVisionDistanceMovedArena1Subject1"]
+        assert np.isnan(distance_moved.data[0])
+
+    def test_available_tracks(self):
+        expected_tracks = [{"arena_name": "Arena 1", "subject_name": "Subject 1"}]
+        assert EthoVisionDataInterface.get_available_tracks(self.FILE_PATH) == expected_tracks
+
+
+class TestEthoVisionMultipleArenasSingleSubject(DataInterfaceTestMixin):
+    FILE_PATH = (
+        ETHOVISION_FOLDER_PATH / "stubs/excel/multiple_arenas_single_subject/track_only/two_arenas_one_subject.xlsx"
+    )
+    data_interface_cls = EthoVisionDataInterface
+    interface_kwargs = dict(file_path=FILE_PATH, arena_name="Arena 2", subject_name="Subject 1")
+    save_directory = OUTPUT_PATH
+
+    def check_extracted_metadata(self, metadata: dict):
+        assert metadata["NWBFile"]["session_start_time"] == datetime(2017, 10, 19, 13, 35, 57, 494000)
+
+    def check_read_nwb(self, nwbfile_path: str):
+        nwbfile = read_nwb(nwbfile_path)
+        position = nwbfile.processing["behavior"]["EthoVisionPositionArena2Subject1"]
+        assert position.data.shape == (120, 2)
+        assert position.unit == "cm"
+
+    def test_available_tracks(self):
+        expected_tracks = [
+            {"arena_name": "Arena 1", "subject_name": "Subject 1"},
+            {"arena_name": "Arena 2", "subject_name": "Subject 1"},
+        ]
+        assert EthoVisionDataInterface.get_available_tracks(self.FILE_PATH) == expected_tracks
+
+
+class TestEthoVisionMultipleArenasMultipleSubjects(DataInterfaceTestMixin):
+    FILE_PATH = (
+        ETHOVISION_FOLDER_PATH
+        / "stubs/excel/multiple_arenas_multiple_subjects/track_only/two_arenas_four_subjects.xlsx"
+    )
+    data_interface_cls = EthoVisionDataInterface
+    interface_kwargs = dict(file_path=FILE_PATH, arena_name="Arena 2", subject_name="Subject 4")
+    save_directory = OUTPUT_PATH
+
+    def check_extracted_metadata(self, metadata: dict):
+        assert metadata["NWBFile"]["session_start_time"] == datetime(2017, 9, 14, 10, 36, 33)
+
+    def check_read_nwb(self, nwbfile_path: str):
+        nwbfile = read_nwb(nwbfile_path)
+        position = nwbfile.processing["behavior"]["EthoVisionPositionArena2Subject4"]
+        assert position.data.shape == (120, 2)
+        assert position.unit == "cm"
+
+    def test_available_tracks(self):
+        expected_tracks = [
+            {"arena_name": "Arena 1", "subject_name": "Subject 1"},
+            {"arena_name": "Arena 1", "subject_name": "Subject 2"},
+            {"arena_name": "Arena 1", "subject_name": "Subject 3"},
+            {"arena_name": "Arena 1", "subject_name": "Subject 4"},
+            {"arena_name": "Arena 2", "subject_name": "Subject 1"},
+            {"arena_name": "Arena 2", "subject_name": "Subject 2"},
+            {"arena_name": "Arena 2", "subject_name": "Subject 3"},
+            {"arena_name": "Arena 2", "subject_name": "Subject 4"},
+        ]
+        assert EthoVisionDataInterface.get_available_tracks(self.FILE_PATH) == expected_tracks


### PR DESCRIPTION
EthoVision exports one Track per arena-subject pair across Excel, CSV and TXT, with optional Manual Scoring in Excel. This PR adds `EthoVisionDataInterface`, Track discovery, composition-based time alignment, core NWB series and ethogram output, and a conversion-gallery recipe. 


I still need to upload the test data before this is ready for review, so the data-dependent checks will fail right now.
