### PR TITLE
Return an integer frame count from `get_electrical_series_chunk_shape`

### DIFF
--- a/changelog_entries/2057.bugfix.md
+++ b/changelog_entries/2057.bugfix.md
@@ -1,0 +1,1 @@
+`get_electrical_series_chunk_shape` now returns an integer frame count, so writing a large `ElectricalSeries` to Zarr no longer warns about non-integer chunks.

--- a/src/neuroconv/tools/iterative_write.py
+++ b/src/neuroconv/tools/iterative_write.py
@@ -161,7 +161,7 @@ def get_electrical_series_chunk_shape(
     total_chunk_space_bytes = chunk_mb * 1e6
 
     # We allocate as many frames as possible with the remaining space of the chunk
-    chunk_frames = total_chunk_space_bytes // size_of_chunk_channels_bytes
+    chunk_frames = int(total_chunk_space_bytes // size_of_chunk_channels_bytes)
 
     # We clip by the number of frames if the samples are too small
     chunk_frames = min(chunk_frames, number_of_frames)

--- a/tests/test_modalities/test_ecephys/test_tools_spikeinterface.py
+++ b/tests/test_modalities/test_ecephys/test_tools_spikeinterface.py
@@ -22,6 +22,7 @@ from spikeinterface.core.generate import (
 )
 from spikeinterface.extractors import NumpyRecording
 
+from neuroconv.tools.iterative_write import get_electrical_series_chunk_shape
 from neuroconv.tools.nwb_helpers import get_module
 from neuroconv.tools.spikeinterface import (
     _add_electrode_groups_to_nwbfile,
@@ -3019,6 +3020,13 @@ class TestAddRecording:
 
         chunk_bytes = np.prod(iterator.chunk_shape) * iterator._get_dtype().itemsize
         assert chunk_bytes <= chunk_mb * 1e6
+
+    def test_electrical_series_chunk_shape_is_integers_when_the_budget_is_smaller_than_the_recording(self):
+        chunk_shape = get_electrical_series_chunk_shape(
+            number_of_channels=384, number_of_frames=30_000 * 3_600, dtype=np.dtype("int16"), chunk_mb=10.0
+        )
+        assert chunk_shape == (78_125, 64)
+        assert all(type(size) is int for size in chunk_shape)
 
     def test_full_metadata_specification(self):
         """User-supplied fields land on every created object and the cross-links resolve.


### PR DESCRIPTION
When testing the parallel Zarr write I realized that zarr warns `chunks contains non-integer value(s)` on every write of a large recording, as `get_electrical_series_chunk_shape` floor-divides a float and returns frame counts like `78125.0`. This PR casts the frame count to `int`.
