### PR TITLE
Write `order_of_images` from the image interfaces so an `IndexSeries` can index them

### DIFF
--- a/changelog_entries/2056.bugfix.md
+++ b/changelog_entries/2056.bugfix.md
@@ -1,0 +1,1 @@
+`ImageInterface` and `ExternalImageInterface` now write `order_of_images` on the `Images` container, in the order of `file_paths` or naturally sorted when the images come from `folder_path`, so an `IndexSeries` can index the images. A conversion that sets `order_of_images` itself after the interface should drop that line, as pynwb refuses to set it twice.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,6 +311,7 @@ icephys = [
 ## Image
 image = [
     "pillow>=10.0.0",
+    "natsort>=7.1.1",
 ]
 
 ## Fiber Photometry

--- a/src/neuroconv/datainterfaces/image/baseimageinterface.py
+++ b/src/neuroconv/datainterfaces/image/baseimageinterface.py
@@ -4,9 +4,10 @@ from pathlib import Path
 from typing import Literal
 
 from pynwb import NWBFile
-from pynwb.base import BaseImage, Images
+from pynwb.base import BaseImage, ImageReferences, Images
 
 from ...basedatainterface import BaseDataInterface
+from ...tools import get_package
 from ...utils import DeepDict, get_base_schema
 
 
@@ -91,6 +92,10 @@ class BaseImageInterface(BaseDataInterface):
 
             if not file_paths:
                 raise ValueError(f"No image files found in {folder}")
+
+            # The glob order depends on the filesystem, so sort it to give `order_of_images` a stable numbering
+            natsort = get_package(package_name="natsort", installation_instructions="pip install natsort")
+            file_paths = natsort.natsorted(file_paths)
 
         self.file_paths = [Path(p) for p in file_paths]
 
@@ -283,12 +288,17 @@ class BaseImageInterface(BaseDataInterface):
 
         # Process each image
         images_metadata_dict = container_metadata.get("images", {})
+        nwb_images = []
         for file_path in self.file_paths:
             image_metadata = images_metadata_dict.get(str(file_path), {})
             nwb_image = self._create_nwb_image(file_path=file_path, image_metadata=image_metadata)
 
             # Add to images container
             images_container.add_image(nwb_image)
+            nwb_images.append(nwb_image)
+
+        # Record the order of `file_paths` so an `IndexSeries` can index the container
+        images_container.order_of_images = ImageReferences(name="order_of_images", data=nwb_images)
 
         # Add images container to nwb file
         if parent_container == "acquisition":

--- a/tests/test_modalities/test_image/test_image_interface.py
+++ b/tests/test_modalities/test_image/test_image_interface.py
@@ -278,9 +278,10 @@ def test_images_are_chunked_and_compressed(tmp_path):
     configure_and_write_nwbfile(nwbfile=nwbfile, nwbfile_path=nwbfile_path, backend="hdf5")
 
     with h5py.File(nwbfile_path, "r") as file:
-        written_images = file["acquisition/Images"]
+        images_group = file["acquisition/Images"]
+        written_images = [images_group[name] for name in images_group if name != "order_of_images"]
         assert len(written_images) == 2
-        for written_image in written_images.values():
+        for written_image in written_images:
             assert written_image.compression == "gzip"
             assert written_image.chunks == (256, 256, 3)
 


### PR DESCRIPTION
When converting a visual experiment I realized that the `Images` container written by `ImageInterface` and `ExternalImageInterface` has no `order_of_images` and an `IndexSeries` can't resolve its indices against it. This PR writes it in the order of `file_paths`, and naturally sorts the images found with `folder_path` as the glob order depends on the filesystem.
